### PR TITLE
Log NSData as human readable string

### DIFF
--- a/swift-sdk/Internal/IterableAPIInternal.swift
+++ b/swift-sdk/Internal/IterableAPIInternal.swift
@@ -606,7 +606,7 @@ final class IterableAPIInternal : NSObject, PushTrackerProtocol {
                 toLog += ", \(reason)"
             }
             if let data = data {
-                toLog += ", got response \(data)"
+                toLog += ", got response \(String(data: data, encoding: .utf8) ?? "nil")"
             }
             ITBError(toLog)
         }


### PR DESCRIPTION
Currently, I see messages being logged as:
```
registerToken failed:, Unable to find a push integration set up for application 
iOSStaging on APNS_SANDBOX, got response 126 bytes
```

This change should make them appear as:
```
registerToken failed:, Unable to find a push integration set up for application 
iOSStaging on APNS_SANDBOX, got response "{\"msg\":\"Unable to find a 
push integration set up for application iOSStaging on 
APNS_SANDBOX\",\"code\":\"BadParams\",\"params\":null}"
```