### PR TITLE
[MOB-945] - Instead of checking for application state in the middle of execution,…

### DIFF
--- a/swift-sdk/Internal/InAppManager+Functions.swift
+++ b/swift-sdk/Internal/InAppManager+Functions.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum ProcessMessagesResult {
+enum MessagesProcessorResult {
     case show(message: IterableInAppMessage, messagesMap: OrderedDictionary<String, IterableInAppMessage>)
     case noShow(messagesMap: OrderedDictionary<String, IterableInAppMessage>)
 }
@@ -20,7 +20,7 @@ struct MessagesProcessor {
         self.messagesMap = messagesMap
     }
     
-    mutating func processMessages() -> ProcessMessagesResult {
+    mutating func processMessages() -> MessagesProcessorResult {
         ITBDebug()
         switch processNextMessage() {
         case let .show(message):


### PR DESCRIPTION
… provide application in the beginning so that we don't have to context switch threads.