### PR TITLE
[MOB-962] - inbox customization 6

### DIFF
--- a/swift-sdk/IterableInboxCell.swift
+++ b/swift-sdk/IterableInboxCell.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-/// If you are creating your own Xib file you must
+/// If you are creating your own Nib file you must
 /// connect the outlets.
 open class IterableInboxCell: UITableViewCell {
     /// A "dot" view showing that the message is unread

--- a/swift-sdk/IterableInboxNavigationViewController.swift
+++ b/swift-sdk/IterableInboxNavigationViewController.swift
@@ -49,6 +49,7 @@ open class IterableInboxNavigationViewController: UINavigationController {
     
     /// Set this property if you want to set the view delegate class name in Storyboard
     /// and want `IterableInboxViewController` to create a view delegate class for you.
+    /// The class name must include the package name as well, e.g., MyModule.CustomInboxViewDelegate
     @IBInspectable public var viewDelegateClassName: String? = nil {
         didSet {
             inboxViewController?.viewDelegateClassName = viewDelegateClassName

--- a/swift-sdk/IterableInboxNavigationViewController.swift
+++ b/swift-sdk/IterableInboxNavigationViewController.swift
@@ -31,11 +31,7 @@ open class IterableInboxNavigationViewController: UINavigationController {
     /// Set this to `false`to push inbox message into navigation stack.
     @IBInspectable public var isPopup: Bool = true {
         didSet {
-            if isPopup {
-                inboxViewController?.inboxMode = .popup
-            } else {
-                inboxViewController?.inboxMode = .nav
-            }
+            inboxViewController?.isPopup = isPopup
         }
     }
     

--- a/swift-sdk/IterableInboxNavigationViewController.swift
+++ b/swift-sdk/IterableInboxNavigationViewController.swift
@@ -10,8 +10,8 @@ open class IterableInboxNavigationViewController: UINavigationController {
     // MARK: Settable properties
     
     /// If you want to use a custom layout for your Inbox TableViewCell
-    /// this is where you should override it. Please note that this assumes
-    /// that the xib is present in the main bundle.
+    /// this is where you should override it.
+    /// Please note that this assumes  that the nib is present in the main bundle.
     @IBInspectable public var cellNibName: String? = nil {
         didSet {
             inboxViewController?.cellNibName = cellNibName

--- a/swift-sdk/IterableInboxViewController.swift
+++ b/swift-sdk/IterableInboxViewController.swift
@@ -41,6 +41,23 @@ open class IterableInboxViewController: UITableViewController {
     
     // MARK: Settable properties
     
+    /// If you want to use a custom layout for your inbox TableViewCell
+    /// this is the variable you should override. Please note that this assumes
+    /// that the nib is present in the main bundle.
+    @IBInspectable public var cellNibName: String? = nil
+    
+    /// Set this to `true` to show a popup when an inbox message is selected in the list.
+    /// Set this to `false`to push inbox message into navigation stack.
+    @IBInspectable public var isPopup: Bool = true {
+        didSet {
+            if isPopup {
+                inboxMode = .popup
+            } else {
+                inboxMode = .nav
+            }
+        }
+    }
+    
     /// Set this property to override default inbox display behavior. You should set either this property
     /// or `viewDelegateClassName`property but not both.
     public weak var viewDelegate: IterableInboxViewControllerViewDelegate?
@@ -56,15 +73,6 @@ open class IterableInboxViewController: UITableViewController {
             instantiateViewDelegate(withClassName: viewDelegateClassName)
         }
     }
-    
-    /// If you want to use a custom layout for your inbox TableViewCell
-    /// this is the variable you should override. Please note that this assumes
-    /// that the nib is present in the main bundle.
-    @IBInspectable public var cellNibName: String? = nil
-    
-    /// Set this mode to `popup` to show a popup when an inbox message is selected in the list.
-    /// Set this mode to `nav` to push inbox message into navigation stack.
-    public var inboxMode = InboxMode.popup
     
     /// You can override these insertion/deletion animations for custom ones
     public var insertionAnimation = UITableView.RowAnimation.automatic
@@ -201,7 +209,9 @@ open class IterableInboxViewController: UITableViewController {
     
     var viewModel: InboxViewControllerViewModelProtocol
     
-    private let iterableCellNibName = "IterableInboxCell"
+    /// Set this mode to `popup` to show a popup when an inbox message is selected in the list.
+    /// Set this mode to `nav` to push inbox message into navigation stack.
+    private var inboxMode = InboxMode.popup
     
     // we need this variable because we are instantiating the delegate class
     private var strongViewDelegate: IterableInboxViewControllerViewDelegate?
@@ -292,7 +302,7 @@ open class IterableInboxViewController: UITableViewController {
         }
         guard let delegateClass = NSClassFromString(className) as? IterableInboxViewControllerViewDelegate.Type else {
             // we can't use IterableLog here because this happens from storyboard before logging is initialized.
-            assertionFailure("Could not initialize dynamic class: \(className), please check protocol \(IterableInboxViewControllerViewDelegate.self) conformanace.")
+            assertionFailure("Could not initialize dynamic class: \(className), please check module name and protocol \(IterableInboxViewControllerViewDelegate.self) conformanace.")
             return
         }
         

--- a/swift-sdk/IterableInboxViewController.swift
+++ b/swift-sdk/IterableInboxViewController.swift
@@ -23,13 +23,13 @@ import UIKit
     /// Use this property only when you  have more than one type of custom table view cells.
     /// For example, if you have inbox cells of one type to show  informational mesages,
     /// and inbox cells of another type to show discount messages.
-    /// - returns: a list of custom XIB names.
-    @objc optional var customXibNames: [String]? { get }
+    /// - returns: a list of custom nib names.
+    @objc optional var customNibNames: [String]? { get }
     
-    /// This function goes hand in hand with `customXibNames` property..
+    /// This function goes hand in hand with `customNibNames` property..
     /// - parameter for: Iterable in app message.
     /// - returns: Name of custom cell for the message or nil if using default cell.
-    @objc optional func customXibName(for message: IterableInAppMessage) -> String?
+    @objc optional func customNibName(for message: IterableInAppMessage) -> String?
 }
 
 @IBDesignable
@@ -59,7 +59,7 @@ open class IterableInboxViewController: UITableViewController {
     
     /// If you want to use a custom layout for your inbox TableViewCell
     /// this is the variable you should override. Please note that this assumes
-    /// that the XIB is present in the main bundle.
+    /// that the nib is present in the main bundle.
     @IBInspectable public var cellNibName: String? = nil
     
     /// Set this mode to `popup` to show a popup when an inbox message is selected in the list.
@@ -393,14 +393,14 @@ private struct CellLoader {
         guard let viewDelegate = viewDelegate else {
             return loadDefaultCell(forTableView: tableView, atIndexPath: indexPath)
         }
-        guard let modifier1 = viewDelegate.customXibNames, let customXibNames = modifier1, customXibNames.count > 0 else {
+        guard let modifier1 = viewDelegate.customNibNames, let customNibNames = modifier1, customNibNames.count > 0 else {
             return loadDefaultCell(forTableView: tableView, atIndexPath: indexPath)
         }
-        guard let modifier2 = viewDelegate.customXibName(for:), let customXibName = modifier2(message) else {
+        guard let modifier2 = viewDelegate.customNibName(for:), let customNibName = modifier2(message) else {
             return loadDefaultCell(forTableView: tableView, atIndexPath: indexPath)
         }
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: customXibName, for: indexPath) as? IterableInboxCell else {
-            ITBError("Please make sure that an the nib: \(customXibName) is present in the main bundle")
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: customNibName, for: indexPath) as? IterableInboxCell else {
+            ITBError("Please make sure that an the nib: \(customNibName) is present in the main bundle")
             return loadDefaultCell(forTableView: tableView, atIndexPath: indexPath)
         }
         
@@ -414,13 +414,13 @@ private struct CellLoader {
         guard let viewDelegate = viewDelegate else {
             return
         }
-        guard let modifier = viewDelegate.customXibNames, let customXibNames = modifier, customXibNames.count > 0 else {
+        guard let modifier = viewDelegate.customNibNames, let customNibNames = modifier, customNibNames.count > 0 else {
             return
         }
         
-        customXibNames.forEach { customXibName in
-            let nib = UINib(nibName: customXibName, bundle: Bundle.main)
-            tableView.register(nib, forCellReuseIdentifier: customXibName)
+        customNibNames.forEach { customNibName in
+            let nib = UINib(nibName: customNibName, bundle: Bundle.main)
+            tableView.register(nib, forCellReuseIdentifier: customNibName)
         }
     }
     


### PR DESCRIPTION
Final touches for inbox customization.
1. consistent naming of xib vs nib
2. initialize protocol in better way
3. expose Xcode inspectable properties for IterableInboxViewController.