### PR TITLE
Podspec support for both Swift 4.2 and 5.0

### DIFF
--- a/Iterable-iOS-AppExtensions.podspec
+++ b/Iterable-iOS-AppExtensions.podspec
@@ -79,9 +79,5 @@ Pod::Spec.new do |s|
 
   # s.public_header_files = "Classes/**/*.h"
 
-  s.pod_target_xcconfig = {
-    'SWIFT_VERSION' => '4.2'
-  }
-
-  s.swift_version = '4.2'
+  s.swift_versions = ['4.2', '5.0']
 end

--- a/Iterable-iOS-SDK.podspec
+++ b/Iterable-iOS-SDK.podspec
@@ -74,9 +74,5 @@ Pod::Spec.new do |s|
 
   s.source_files  = "swift-sdk/**/*.{h,m,swift}"
 
-  s.pod_target_xcconfig = {
-    'SWIFT_VERSION' => '4.2'
-  }
-
-  s.swift_version = '4.2'
+  s.swift_versions = ['4.2', '5.0']
 end

--- a/swift-sdk/Internal/DeviceInfo.swift
+++ b/swift-sdk/Internal/DeviceInfo.swift
@@ -61,6 +61,10 @@ struct DeviceInfo : Codable {
             return "CarPlay"
         case .unspecified:
             return "Unknown"
+        #if swift(>=5.0)
+        @unknown default:
+            return "Unknown"
+        #endif
         }
     }
 }

--- a/swift-sdk/Internal/IterableAppIntegrationInternal.swift
+++ b/swift-sdk/Internal/IterableAppIntegrationInternal.swift
@@ -147,6 +147,10 @@ struct IterableAppIntegrationInternal {
                     performDefaultNotificationAction(userInfo)
                 }
                 break
+            #if swift(>=5.0)
+            @unknown default:
+                break
+            #endif
             }
         }
         


### PR DESCRIPTION
The CocoaPod pod spec format has a mechanism to [specify multiple version of Swift](https://guides.cocoapods.org/syntax/podspec.html#swift_versions) that a Pod support. This PR adds Swift 4.2 and 5.0 to the `swift_versions` list since the Iterable the SDK is compatible with both.

Commit 9bd6091 addresses a couple compiler warnings (not errors) when compiling with Swift 5