### PR TITLE
[MOB-1096] - Use indexPath instead of rowIndex.

### DIFF
--- a/Tests/swift-sdk-swift-tests/InboxViewControllerViewModelTests.swift
+++ b/Tests/swift-sdk-swift-tests/InboxViewControllerViewModelTests.swift
@@ -412,7 +412,7 @@ class InboxViewControllerViewModelTests: XCTestCase {
     }
     
     private class MockViewModelView: InboxViewControllerViewModelView {
-        let currentlyVisibleRowIndices: [Int] = []
+        let currentlyVisibleRowIndexPaths: [IndexPath] = []
         
         var onImageLoadedCallback: ((IndexPath) -> Void)?
         

--- a/swift-sdk/Internal/InboxViewControllerViewModel.swift
+++ b/swift-sdk/Internal/InboxViewControllerViewModel.swift
@@ -10,7 +10,7 @@ protocol InboxViewControllerViewModelView: AnyObject {
     // All these methods should be called on the main thread
     func onViewModelChanged(diff: [SectionedDiffStep<Int, InboxMessageViewModel>])
     func onImageLoaded(for indexPath: IndexPath)
-    var currentlyVisibleRowIndices: [Int] { get }
+    var currentlyVisibleRowIndexPaths: [IndexPath] { get }
 }
 
 protocol InboxViewControllerViewModelProtocol {
@@ -188,12 +188,16 @@ class InboxViewControllerViewModel: InboxViewControllerViewModelProtocol {
             return []
         }
         
-        return view.currentlyVisibleRowIndices.compactMap { index in
-            let allMessages = allMessagesInSections()
-            guard index < allMessages.count else {
+        return view.currentlyVisibleRowIndexPaths.compactMap { indexPath in
+            guard indexPath.section < sectionedMessages.sectionsAndValues.count else {
                 return nil
             }
-            let message = allMessages[index].iterableMessage
+            let sectionMessages = sectionedMessages.sectionsAndValues[indexPath.section].1
+            guard indexPath.row < sectionMessages.count else {
+                return nil
+            }
+            
+            let message = sectionMessages[indexPath.row].iterableMessage
             return InboxImpressionTracker.RowInfo(messageId: message.messageId, silentInbox: message.silentInbox)
         }
     }

--- a/swift-sdk/IterableInboxViewController.swift
+++ b/swift-sdk/IterableInboxViewController.swift
@@ -440,7 +440,7 @@ extension IterableInboxViewController: InboxViewControllerViewModelView {
         tableView.reloadRows(at: [indexPath], with: .automatic)
     }
     
-    var currentlyVisibleRowIndices: [Int] {
+    var currentlyVisibleRowIndexPaths: [IndexPath] {
         return tableView.indexPathsForVisibleRows?.compactMap(isRowVisible(atIndexPath:)) ?? []
     }
     
@@ -467,7 +467,7 @@ extension IterableInboxViewController: InboxViewControllerViewModelView {
         viewModel.endedUpdates()
     }
     
-    private func isRowVisible(atIndexPath indexPath: IndexPath) -> Int? {
+    private func isRowVisible(atIndexPath indexPath: IndexPath) -> IndexPath? {
         let topMargin = CGFloat(10.0)
         let bottomMargin = CGFloat(10.0)
         let frame = tableView.frame
@@ -484,7 +484,7 @@ extension IterableInboxViewController: InboxViewControllerViewModelView {
         let cellRect = tableView.rectForRow(at: indexPath)
         let convertedRect = tableView.convert(cellRect, to: tableView.superview)
         
-        return newRect.contains(convertedRect) ? indexPath.row : nil
+        return newRect.contains(convertedRect) ? indexPath : nil
     }
 }
 


### PR DESCRIPTION
We can have multiple sections now so we should look at index path instead of row index.