### PR TITLE
[MOB-1775] add way for auth token to be included

### DIFF
--- a/swift-sdk.xcodeproj/project.pbxproj
+++ b/swift-sdk.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		5531CDAC22A997A4000D05E2 /* IterableInboxViewControllerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5585DF9022A877E6000A32B9 /* IterableInboxViewControllerUITests.swift */; };
 		5531CDAE22A9C992000D05E2 /* ClassExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5531CDAD22A9C992000D05E2 /* ClassExtensionsTests.swift */; };
 		556FB1EA244FAF6A00EDF6BD /* InAppPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556FB1E9244FAF6A00EDF6BD /* InAppPresenter.swift */; };
+		557AE6BF24A56E5E00B57750 /* Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557AE6BE24A56E5E00B57750 /* Auth.swift */; };
 		5585DF8F22A73390000A32B9 /* IterableInboxViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5585DF8E22A73390000A32B9 /* IterableInboxViewControllerTests.swift */; };
 		55B37FC1229620D20042F13A /* CommerceItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B37FC0229620D20042F13A /* CommerceItemTests.swift */; };
 		55B37FC42297135F0042F13A /* NotificationMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B37FC32297135F0042F13A /* NotificationMetadataTests.swift */; };
@@ -281,6 +282,7 @@
 		551E5C0F234D485A005FEE9E /* DeprecatedFunctionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedFunctionsTests.swift; sourceTree = "<group>"; };
 		5531CDAD22A9C992000D05E2 /* ClassExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassExtensionsTests.swift; sourceTree = "<group>"; };
 		556FB1E9244FAF6A00EDF6BD /* InAppPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPresenter.swift; sourceTree = "<group>"; };
+		557AE6BE24A56E5E00B57750 /* Auth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Auth.swift; sourceTree = "<group>"; };
 		5585DF8E22A73390000A32B9 /* IterableInboxViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterableInboxViewControllerTests.swift; sourceTree = "<group>"; };
 		5585DF9022A877E6000A32B9 /* IterableInboxViewControllerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterableInboxViewControllerUITests.swift; sourceTree = "<group>"; };
 		55B37FC0229620D20042F13A /* CommerceItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommerceItemTests.swift; sourceTree = "<group>"; };
@@ -718,6 +720,7 @@
 				AC3C10F7213F43AC00A9B839 /* Logging */,
 				AC219C4B225FE2B300B98631 /* UI */,
 				AC72A0AC20CF4C08004D7997 /* Util */,
+				557AE6BE24A56E5E00B57750 /* Auth.swift */,
 				AC2C667D20D3111900D46CC9 /* DateProvider.swift */,
 				AC72A0C420CF4CB8004D7997 /* IterableActionRunner.swift */,
 				AC72A0C520CF4CB9004D7997 /* IterableAPIInternal.swift */,
@@ -747,21 +750,23 @@
 				5531CDAD22A9C992000D05E2 /* ClassExtensionsTests.swift */,
 				55B37FC0229620D20042F13A /* CommerceItemTests.swift */,
 				55E6F45E238E066400808BCE /* DeepLinkTests.swift */,
-				55CC257A2462064F00A77FD5 /* InAppPresenterTests.swift */,
 				55E6F45D238E066400808BCE /* DeferredDeepLinkTests.swift */,
 				551E5C0F234D485A005FEE9E /* DeprecatedFunctionsTests.swift */,
 				AC750A49234CD67900561902 /* InAppHelperTests.swift */,
 				AC6FDD8B20F56309005D811E /* InAppParsingTests.swift */,
 				55B37FED229F59290042F13A /* InAppPersistenceTests.swift */,
+				55CC257A2462064F00A77FD5 /* InAppPresenterTests.swift */,
 				ACA8D1A821965B7D001B1332 /* InAppTests.swift */,
+				55B549852397462300243E87 /* InboxImpressionTrackerTests.swift */,
 				55B37FC722975A840042F13A /* InboxMessageViewModelTests.swift */,
 				55B5498323973B5C00243E87 /* InboxSessionManagerTests.swift */,
-				55B549852397462300243E87 /* InboxImpressionTrackerTests.swift */,
 				AC1670CC2230A91C00989F8E /* InboxTests.swift */,
+				AC8F35A1239806B500302994 /* InboxViewControllerViewModelTests.swift */,
 				AC2C668620D3435700D46CC9 /* IterableActionRunnerTests.swift */,
 				AC64626A2140AACF0046E1BD /* IterableAPIResponseTests.swift */,
 				ACD6116D21080564003E7F6B /* IterableAPITests.swift */,
 				AC89661D2124FBCE0051A6CD /* IterableAutoRegistrationTests.swift */,
+				AC4BA00124163D8F007359F1 /* IterableHtmlMessageViewControllerTests.swift */,
 				5585DF8E22A73390000A32B9 /* IterableInboxViewControllerTests.swift */,
 				AC2C667F20D31B1F00D46CC9 /* IterableNotificationResponseTests.swift */,
 				AC776DA3211A17C700C27C27 /* IterableRequestUtilTests.swift */,
@@ -772,9 +777,7 @@
 				ACEDF41E2183C436000B9BFE /* PromiseTests.swift */,
 				AC02CAA5234E50B5006617E0 /* RegistrationTests.swift */,
 				ACAA816D231163660035C743 /* RequestCreatorTests.swift */,
-				AC8F35A1239806B500302994 /* InboxViewControllerViewModelTests.swift */,
 				ACB37AAF240268A60093A8EA /* SampleInboxViewDelegateImplementations.swift */,
-				AC4BA00124163D8F007359F1 /* IterableHtmlMessageViewControllerTests.swift */,
 			);
 			path = "swift-sdk-swift-tests";
 			sourceTree = "<group>";
@@ -1492,6 +1495,7 @@
 				ACEDF41D2183C2EC000B9BFE /* Promise.swift in Sources */,
 				AC7125EF20D4579E0043BBC1 /* IterableConfig.swift in Sources */,
 				AC03094B21E532470003A288 /* InAppPersistence.swift in Sources */,
+				557AE6BF24A56E5E00B57750 /* Auth.swift in Sources */,
 				AC819184227138EF0014955E /* Dwifft.swift in Sources */,
 				AC02480822791E2100495FB9 /* IterableInboxNavigationViewController.swift in Sources */,
 				AC845107228DF54E0052BB8F /* ApiClient.swift in Sources */,

--- a/swift-sdk.xcodeproj/project.pbxproj
+++ b/swift-sdk.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		55B37FEE229F59290042F13A /* InAppPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B37FED229F59290042F13A /* InAppPersistenceTests.swift */; };
 		55B5498423973B5C00243E87 /* InboxSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B5498323973B5C00243E87 /* InboxSessionManagerTests.swift */; };
 		55B549862397462300243E87 /* InboxImpressionTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B549852397462300243E87 /* InboxImpressionTrackerTests.swift */; };
+		55B9F15124B3D33700E8198A /* AuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B9F15024B3D33700E8198A /* AuthTests.swift */; };
 		55CC257B2462064F00A77FD5 /* InAppPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CC257A2462064F00A77FD5 /* InAppPresenterTests.swift */; };
 		55D54656239AE5750093ED1E /* LoggingInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D54655239AE5750093ED1E /* LoggingInternal.swift */; };
 		55E6F460238E066400808BCE /* DeferredDeepLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E6F45D238E066400808BCE /* DeferredDeepLinkTests.swift */; };
@@ -307,6 +308,7 @@
 		55B37FED229F59290042F13A /* InAppPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPersistenceTests.swift; sourceTree = "<group>"; };
 		55B5498323973B5C00243E87 /* InboxSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxSessionManagerTests.swift; sourceTree = "<group>"; };
 		55B549852397462300243E87 /* InboxImpressionTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxImpressionTrackerTests.swift; sourceTree = "<group>"; };
+		55B9F15024B3D33700E8198A /* AuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTests.swift; sourceTree = "<group>"; };
 		55CC257A2462064F00A77FD5 /* InAppPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPresenterTests.swift; sourceTree = "<group>"; };
 		55D54655239AE5750093ED1E /* LoggingInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingInternal.swift; sourceTree = "<group>"; };
 		55E6F45D238E066400808BCE /* DeferredDeepLinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeferredDeepLinkTests.swift; sourceTree = "<group>"; };
@@ -787,6 +789,7 @@
 				AC87172421A4E3FF00FEA369 /* Helper Classes */,
 				00B6FACF210E8B10007535CF /* Test Files */,
 				00B6FACB210E8484007535CF /* APNSTypeCheckerTests.swift */,
+				55B9F15024B3D33700E8198A /* AuthTests.swift */,
 				5531CDAD22A9C992000D05E2 /* ClassExtensionsTests.swift */,
 				55B37FC0229620D20042F13A /* CommerceItemTests.swift */,
 				55E6F45E238E066400808BCE /* DeepLinkTests.swift */,
@@ -968,11 +971,11 @@
 			isa = PBXGroup;
 			children = (
 				AC995F932166EC310099A184 /* common */,
+				AC28480824AA44C600C1FC7F /* endpoint-tests */,
+				ACDA976F23159C39004C412E /* inbox-ui-tests-app-ui-tests */,
 				AC90C4D220D8632E00EECA5D /* notification-extension-tests */,
 				AC7B142C20D02CE200877BFE /* swift-sdk-swift-tests */,
 				ACC87764215C20B50097E29B /* ui-tests */,
-				ACDA976F23159C39004C412E /* inbox-ui-tests-app-ui-tests */,
-				AC28480824AA44C600C1FC7F /* endpoint-tests */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -1484,6 +1487,7 @@
 				AC8F35A2239806B500302994 /* InboxViewControllerViewModelTests.swift in Sources */,
 				AC995F9A2166EEB50099A184 /* CommonMocks.swift in Sources */,
 				5585DF8F22A73390000A32B9 /* IterableInboxViewControllerTests.swift in Sources */,
+				55B9F15124B3D33700E8198A /* AuthTests.swift in Sources */,
 				551E5C10234D485A005FEE9E /* DeprecatedFunctionsTests.swift in Sources */,
 				ACED4C01213F50B30055A497 /* LoggingTests.swift in Sources */,
 				55B37FC42297135F0042F13A /* NotificationMetadataTests.swift in Sources */,

--- a/swift-sdk/Constants.swift
+++ b/swift-sdk/Constants.swift
@@ -48,6 +48,7 @@ public enum Const {
         static let attributionInfoKey = "itbl_attribution_info_key"
         public static let emailKey = "itbl_email"
         static let userIdKey = "itbl_userid"
+        static let authTokenKey = "itbl_auth_token"
         static let ddlChecked = "itbl_ddl_checked"
         static let deviceId = "itbl_device_id"
         static let sdkVersion = "itbl_sdk_version"
@@ -171,6 +172,7 @@ public enum JsonKey: String, JsonKeyRepresentable {
         static let apiKey = "Api-Key"
         static let sdkVersion = "SDK-Version"
         static let sdkPlatform = "SDK-Platform"
+        static let authorization = "Authorization"
     }
     
     public enum InApp {
@@ -207,6 +209,7 @@ public enum JsonValue: String, JsonValueRepresentable {
     case apnsSandbox = "APNS_SANDBOX"
     case apnsProduction = "APNS"
     case iOS
+    case bearer = "Bearer"
     
     public enum ActionIdentifier {
         static let pushOpenDefault = "default"

--- a/swift-sdk/Internal/ApiClient.swift
+++ b/swift-sdk/Internal/ApiClient.swift
@@ -118,7 +118,7 @@ class ApiClient {
     }
     
     private let apiKey: String
-    private weak var authProvider: AuthProvider?
+    private let authProvider: AuthProvider?
     private let endPoint: String
     private let networkSession: NetworkSessionProtocol
     private let deviceMetadata: DeviceMetadata

--- a/swift-sdk/Internal/ApiClient.swift
+++ b/swift-sdk/Internal/ApiClient.swift
@@ -118,7 +118,7 @@ class ApiClient {
     }
     
     private let apiKey: String
-    private let authProvider: AuthProvider?
+    private weak var authProvider: AuthProvider?
     private let endPoint: String
     private let networkSession: NetworkSessionProtocol
     private let deviceMetadata: DeviceMetadata

--- a/swift-sdk/Internal/Auth.swift
+++ b/swift-sdk/Internal/Auth.swift
@@ -12,7 +12,7 @@ protocol AuthProvider: AnyObject {
 struct Auth {
     let userId: String?
     let email: String?
-    var authToken: String?
+    let authToken: String?
     
     var emailOrUserId: EmailOrUserId {
         if let email = email {

--- a/swift-sdk/Internal/Auth.swift
+++ b/swift-sdk/Internal/Auth.swift
@@ -1,0 +1,32 @@
+//
+//  Created by Jay Kim on 6/25/20.
+//  Copyright © 2020 Iterable. All rights reserved.
+//
+
+import Foundation
+
+protocol AuthProvider: AnyObject {
+    var auth: Auth { get }
+}
+
+struct Auth {
+    let userId: String?
+    let email: String?
+    var authToken: String?
+    
+    var emailOrUserId: EmailOrUserId {
+        if let email = email {
+            return .email(email)
+        } else if let userId = userId {
+            return .userId(userId)
+        } else {
+            return .none
+        }
+    }
+    
+    enum EmailOrUserId {
+        case email(String)
+        case userId(String)
+        case none
+    }
+}

--- a/swift-sdk/Internal/DataFieldsHelper.swift
+++ b/swift-sdk/Internal/DataFieldsHelper.swift
@@ -9,7 +9,12 @@ import Foundation
 import UIKit
 
 struct DataFieldsHelper {
-    static func createDataFields(sdkVersion: String?, deviceId: String, device: UIDevice, bundle: Bundle, notificationsEnabled: Bool, deviceAttributes: [String: String]) -> [String: Any] {
+    static func createDataFields(sdkVersion: String?,
+                                 deviceId: String,
+                                 device: UIDevice,
+                                 bundle: Bundle,
+                                 notificationsEnabled: Bool,
+                                 deviceAttributes: [String: String]) -> [String: Any] {
         var dataFields = [String: Any]()
         
         deviceAttributes.forEach { deviceAttribute in
@@ -17,9 +22,11 @@ struct DataFieldsHelper {
         }
         
         dataFields[JsonKey.deviceId.jsonKey] = deviceId
+        
         if let sdkVersion = sdkVersion {
             dataFields[JsonKey.iterableSdkVersion.jsonKey] = sdkVersion
         }
+        
         dataFields[JsonKey.notificationsEnabled.jsonKey] = notificationsEnabled
         
         dataFields.addAll(other: createBundleFields(bundle: bundle))

--- a/swift-sdk/Internal/IterableAPIInternal.swift
+++ b/swift-sdk/Internal/IterableAPIInternal.swift
@@ -136,13 +136,13 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
         }
     }
     
-    func setEmail(_ email: String, _ token: String? = nil) {
+    func setEmail(_ email: String, withToken token: String? = nil) {
         authToken = token
         
         self.email = email
     }
     
-    func setUserId(_ userId: String, _ token: String? = nil) {
+    func setUserId(_ userId: String, withToken token: String? = nil) {
         authToken = token
         
         self.userId = userId

--- a/swift-sdk/Internal/IterableAPIInternal.swift
+++ b/swift-sdk/Internal/IterableAPIInternal.swift
@@ -20,18 +20,15 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
         get {
             _email
         } set {
-            guard newValue != _email else {
-                return
+            if newValue == nil {
+                logoutPreviousUser()
+            } else {
+                guard let newEmail = newValue else {
+                    return
+                }
+                
+                setEmail(newEmail)
             }
-            
-            logoutPreviousUser()
-            
-            _email = newValue
-            _userId = nil
-            
-            storeAuthData()
-            
-            loginNewUser()
         }
     }
     
@@ -39,18 +36,15 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
         get {
             _userId
         } set {
-            guard newValue != _userId else {
-                return
+            if newValue == nil {
+                logoutPreviousUser()
+            } else {
+                guard let newUserId = newValue else {
+                    return
+                }
+                
+                setUserId(newUserId)
             }
-            
-            logoutPreviousUser()
-            
-            _userId = newValue
-            _email = nil
-            
-            storeAuthData()
-            
-            loginNewUser()
         }
     }
     
@@ -137,15 +131,35 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
     }
     
     func setEmail(_ email: String, withToken token: String? = nil) {
+        guard email != _email else {
+            return
+        }
+        
+        logoutPreviousUser()
+        
+        _email = email
+        _userId = nil
         authToken = token
         
-        self.email = email
+        storeAuthData()
+        
+        loginNewUser()
     }
     
     func setUserId(_ userId: String, withToken token: String? = nil) {
+        guard userId != _userId else {
+            return
+        }
+        
+        logoutPreviousUser()
+        
+        _userId = userId
+        _email = nil
         authToken = token
         
-        self.userId = userId
+        storeAuthData()
+        
+        loginNewUser()
     }
     
     // MARK: - API Request Calls
@@ -406,7 +420,11 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
             disableDeviceForCurrentUser()
         }
         
+        _email = nil
+        _userId = nil
         authToken = nil
+        
+        storeAuthData()
         
         _ = inAppManager.reset()
     }

--- a/swift-sdk/Internal/IterableAPIInternal.swift
+++ b/swift-sdk/Internal/IterableAPIInternal.swift
@@ -534,7 +534,7 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
     func start() -> Future<Bool, Error> {
         ITBInfo()
         
-        updateSdkVersion()
+        updateSDKVersion()
         
         checkForDeferredDeepLink()
         
@@ -622,7 +622,7 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
         }
     }
     
-    private func updateSdkVersion() {
+    private func updateSDKVersion() {
         if let lastVersion = localStorage.sdkVersion, lastVersion != IterableAPI.sdkVersion {
             performUpgrade(lastVersion: lastVersion, newVersion: IterableAPI.sdkVersion)
         } else {

--- a/swift-sdk/Internal/IterableAPIInternal.swift
+++ b/swift-sdk/Internal/IterableAPIInternal.swift
@@ -136,18 +136,10 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
         }
     }
     
-    func getEmail() -> String? {
-        return _email
-    }
-    
     func setEmail(_ email: String, _ token: String? = nil) {
         authToken = token
         
         self.email = email
-    }
-    
-    func getUserId() -> String? {
-        return _userId
     }
     
     func setUserId(_ userId: String, _ token: String? = nil) {

--- a/swift-sdk/Internal/IterableAPIInternal.swift
+++ b/swift-sdk/Internal/IterableAPIInternal.swift
@@ -20,15 +20,7 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
         get {
             _email
         } set {
-            if newValue == nil {
-                logoutPreviousUser()
-            } else {
-                guard let newEmail = newValue else {
-                    return
-                }
-                
-                setEmail(newEmail)
-            }
+            setEmail(newValue)
         }
     }
     
@@ -36,15 +28,7 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
         get {
             _userId
         } set {
-            if newValue == nil {
-                logoutPreviousUser()
-            } else {
-                guard let newUserId = newValue else {
-                    return
-                }
-                
-                setUserId(newUserId)
-            }
+            setUserId(newValue)
         }
     }
     
@@ -130,7 +114,7 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
         }
     }
     
-    func setEmail(_ email: String, withToken token: String? = nil) {
+    func setEmail(_ email: String?, withToken token: String? = nil) {
         guard email != _email else {
             return
         }
@@ -146,7 +130,7 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
         loginNewUser()
     }
     
-    func setUserId(_ userId: String, withToken token: String? = nil) {
+    func setUserId(_ userId: String?, withToken token: String? = nil) {
         guard userId != _userId else {
             return
         }

--- a/swift-sdk/Internal/LocalStorageProtocol.swift
+++ b/swift-sdk/Internal/LocalStorageProtocol.swift
@@ -8,6 +8,7 @@ import Foundation
 protocol LocalStorageProtocol {
     var userId: String? { get set }
     var email: String? { get set }
+    var authToken: String? { get set }
     var ddlChecked: Bool { get set }
     var deviceId: String? { get set }
     var sdkVersion: String? { get set }

--- a/swift-sdk/Internal/UserDefaultsLocalStorage.swift
+++ b/swift-sdk/Internal/UserDefaultsLocalStorage.swift
@@ -26,6 +26,14 @@ struct UserDefaultsLocalStorage: LocalStorageProtocol {
         }
     }
     
+    var authToken: String? {
+        get {
+            return string(withKey: .authToken)
+        } set {
+            save(string: newValue, withKey: .authToken)
+        }
+    }
+    
     var ddlChecked: Bool {
         get {
             return bool(withKey: .ddlChecked)
@@ -174,6 +182,7 @@ struct UserDefaultsLocalStorage: LocalStorageProtocol {
         static let attributionInfo = LocalStorageKey(value: Const.UserDefaults.attributionInfoKey)
         static let email = LocalStorageKey(value: Const.UserDefaults.emailKey)
         static let userId = LocalStorageKey(value: Const.UserDefaults.userIdKey)
+        static let authToken = LocalStorageKey(value: Const.UserDefaults.authTokenKey)
         static let ddlChecked = LocalStorageKey(value: Const.UserDefaults.ddlChecked)
         static let deviceId = LocalStorageKey(value: Const.UserDefaults.deviceId)
         static let sdkVersion = LocalStorageKey(value: Const.UserDefaults.sdkVersion)

--- a/swift-sdk/IterableAPI.swift
+++ b/swift-sdk/IterableAPI.swift
@@ -120,7 +120,7 @@ import UIKit
     /// - parameter token: the associated authentication token for the user
     @objc(setEmail:withToken:)
     public static func setEmail(_ email: String, withToken token: String? = nil) {
-        internalImplementation?.setEmail(email, token)
+        internalImplementation?.setEmail(email, withToken: token)
     }
     
     /// Set the user of the SDK instance to the user ID specified
@@ -129,7 +129,7 @@ import UIKit
     /// - parameter token: the associated authentication token for the user
     @objc(setUserId:withToken:)
     public static func setUserId(_ userId: String, withToken token: String? = nil) {
-        internalImplementation?.setUserId(userId, token)
+        internalImplementation?.setUserId(userId, withToken: token)
     }
     
     /// Use this property for getting and showing in-app messages.

--- a/swift-sdk/IterableAPI.swift
+++ b/swift-sdk/IterableAPI.swift
@@ -114,11 +114,6 @@ import UIKit
         internalImplementation?.removeDeviceAttribute(name: name)
     }
     
-    /// Get the email address of the user of the SDK instance
-    public static func getEmail() -> String? {
-        return internalImplementation?.getEmail()
-    }
-    
     /// Set the user of the SDK instance to the email address specified
     ///
     /// - parameter email: the email of the user for the SDK instance
@@ -126,11 +121,6 @@ import UIKit
     @objc(setEmail:token:)
     public static func setEmail(_ email: String, _ token: String? = nil) {
         internalImplementation?.setEmail(email, token)
-    }
-    
-    /// Get the user ID of the user of the SDK instance
-    public static func getUserId() -> String? {
-        return internalImplementation?.getUserId()
     }
     
     /// Set the user of the SDK instance to the user ID specified

--- a/swift-sdk/IterableAPI.swift
+++ b/swift-sdk/IterableAPI.swift
@@ -114,6 +114,34 @@ import UIKit
         internalImplementation?.removeDeviceAttribute(name: name)
     }
     
+    /// Get the email address of the user of the SDK instance
+    public static func getEmail() -> String? {
+        return internalImplementation?.getEmail()
+    }
+    
+    /// Set the user of the SDK instance to the email address specified
+    ///
+    /// - parameter email: the email of the user for the SDK instance
+    /// - parameter token: the associated authentication token for the user
+    @objc(setEmail:token:)
+    public static func setEmail(_ email: String, _ token: String? = nil) {
+        internalImplementation?.setEmail(email, token)
+    }
+    
+    /// Get the user ID of the user of the SDK instance
+    public static func getUserId() -> String? {
+        return internalImplementation?.getUserId()
+    }
+    
+    /// Set the user of the SDK instance to the user ID specified
+    ///
+    /// - parameter userId: the userId of the user for the SDK instance
+    /// - parameter token: the associated authentication token for the user
+    @objc(setUserId:token:)
+    public static func setUserId(_ userId: String, _ token: String? = nil) {
+        internalImplementation?.setUserId(userId, token)
+    }
+    
     /// Use this property for getting and showing in-app messages.
     /// This property has no meaning if IterableAPI has not been initialized using
     /// IterableAPI.initialize

--- a/swift-sdk/IterableAPI.swift
+++ b/swift-sdk/IterableAPI.swift
@@ -118,8 +118,8 @@ import UIKit
     ///
     /// - parameter email: the email of the user for the SDK instance
     /// - parameter token: the associated authentication token for the user
-    @objc(setEmail:token:)
-    public static func setEmail(_ email: String, _ token: String? = nil) {
+    @objc(setEmail:withToken:)
+    public static func setEmail(_ email: String, withToken token: String? = nil) {
         internalImplementation?.setEmail(email, token)
     }
     
@@ -127,8 +127,8 @@ import UIKit
     ///
     /// - parameter userId: the userId of the user for the SDK instance
     /// - parameter token: the associated authentication token for the user
-    @objc(setUserId:token:)
-    public static func setUserId(_ userId: String, _ token: String? = nil) {
+    @objc(setUserId:withToken:)
+    public static func setUserId(_ userId: String, withToken token: String? = nil) {
         internalImplementation?.setUserId(userId, token)
     }
     

--- a/tests/swift-sdk-swift-tests/AuthTests.swift
+++ b/tests/swift-sdk-swift-tests/AuthTests.swift
@@ -1,0 +1,69 @@
+//
+//  AuthTests.swift
+//  swift-sdk-swift-tests
+//
+//  Created by Jay Kim on 7/6/20.
+//  Copyright © 2020 Iterable. All rights reserved.
+//
+
+import XCTest
+
+@testable import IterableSDK
+
+class AuthTests: XCTestCase {
+    private static let apiKey = "zeeApiKey"
+    private static let email = "user@example.com"
+    private static let userId = "testUserId"
+    
+    override func setUp() {
+        super.setUp()
+        
+        TestUtils.clearTestUserDefaults()
+    }
+    
+    func testEmailPersistence() {
+        let internalAPI = IterableAPIInternal.initializeForTesting()
+        
+        internalAPI.email = IterableAPITests.email
+        XCTAssertEqual(internalAPI.email, IterableAPITests.email)
+        XCTAssertNil(internalAPI.userId)
+    }
+    
+    func testUserIdPersistence() {
+        let internalAPI = IterableAPIInternal.initializeForTesting()
+        
+        internalAPI.userId = IterableAPITests.userId
+        XCTAssertEqual(internalAPI.userId, IterableAPITests.userId)
+        XCTAssertNil(internalAPI.email)
+    }
+    
+    func testEmailWithTokenPersistence() {
+        let internalAPI = IterableAPIInternal.initializeForTesting()
+        
+        let emailToken = "asdf"
+        
+        internalAPI.setEmail(IterableAPITests.email, withToken: emailToken)
+        XCTAssertEqual(internalAPI.email, IterableAPITests.email)
+        XCTAssertNil(internalAPI.userId)
+        XCTAssertEqual(internalAPI.auth.authToken, emailToken)
+    }
+    
+    func testUserIdWithTokenPersistence() {
+        let internalAPI = IterableAPIInternal.initializeForTesting()
+        
+        let userIdToken = "qwer"
+        
+        internalAPI.setUserId(IterableAPITests.userId, withToken: userIdToken)
+        XCTAssertEqual(internalAPI.userId, IterableAPITests.userId)
+        XCTAssertNil(internalAPI.email)
+        XCTAssertEqual(internalAPI.auth.authToken, userIdToken)
+    }
+    
+    func testUserLoginAndLogout() {
+        
+    }
+    
+    func testEmailWithTokenChange() {
+        
+    }
+}

--- a/tests/swift-sdk-swift-tests/AuthTests.swift
+++ b/tests/swift-sdk-swift-tests/AuthTests.swift
@@ -44,6 +44,8 @@ class AuthTests: XCTestCase {
     func testEmailWithTokenPersistence() {
         let internalAPI = IterableAPIInternal.initializeForTesting()
         
+        internalAPI.email = "previous.user@example.com"
+        
         let emailToken = "asdf"
         
         internalAPI.setEmail(AuthTests.email, withToken: emailToken)
@@ -55,6 +57,8 @@ class AuthTests: XCTestCase {
     
     func testUserIdWithTokenPersistence() {
         let internalAPI = IterableAPIInternal.initializeForTesting()
+        
+        internalAPI.userId = "previousUserId"
         
         let userIdToken = "qwer"
         

--- a/tests/swift-sdk-swift-tests/AuthTests.swift
+++ b/tests/swift-sdk-swift-tests/AuthTests.swift
@@ -24,17 +24,21 @@ class AuthTests: XCTestCase {
     func testEmailPersistence() {
         let internalAPI = IterableAPIInternal.initializeForTesting()
         
-        internalAPI.email = IterableAPITests.email
-        XCTAssertEqual(internalAPI.email, IterableAPITests.email)
+        internalAPI.email = AuthTests.email
+        
+        XCTAssertEqual(internalAPI.email, AuthTests.email)
         XCTAssertNil(internalAPI.userId)
+        XCTAssertNil(internalAPI.auth.authToken)
     }
     
     func testUserIdPersistence() {
         let internalAPI = IterableAPIInternal.initializeForTesting()
         
-        internalAPI.userId = IterableAPITests.userId
-        XCTAssertEqual(internalAPI.userId, IterableAPITests.userId)
+        internalAPI.userId = AuthTests.userId
+        
         XCTAssertNil(internalAPI.email)
+        XCTAssertEqual(internalAPI.userId, AuthTests.userId)
+        XCTAssertNil(internalAPI.auth.authToken)
     }
     
     func testEmailWithTokenPersistence() {
@@ -42,8 +46,9 @@ class AuthTests: XCTestCase {
         
         let emailToken = "asdf"
         
-        internalAPI.setEmail(IterableAPITests.email, withToken: emailToken)
-        XCTAssertEqual(internalAPI.email, IterableAPITests.email)
+        internalAPI.setEmail(AuthTests.email, withToken: emailToken)
+        
+        XCTAssertEqual(internalAPI.email, AuthTests.email)
         XCTAssertNil(internalAPI.userId)
         XCTAssertEqual(internalAPI.auth.authToken, emailToken)
     }
@@ -53,17 +58,48 @@ class AuthTests: XCTestCase {
         
         let userIdToken = "qwer"
         
-        internalAPI.setUserId(IterableAPITests.userId, withToken: userIdToken)
-        XCTAssertEqual(internalAPI.userId, IterableAPITests.userId)
+        internalAPI.setUserId(AuthTests.userId, withToken: userIdToken)
+        
         XCTAssertNil(internalAPI.email)
+        XCTAssertEqual(internalAPI.userId, AuthTests.userId)
         XCTAssertEqual(internalAPI.auth.authToken, userIdToken)
     }
     
     func testUserLoginAndLogout() {
+        let internalAPI = IterableAPIInternal.initializeForTesting()
         
+        internalAPI.setEmail(AuthTests.email)
+        
+        XCTAssertEqual(internalAPI.email, AuthTests.email)
+        XCTAssertNil(internalAPI.userId)
+        XCTAssertNil(internalAPI.auth.authToken)
+        
+        internalAPI.email = nil
+        
+        XCTAssertNil(internalAPI.email)
+        XCTAssertNil(internalAPI.userId)
+        XCTAssertNil(internalAPI.auth.authToken)
     }
     
     func testEmailWithTokenChange() {
+        let internalAPI = IterableAPIInternal.initializeForTesting()
         
+        let originalEmail = "first@example.com"
+        let originalToken = "fdsa"
+        
+        let newEmail = "second@example.com"
+        let newToken = "jay"
+        
+        internalAPI.setEmail(originalEmail, withToken: originalToken)
+        
+        XCTAssertEqual(internalAPI.email, originalEmail)
+        XCTAssertNil(internalAPI.userId)
+        XCTAssertEqual(internalAPI.auth.authToken, originalToken)
+        
+        internalAPI.setEmail(newEmail, withToken: newToken)
+        
+        XCTAssertEqual(internalAPI.email, newEmail)
+        XCTAssertNil(internalAPI.userId)
+        XCTAssertEqual(internalAPI.auth.authToken, newToken)
     }
 }

--- a/tests/swift-sdk-swift-tests/DeferredDeepLinkTests.swift
+++ b/tests/swift-sdk-swift-tests/DeferredDeepLinkTests.swift
@@ -12,6 +12,7 @@ class DeferredDeepLinkTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
+        
         TestUtils.clearTestUserDefaults()
     }
     
@@ -25,6 +26,7 @@ class DeferredDeepLinkTests: XCTestCase {
             "templateId": "1",
             "messageId": "1",
         ]
+        
         let networkSession = MockNetworkSession(statusCode: 200, json: json)
         
         let config = IterableConfig()
@@ -35,6 +37,7 @@ class DeferredDeepLinkTests: XCTestCase {
             expectation.fulfill()
             XCTAssertEqual(url.absoluteString, "zeeDestinationUrl")
         }
+        
         config.urlDelegate = urlDelegate
         IterableAPIInternal.initializeForTesting(apiKey: DeferredDeepLinkTests.apiKey, config: config, networkSession: networkSession)
         

--- a/tests/swift-sdk-swift-tests/InboxTests.swift
+++ b/tests/swift-sdk-swift-tests/InboxTests.swift
@@ -600,7 +600,7 @@ class InboxTests: XCTestCase {
         wait(for: [expectation3, expectation1, expectation2], timeout: testExpectationTimeout)
     }
     
-    func testLogout() {
+    func testInboxLogoutClearMessageQueue() {
         TestUtils.clearTestUserDefaults()
         
         let expectation1 = expectation(description: "initial messages sent")
@@ -615,6 +615,7 @@ class InboxTests: XCTestCase {
             inAppFetcher: mockInAppFetcher,
             notificationCenter: mockNotificationCenter
         )
+        
         internalAPI.email = "user@example.com"
         
         let payload = """
@@ -639,6 +640,7 @@ class InboxTests: XCTestCase {
             mockNotificationCenter.addCallback(forNotification: .iterableInboxChanged) {
                 expectation2.fulfill()
             }
+            
             internalAPI.email = nil
         }
         

--- a/tests/swift-sdk-swift-tests/IterableAPIResponseTests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPIResponseTests.swift
@@ -34,8 +34,7 @@ class IterableAPIResponseTests: XCTestCase {
         let urlRequest = apiClient.convertToURLRequest(iterableRequest: iterableRequest)!
         
         verifyIterableHeaders(urlRequest)
-        
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.authorization), "Bearer \(authToken)")
+        verifyAuthTokenInHeader(urlRequest, authToken)
     }
     
     func testResponseCode200() {
@@ -191,6 +190,10 @@ class IterableAPIResponseTests: XCTestCase {
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.sdkVersion), IterableAPI.sdkVersion)
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.apiKey), apiKey)
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.contentType.jsonKey), JsonValue.applicationJson.jsonStringValue)
+    }
+    
+    private func verifyAuthTokenInHeader(_ urlRequest: URLRequest, _ authToken: String) {
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.authorization), "Bearer \(authToken)")
     }
     
     private func createApiClient(networkSession: NetworkSessionProtocol) -> ApiClient {

--- a/tests/swift-sdk-swift-tests/IterableAPIResponseTests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPIResponseTests.swift
@@ -209,14 +209,16 @@ class IterableAPIResponseTests: XCTestCase {
     }
     
     private func createApiClientWithAuthToken() -> ApiClient {
-        class AuthProviderImpl: AuthProvider {
-            let auth: Auth = Auth(userId: nil, email: "user@example.com", authToken: "asdf")
-        }
-        
         return ApiClient(apiKey: apiKey,
-                         authProvider: AuthProviderImpl(),
+                         authProvider: self,
                          endPoint: Endpoint.api,
                          networkSession: MockNetworkSession(),
                          deviceMetadata: IterableAPIInternal.initializeForTesting().deviceMetadata)
+    }
+}
+
+extension IterableAPIResponseTests: AuthProvider {
+    var auth: Auth {
+        Auth(userId: nil, email: email, authToken: authToken)
     }
 }

--- a/tests/swift-sdk-swift-tests/IterableAPIResponseTests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPIResponseTests.swift
@@ -25,13 +25,6 @@ class IterableAPIResponseTests: XCTestCase {
         verifyIterableHeaders(urlRequest)
     }
     
-    fileprivate func verifyIterableHeaders(_ urlRequest: URLRequest) {
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.sdkPlatform), JsonValue.iOS.jsonStringValue)
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.sdkVersion), IterableAPI.sdkVersion)
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.apiKey), apiKey)
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
-    }
-    
     func testResponseCode200() {
         let xpectation = expectation(description: "response code 200")
         let networkSession = MockNetworkSession(statusCode: 200)
@@ -84,7 +77,7 @@ class IterableAPIResponseTests: XCTestCase {
         wait(for: [xpectation], timeout: testExpectationTimeout)
     }
     
-    func testResponseCode400WitMessage() {
+    func testResponseCode400WithMessage() {
         let xpectation = expectation(description: "400 with message")
         let networkSession = MockNetworkSession(statusCode: 400, json: ["msg": "Test error"])
         let iterableRequest = IterableRequest.post(PostRequest(path: "", args: nil, body: [:]))
@@ -163,6 +156,7 @@ class IterableAPIResponseTests: XCTestCase {
             response.responseTime = responseTime
             return response
         }
+        
         let networkSession = URLSession(configuration: URLSessionConfiguration.default)
         
         let iterableRequest = IterableRequest.post(PostRequest(path: "", args: nil, body: [:]))
@@ -177,6 +171,13 @@ class IterableAPIResponseTests: XCTestCase {
         }
         
         wait(for: [xpectation], timeout: testExpectationTimeout)
+    }
+    
+    private func verifyIterableHeaders(_ urlRequest: URLRequest) {
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.sdkPlatform), JsonValue.iOS.jsonStringValue)
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.sdkVersion), IterableAPI.sdkVersion)
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.apiKey), apiKey)
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.contentType.jsonKey), JsonValue.applicationJson.jsonStringValue)
     }
     
     private func createApiClient(networkSession: NetworkSessionProtocol) -> ApiClient {

--- a/tests/swift-sdk-swift-tests/IterableAPITests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPITests.swift
@@ -187,30 +187,6 @@ class IterableAPITests: XCTestCase {
         XCTAssertNil(internalAPI.email)
     }
     
-    func testEmailWithTokenPersistence() {
-        let internalAPI = IterableAPIInternal.initializeForTesting()
-        internalAPI.email = "previous.user@example.com"
-        
-        let emailToken = "asdf"
-        
-        internalAPI.setEmail(IterableAPITests.email, withToken: emailToken)
-        XCTAssertEqual(internalAPI.email, IterableAPITests.email)
-        XCTAssertNil(internalAPI.userId)
-        XCTAssertEqual(internalAPI.auth.authToken, emailToken)
-    }
-    
-    func testUserIdWithTokenPersistence() {
-        let internalAPI = IterableAPIInternal.initializeForTesting()
-        internalAPI.userId = "previousUserId"
-        
-        let userIdToken = "qwer"
-        
-        internalAPI.setUserId(IterableAPITests.userId, withToken: userIdToken)
-        XCTAssertEqual(internalAPI.userId, IterableAPITests.userId)
-        XCTAssertNil(internalAPI.email)
-        XCTAssertEqual(internalAPI.auth.authToken, userIdToken)
-    }
-    
     func testUpdateUserWithEmail() {
         let expectation = XCTestExpectation(description: "testUpdateUserWithEmail")
         

--- a/tests/swift-sdk-swift-tests/IterableAPITests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPITests.swift
@@ -189,6 +189,7 @@ class IterableAPITests: XCTestCase {
     
     func testEmailWithTokenPersistence() {
         let internalAPI = IterableAPIInternal.initializeForTesting()
+        internalAPI.email = "previous.user@example.com"
         
         let emailToken = "asdf"
         
@@ -200,6 +201,7 @@ class IterableAPITests: XCTestCase {
     
     func testUserIdWithTokenPersistence() {
         let internalAPI = IterableAPIInternal.initializeForTesting()
+        internalAPI.userId = "previousUserId"
         
         let userIdToken = "qwer"
         

--- a/tests/swift-sdk-swift-tests/IterableAPITests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPITests.swift
@@ -11,6 +11,7 @@ import XCTest
 class IterableAPITests: XCTestCase {
     private static let apiKey = "zeeApiKey"
     private static let email = "user@example.com"
+    private static let userId = "testUserId"
     
     override func setUp() {
         super.setUp()
@@ -170,17 +171,42 @@ class IterableAPITests: XCTestCase {
         wait(for: [expectation], timeout: testExpectationTimeout)
     }
     
-    func testEmailUserIdPersistence() {
+    func testEmailPersistence() {
         let internalAPI = IterableAPIInternal.initializeForTesting()
         
         internalAPI.email = IterableAPITests.email
         XCTAssertEqual(internalAPI.email, IterableAPITests.email)
         XCTAssertNil(internalAPI.userId)
+    }
+    
+    func testEmailUserIdPersistence() {
+        let internalAPI = IterableAPIInternal.initializeForTesting()
         
-        let userId = "testUserId"
-        internalAPI.userId = userId
-        XCTAssertEqual(internalAPI.userId, userId)
+        internalAPI.userId = IterableAPITests.userId
+        XCTAssertEqual(internalAPI.userId, IterableAPITests.userId)
         XCTAssertNil(internalAPI.email)
+    }
+    
+    func testEmailWithTokenPersistence() {
+        let internalAPI = IterableAPIInternal.initializeForTesting()
+        
+        let emailToken = "asdf"
+        
+        internalAPI.setEmail(IterableAPITests.email, emailToken)
+        XCTAssertEqual(internalAPI.email, IterableAPITests.email)
+        XCTAssertNil(internalAPI.userId)
+        XCTAssertEqual(internalAPI.auth.authToken, emailToken)
+    }
+    
+    func testUserIdWithTokenPersistence() {
+        let internalAPI = IterableAPIInternal.initializeForTesting()
+        
+        let userIdToken = "qwer"
+        
+        internalAPI.setUserId(IterableAPITests.userId, userIdToken)
+        XCTAssertEqual(internalAPI.userId, IterableAPITests.userId)
+        XCTAssertNil(internalAPI.email)
+        XCTAssertEqual(internalAPI.auth.authToken, userIdToken)
     }
     
     func testUpdateUserWithEmail() {

--- a/tests/swift-sdk-swift-tests/IterableAPITests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPITests.swift
@@ -179,7 +179,7 @@ class IterableAPITests: XCTestCase {
         XCTAssertNil(internalAPI.userId)
     }
     
-    func testEmailUserIdPersistence() {
+    func testUserIdPersistence() {
         let internalAPI = IterableAPIInternal.initializeForTesting()
         
         internalAPI.userId = IterableAPITests.userId

--- a/tests/swift-sdk-swift-tests/IterableAPITests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPITests.swift
@@ -192,7 +192,7 @@ class IterableAPITests: XCTestCase {
         
         let emailToken = "asdf"
         
-        internalAPI.setEmail(IterableAPITests.email, emailToken)
+        internalAPI.setEmail(IterableAPITests.email, withToken: emailToken)
         XCTAssertEqual(internalAPI.email, IterableAPITests.email)
         XCTAssertNil(internalAPI.userId)
         XCTAssertEqual(internalAPI.auth.authToken, emailToken)
@@ -203,7 +203,7 @@ class IterableAPITests: XCTestCase {
         
         let userIdToken = "qwer"
         
-        internalAPI.setUserId(IterableAPITests.userId, userIdToken)
+        internalAPI.setUserId(IterableAPITests.userId, withToken: userIdToken)
         XCTAssertEqual(internalAPI.userId, IterableAPITests.userId)
         XCTAssertNil(internalAPI.email)
         XCTAssertEqual(internalAPI.auth.authToken, userIdToken)

--- a/tests/swift-sdk-swift-tests/RequestCreatorTests.swift
+++ b/tests/swift-sdk-swift-tests/RequestCreatorTests.swift
@@ -149,7 +149,7 @@ class RequestCreatorTests: XCTestCase {
     }
     
     func testGetInAppMessagesRequestFailure() {
-        let auth = Auth(userId: nil, email: nil)
+        let auth = Auth(userId: nil, email: nil, authToken: nil)
         let requestCreator = RequestCreator(apiKey: apiKey, auth: auth, deviceMetadata: IterableAPIInternal.initializeForTesting().deviceMetadata)
         
         let failingRequest = requestCreator.createGetInAppMessagesRequest(1)
@@ -306,6 +306,6 @@ class RequestCreatorTests: XCTestCase {
 
 extension RequestCreatorTests: AuthProvider {
     var auth: Auth {
-        return Auth(userId: nil, email: email)
+        return Auth(userId: nil, email: email, authToken: nil)
     }
 }


### PR DESCRIPTION
This PR adds a way to let our customers use authentication tokens (like [JWT](https://jwt.io/)) be used with our SDK. This is done by:
- adding a new `setEmail`/`setUserId` function that not only does the same thing as `IterableAPI.email = "email address"`/`IterableAPI.userId = "user ID"` but also adds an optional field to set the user's token (which our customers will generate/handle). This does mean that calling the function is the only way to set the token. I made this choice to avoid possible race conditions with setting properties, and because I think it's a better formalized way to use our SDK.
- adding the token to API calls if it's present

This PR also has some minor refactoring just for organizational purposes.