### PR TITLE
Remove build step run swiftformat

### DIFF
--- a/swift-sdk.xcodeproj/project.pbxproj
+++ b/swift-sdk.xcodeproj/project.pbxproj
@@ -1027,7 +1027,6 @@
 				AC2263DB20CF49B8009800EB /* Frameworks */,
 				AC2263DC20CF49B8009800EB /* Headers */,
 				AC2263DD20CF49B8009800EB /* Resources */,
-				ACEC0AA522FC4E750011885A /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1065,7 +1064,6 @@
 				AC7B142720D02CE200877BFE /* Sources */,
 				AC7B142820D02CE200877BFE /* Frameworks */,
 				AC7B142920D02CE200877BFE /* Resources */,
-				ACEC0AA822FC4F0E0011885A /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1089,7 +1087,6 @@
 				AC90C4C020D8632D00EECA5D /* Frameworks */,
 				AC90C4C120D8632D00EECA5D /* Headers */,
 				AC90C4C220D8632D00EECA5D /* Resources */,
-				ACEC0AA622FC4EC90011885A /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1107,7 +1104,6 @@
 				AC90C4C820D8632E00EECA5D /* Sources */,
 				AC90C4C920D8632E00EECA5D /* Frameworks */,
 				AC90C4CA20D8632E00EECA5D /* Resources */,
-				ACEC0AA922FC4F250011885A /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1127,7 +1123,6 @@
 				ACC8775F215C20B50097E29B /* Sources */,
 				ACC87760215C20B50097E29B /* Frameworks */,
 				ACC87761215C20B50097E29B /* Resources */,
-				ACEC0AAA22FC4F3B0011885A /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1184,7 +1179,6 @@
 				ACF560D020E443BF000AAC23 /* Frameworks */,
 				ACF560D120E443BF000AAC23 /* Resources */,
 				ACC87771215C23CC0097E29B /* Embed Frameworks */,
-				ACEC0AA722FC4EFB0011885A /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1204,7 +1198,6 @@
 				ACFF429224656BDF00FDF10D /* Frameworks */,
 				ACFF429424656BDF00FDF10D /* Resources */,
 				ACFF429824656BDF00FDF10D /* Embed Frameworks */,
-				ACFF429A24656BDF00FDF10D /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1393,128 +1386,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		ACEC0AA522FC4E750011885A /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# if which swiftformat >/dev/null; then\n#  swiftformat .\n# else\n#   echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\n# fi\n";
-		};
-		ACEC0AA622FC4EC90011885A /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftformat >/dev/null; then\n  swiftformat .\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
-		};
-		ACEC0AA722FC4EFB0011885A /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftformat >/dev/null; then\n  swiftformat .\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
-		};
-		ACEC0AA822FC4F0E0011885A /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftformat >/dev/null; then\n  swiftformat .\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
-		};
-		ACEC0AA922FC4F250011885A /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftformat >/dev/null; then\n  swiftformat .\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
-		};
-		ACEC0AAA22FC4F3B0011885A /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftformat >/dev/null; then\n  swiftformat .\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
-		};
-		ACFF429A24656BDF00FDF10D /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftformat >/dev/null; then\n  swiftformat .\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\"\nfi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		AC2263DA20CF49B8009800EB /* Sources */ = {


### PR DESCRIPTION
We can always run `swiftormat .` from the command line. This is causing Xcode issues. I am seeing "code was modified outside" messages often. Also I think this may be impacting code highlighting. 
Plus we should have separate PRs for formatting related issues.