### PR TITLE
[MOB-2523] - Replace getLastRequestBody with less error prone request callback.

### DIFF
--- a/tests/common/CommonExtensions.swift
+++ b/tests/common/CommonExtensions.swift
@@ -14,6 +14,11 @@ extension String {
     }
 }
 
+extension Data {
+    func json() -> [AnyHashable: Any] {
+        try! JSONSerialization.jsonObject(with: self, options: []) as! [AnyHashable: Any]
+    }
+}
 extension Dictionary where Key == AnyHashable {
     func toJsonData() -> Data {
         try! JSONSerialization.data(withJSONObject: self, options: [])

--- a/tests/common/CommonMocks.swift
+++ b/tests/common/CommonMocks.swift
@@ -236,11 +236,6 @@ class MockNetworkSession: NetworkSessionProtocol {
         MockDataTask(url: url, completionHandler: completionHandler, parent: self)
     }
 
-    // TODO: tqm: Change this
-    func getLastRequestBody() -> [AnyHashable: Any] {
-        MockNetworkSession.json(fromData: requests[requests.count-1].httpBody!)
-    }
-    
     func getRequest(withEndPoint endPoint: String) -> URLRequest? {
         return requests.first { request in
             request.url?.absoluteString.contains(endPoint) == true

--- a/tests/offline-events-tests/TaskProcessorTests.swift
+++ b/tests/offline-events-tests/TaskProcessorTests.swift
@@ -49,7 +49,8 @@ class TaskProcessorTests: XCTestCase {
         // process data
         let processor = IterableAPICallTaskProcessor(networkSession: internalAPI.networkSession)
         try processor.process(task: found).onSuccess { _ in
-            let body = networkSession.getLastRequestBody() as! [String: Any]
+            let request = networkSession.getRequest(withEndPoint: Const.Path.trackEvent)!
+            let body = request.httpBody!.json() as! [String: Any]
             TestUtils.validateMatch(keyPath: KeyPath(.email), value: email, inDictionary: body)
             TestUtils.validateMatch(keyPath: KeyPath(.dataFields), value: dataFields, inDictionary: body)
             expectation1.fulfill()

--- a/tests/swift-sdk-swift-tests/IterableAPITests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPITests.swift
@@ -110,9 +110,11 @@ class IterableAPITests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
         internalAPI.email = IterableAPITests.email
+
         internalAPI.track(eventName, dataFields: nil, onSuccess: { _ in
-            TestUtils.validate(request: networkSession.getRequest(withEndPoint: Const.Path.trackEvent)!, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackEvent, queryParams: [])
-            let body = networkSession.getLastRequestBody()
+            let request = networkSession.getRequest(withEndPoint: Const.Path.trackEvent)!
+            TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackEvent, queryParams: [])
+            let body = request.httpBody!.json() as! [String: Any]
             TestUtils.validateElementPresent(withName: JsonKey.eventName.jsonKey, andValue: eventName, inDictionary: body)
             TestUtils.validateElementPresent(withName: JsonKey.email.jsonKey, andValue: IterableAPITests.email, inDictionary: body)
             expectation.fulfill()
@@ -383,7 +385,9 @@ class IterableAPITests: XCTestCase {
         internalAPI.setDeviceAttribute(name: attributeToAddAndRemove, value: "valueToAdd")
         internalAPI.removeDeviceAttribute(name: attributeToAddAndRemove)
         internalAPI.register(token: token, onSuccess: { _ in
-            let body = networkSession.getLastRequestBody() as! [String: Any]
+            let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
+            let body = request.httpBody!.json() as! [String: Any]
+            
             TestUtils.validateElementPresent(withName: "email", andValue: "user@example.com", inDictionary: body)
             TestUtils.validateMatch(keyPath: KeyPath("device.applicationName"), value: "my-push-integration", inDictionary: body)
             TestUtils.validateMatch(keyPath: KeyPath("device.platform"), value: JsonValue.apnsSandbox.jsonStringValue, inDictionary: body)

--- a/tests/swift-sdk-swift-tests/RegistrationTests.swift
+++ b/tests/swift-sdk-swift-tests/RegistrationTests.swift
@@ -33,7 +33,8 @@ class RegistrationTests: XCTestCase {
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token, onSuccess: { _ in
-            let body = networkSession.getLastRequestBody() as! [String: Any]
+            let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
+            let body = request.httpBody!.json() as! [String: Any]
             TestUtils.validateMatch(keyPath: KeyPath(.email), value: "user@example.com", inDictionary: body)
             TestUtils.validateMatch(keyPath: KeyPath(.device, .applicationName), value: "my-push-integration", inDictionary: body)
             TestUtils.validateMatch(keyPath: KeyPath(.device, .platform), value: JsonValue.apnsProduction.jsonValue as! String, inDictionary: body)
@@ -82,7 +83,8 @@ class RegistrationTests: XCTestCase {
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token, onSuccess: { _ in
-            let body = networkSession.getLastRequestBody() as! [String: Any]
+            let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
+            let body = request.httpBody!.json() as! [String: Any]
             TestUtils.validateMatch(keyPath: KeyPath(.device, .applicationName), value: config.sandboxPushIntegrationName, inDictionary: body)
             TestUtils.validateMatch(keyPath: KeyPath(.device, .platform), value: JsonValue.apnsSandbox.jsonValue as! String, inDictionary: body)
             expectation.fulfill()
@@ -111,7 +113,8 @@ class RegistrationTests: XCTestCase {
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token, onSuccess: { _ in
-            let body = networkSession.getLastRequestBody() as! [String: Any]
+            let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
+            let body = request.httpBody!.json() as! [String: Any]
             TestUtils.validateMatch(keyPath: KeyPath(.device, .applicationName), value: config.sandboxPushIntegrationName, inDictionary: body)
             TestUtils.validateMatch(keyPath: KeyPath(.device, .platform), value: JsonValue.apnsSandbox.jsonValue as! String, inDictionary: body)
             expectation.fulfill()
@@ -140,7 +143,8 @@ class RegistrationTests: XCTestCase {
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token, onSuccess: { _ in
-            let body = networkSession.getLastRequestBody() as! [String: Any]
+            let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
+            let body = request.httpBody!.json() as! [String: Any]
             TestUtils.validateMatch(keyPath: KeyPath(.device, .applicationName), value: config.pushIntegrationName, inDictionary: body)
             TestUtils.validateMatch(keyPath: KeyPath(.device, .platform), value: JsonValue.apnsProduction.jsonValue as! String, inDictionary: body)
             expectation.fulfill()
@@ -167,7 +171,8 @@ class RegistrationTests: XCTestCase {
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token, onSuccess: { _ in
-            let body = networkSession.getLastRequestBody() as! [String: Any]
+            let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
+            let body = request.httpBody!.json() as! [String: Any]
             TestUtils.validateMatch(keyPath: KeyPath(.device, .applicationName), value: TestUtils.appPackageName, inDictionary: body)
             TestUtils.validateMatch(keyPath: KeyPath(.device, .platform), value: JsonValue.apnsSandbox.jsonValue as! String, inDictionary: body)
             expectation.fulfill()
@@ -194,7 +199,8 @@ class RegistrationTests: XCTestCase {
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token, onSuccess: { _ in
-            let body = networkSession.getLastRequestBody() as! [String: Any]
+            let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
+            let body = request.httpBody!.json() as! [String: Any]
             TestUtils.validateMatch(keyPath: KeyPath(.device, .applicationName), value: TestUtils.appPackageName, inDictionary: body)
             TestUtils.validateMatch(keyPath: KeyPath(.device, .platform), value: JsonValue.apnsProduction.jsonValue as! String, inDictionary: body)
             expectation.fulfill()

--- a/tests/swift-sdk-swift-tests/in-app-tests/InAppTests.swift
+++ b/tests/swift-sdk-swift-tests/in-app-tests/InAppTests.swift
@@ -1081,7 +1081,7 @@ class InAppTests: XCTestCase {
                 return
             }
             TestUtils.validate(request: urlRequest, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.inAppConsume)
-            let body = mockNetworkSession.getLastRequestBody() as! [String: Any]
+            let body = urlRequest.httpBody!.json() as! [String: Any]
             TestUtils.validateMessageContext(messageId: "message1", saveToInbox: true, silentInbox: true, location: location, inBody: body)
             if let deleteAction = source {
                 TestUtils.validateMatch(keyPath: KeyPath(.deleteAction), value: deleteAction.jsonValue as! String, inDictionary: body, message: "deleteAction should be nil")


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-2523](https://iterable.atlassian.net/browse/MOB-2523)

## ✏️ Description

> Removed method `getLastRequestBody`. This was using hard coded last request instead of getting the specific request for an endpoint.