### PR TITLE
[MOB-2601] - Memory leak

### DIFF
--- a/swift-sdk/Internal/Promise.swift
+++ b/swift-sdk/Internal/Promise.swift
@@ -150,6 +150,7 @@ extension Future {
 // This class takes the responsibility of setting value for Future
 class Promise<Value, Failure>: Future<Value, Failure> where Failure: Error {
     public init(value: Value? = nil) {
+        ITBInfo()
         super.init()
         if let value = value {
             result = Result.success(value)
@@ -159,8 +160,13 @@ class Promise<Value, Failure>: Future<Value, Failure> where Failure: Error {
     }
     
     public init(error: Failure) {
+        ITBInfo()
         super.init()
         result = Result.failure(error)
+    }
+
+    deinit {
+        ITBInfo()
     }
     
     public func resolve(with value: Value) {

--- a/tests/common/CommonExtensions.swift
+++ b/tests/common/CommonExtensions.swift
@@ -97,6 +97,7 @@ class MockDependencyContainer: DependencyContainerProtocol {
          applicationStateProvider: ApplicationStateProviderProtocol,
          notificationCenter: NotificationCenterProtocol,
          apnsTypeChecker: APNSTypeCheckerProtocol) {
+        ITBInfo()
         self.dateProvider = dateProvider
         self.networkSession = networkSession
         self.notificationStateProvider = notificationStateProvider
@@ -108,6 +109,10 @@ class MockDependencyContainer: DependencyContainerProtocol {
         self.applicationStateProvider = applicationStateProvider
         self.notificationCenter = notificationCenter
         self.apnsTypeChecker = apnsTypeChecker
+    }
+    
+    deinit {
+        ITBInfo()
     }
     
     func createInAppFetcher(apiClient _: ApiClientProtocol) -> InAppFetcherProtocol {

--- a/tests/offline-events-tests/TaskSchedulerTests.swift
+++ b/tests/offline-events-tests/TaskSchedulerTests.swift
@@ -27,9 +27,10 @@ class TaskSchedulerTests: XCTestCase {
         let dataFields = ["var1": "val1", "var2": "val2"]
         
         let notificationCenter = MockNotificationCenter()
-        notificationCenter.addCallback(forNotification: .iterableTaskScheduled) { _ in
+        let reference = notificationCenter.addCallback(forNotification: .iterableTaskScheduled) { _ in
             expectation1.fulfill()
         }
+        XCTAssertNotNil(reference)
         let requestCreator = RequestCreator(apiKey: apiKey, auth: auth, deviceMetadata: deviceMetadata)
         guard case let Result.success(trackEventRequest) = requestCreator.createTrackEventRequest(eventName, dataFields: dataFields) else {
             throw IterableError.general(description: "Could not create trackEvent request")

--- a/tests/swift-sdk-swift-tests/in-app-tests/InAppTests.swift
+++ b/tests/swift-sdk-swift-tests/in-app-tests/InAppTests.swift
@@ -1148,9 +1148,11 @@ class InAppTests: XCTestCase {
         """.toJsonDict()
         
         let mockNotificationCenter = MockNotificationCenter()
-        mockNotificationCenter.addCallback(forNotification: .iterableInboxChanged) { _ in
+        let reference = mockNotificationCenter.addCallback(forNotification: .iterableInboxChanged) { _ in
             expectation1.fulfill()
         }
+        
+        XCTAssertNotNil(reference)
         
         let config = IterableConfig()
         let internalApi = IterableAPIInternal.initializeForTesting(config: config, notificationCenter: mockNotificationCenter)


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-2601](https://iterable.atlassian.net/browse/MOB-2601)

## ✏️ Description

> 
1. Fixed MockNotificationCenter to not hold strong references. 
2. InAppManager, avoid using strong references when using callbacks. 
3. Uncommented failing test in InAppPriorityTests.
