### PR TITLE
[MOB-2614] - Offline mode not initialized when including IterableSDK from a framework bundle.

### DIFF
--- a/swift-sdk/Internal/IterableCoreDataPersistence.swift
+++ b/swift-sdk/Internal/IterableCoreDataPersistence.swift
@@ -24,7 +24,7 @@ enum PersistenceConst {
 @available(iOS 10.0, *)
 class PersistentContainer: NSPersistentContainer {
     static let shared: PersistentContainer? = {
-        guard let url = ResourceHelper.url(forResource: PersistenceConst.dataModelFileName, withExtension: PersistenceConst.dataModelExtension, fromBundle: Bundle(for: PersistentContainer.self)) else {
+        guard let url = ResourceHelper.url(forResource: PersistenceConst.dataModelFileName, withExtension: PersistenceConst.dataModelExtension, fromBundle: Bundle.main) else {
             ITBError("Could not find \(PersistenceConst.dataModelFileName) in bundle")
             return nil
         }

--- a/tests/endpoint-tests/OfflineModeE2ETests.swift
+++ b/tests/endpoint-tests/OfflineModeE2ETests.swift
@@ -116,7 +116,7 @@ class OfflineModeEndpointTests: XCTestCase {
     private static let pushTemplateId = Environment.pushTemplateId!
     private static let inAppCampaignId = Environment.inAppCampaignId!
     private lazy var persistenceContextProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider()!
+        let provider = CoreDataPersistenceContextProvider(fromBundle: Bundle(for: PersistentContainer.self))!
         return provider
     }()
 }

--- a/tests/offline-events-tests/RequestHandlerTests.swift
+++ b/tests/offline-events-tests/RequestHandlerTests.swift
@@ -941,7 +941,8 @@ class RequestHandlerTests: XCTestCase {
     private let dateProvider = MockDateProvider()
     
     private lazy var persistenceContextProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider)!
+        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider,
+                                                          fromBundle: Bundle(for: PersistentContainer.self))!
         return provider
     }()
 }

--- a/tests/offline-events-tests/TaskProcessorTests.swift
+++ b/tests/offline-events-tests/TaskProcessorTests.swift
@@ -255,7 +255,7 @@ class TaskProcessorTests: XCTestCase {
                                                 appPackageName: Bundle.main.appPackageName ?? "")
 
     private lazy var persistenceProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider()!
+        let provider = CoreDataPersistenceContextProvider(fromBundle: Bundle(for: PersistentContainer.self))!
         try! provider.mainQueueContext().deleteAllTasks()
         try! provider.mainQueueContext().save()
         return provider

--- a/tests/offline-events-tests/TaskRunnerTests.swift
+++ b/tests/offline-events-tests/TaskRunnerTests.swift
@@ -334,7 +334,7 @@ class TaskRunnerTests: XCTestCase {
                                                 appPackageName: Bundle.main.appPackageName ?? "")
     
     private lazy var persistenceContextProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider()!
+        let provider = CoreDataPersistenceContextProvider(fromBundle: Bundle(for: PersistentContainer.self))!
         return provider
     }()
 }

--- a/tests/offline-events-tests/TaskSchedulerTests.swift
+++ b/tests/offline-events-tests/TaskSchedulerTests.swift
@@ -59,7 +59,8 @@ class TaskSchedulerTests: XCTestCase {
                                                 appPackageName: Bundle.main.appPackageName ?? "")
 
     private lazy var persistenceContextProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider)!
+        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider,
+                                                          fromBundle: Bundle(for: PersistentContainer.self))!
         return provider
     }()
 

--- a/tests/offline-events-tests/TasksCRUDTests.swift
+++ b/tests/offline-events-tests/TasksCRUDTests.swift
@@ -167,10 +167,10 @@ class TasksCRUDTests: XCTestCase {
     private let dateProvider = MockDateProvider()
     
     private lazy var persistenceProvider: IterablePersistenceContextProvider = {
-        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider)!
+        let provider = CoreDataPersistenceContextProvider(dateProvider: dateProvider,
+                                                          fromBundle: Bundle(for: PersistentContainer.self))!
         try! provider.mainQueueContext().deleteAllTasks()
         try! provider.mainQueueContext().save()
         return provider
     }()
 }
-


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-2614](https://iterable.atlassian.net/browse/MOB-2614)

## ✏️ Description

> If our customer app is using Swift package manager and they are initializing and using our SDK in a separate framework, core data would not be initialized because data model file would not be located. Fixed this by searching for resources from main bundle instead of framework bundle.
