### PR TITLE
[MOB-2626] - Rename IterableAPIInternal => InternalIterableAPI

### DIFF
--- a/swift-sdk.xcodeproj/project.pbxproj
+++ b/swift-sdk.xcodeproj/project.pbxproj
@@ -101,7 +101,7 @@
 		AC72A0C820CF4CE2004D7997 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC72A0BE20CF4CB8004D7997 /* Constants.swift */; };
 		AC72A0C920CF4CE2004D7997 /* IterableAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC72A0BF20CF4CB8004D7997 /* IterableAction.swift */; };
 		AC72A0CA20CF4CE2004D7997 /* IterableActionRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC72A0C420CF4CB8004D7997 /* IterableActionRunner.swift */; };
-		AC72A0CB20CF4CE2004D7997 /* IterableAPIInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC72A0C520CF4CB9004D7997 /* IterableAPIInternal.swift */; };
+		AC72A0CB20CF4CE2004D7997 /* InternalIterableAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC72A0C520CF4CB9004D7997 /* InternalIterableAPI.swift */; };
 		AC72A0CD20CF4CE2004D7997 /* IterableAppIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC72A0C620CF4CB9004D7997 /* IterableAppIntegration.swift */; };
 		AC72A0CE20CF4CE2004D7997 /* IterableAttributionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC72A0C020CF4CB8004D7997 /* IterableAttributionInfo.swift */; };
 		AC72A0D120CF4D0B004D7997 /* InAppHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC72A0AA20CF4BEB004D7997 /* InAppHelper.swift */; };
@@ -456,7 +456,7 @@
 		AC72A0C020CF4CB8004D7997 /* IterableAttributionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterableAttributionInfo.swift; sourceTree = "<group>"; };
 		AC72A0C120CF4CB8004D7997 /* CommerceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommerceItem.swift; sourceTree = "<group>"; };
 		AC72A0C420CF4CB8004D7997 /* IterableActionRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterableActionRunner.swift; sourceTree = "<group>"; };
-		AC72A0C520CF4CB9004D7997 /* IterableAPIInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterableAPIInternal.swift; sourceTree = "<group>"; };
+		AC72A0C520CF4CB9004D7997 /* InternalIterableAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalIterableAPI.swift; sourceTree = "<group>"; };
 		AC72A0C620CF4CB9004D7997 /* IterableAppIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterableAppIntegration.swift; sourceTree = "<group>"; };
 		AC738CE92315A8B200B96B2D /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		AC74FE1E23A8C0DB004AC442 /* image.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = image.jpg; sourceTree = "<group>"; };
@@ -998,7 +998,7 @@
 				55298B222501A5AB00190BAE /* AuthManager.swift */,
 				AC2C667D20D3111900D46CC9 /* DateProvider.swift */,
 				AC72A0C420CF4CB8004D7997 /* IterableActionRunner.swift */,
-				AC72A0C520CF4CB9004D7997 /* IterableAPIInternal.swift */,
+				AC72A0C520CF4CB9004D7997 /* InternalIterableAPI.swift */,
 				AC2C668120D32F2800D46CC9 /* IterableAppIntegrationInternal.swift */,
 				AC72A0BD20CF4C98004D7997 /* IterableDeepLinkManager.swift */,
 				AC2B79F621E6A38900A59080 /* NotificationHelper.swift */,
@@ -1767,7 +1767,7 @@
 				ACC362BA24D20BBB002C67BA /* IterableAPICallRequest.swift in Sources */,
 				AC776DA22118B86600C27C27 /* DeviceInfo.swift in Sources */,
 				55B3119B251015CF0056E4FC /* AuthManager.swift in Sources */,
-				AC72A0CB20CF4CE2004D7997 /* IterableAPIInternal.swift in Sources */,
+				AC72A0CB20CF4CE2004D7997 /* InternalIterableAPI.swift in Sources */,
 				AC72A0C720CF4CE2004D7997 /* CommerceItem.swift in Sources */,
 				AC31B040232AB42100BE25EB /* InboxSessionManager.swift in Sources */,
 				ACE34AB321376B1000691224 /* UserDefaultsLocalStorage.swift in Sources */,

--- a/swift-sdk/Internal/InboxViewControllerViewModel.swift
+++ b/swift-sdk/Internal/InboxViewControllerViewModel.swift
@@ -45,7 +45,7 @@ class InboxViewControllerViewModel: InboxViewControllerViewModelProtocol {
         sectionedMessages = sortAndFilter(messages: allMessagesInSections())
     }
     
-    init(internalAPIProvider: @escaping @autoclosure () -> IterableAPIInternal? = IterableAPI.internalImplementation) {
+    init(internalAPIProvider: @escaping @autoclosure () -> InternalIterableAPI? = IterableAPI.internalImplementation) {
         ITBInfo()
         
         self.internalAPIProvider = internalAPIProvider
@@ -302,7 +302,7 @@ class InboxViewControllerViewModel: InboxViewControllerViewModelProtocol {
         sectionedMessages.values
     }
     
-    private var internalAPI: IterableAPIInternal? {
+    private var internalAPI: InternalIterableAPI? {
         internalAPIProvider()
     }
     
@@ -313,7 +313,7 @@ class InboxViewControllerViewModel: InboxViewControllerViewModelProtocol {
     private var sectionedMessages = SectionedValues<Int, InboxMessageViewModel>()
     private var newSectionedMessages = SectionedValues<Int, InboxMessageViewModel>()
     private var sessionManager = InboxSessionManager()
-    private var internalAPIProvider: () -> IterableAPIInternal?
+    private var internalAPIProvider: () -> InternalIterableAPI?
     
     private var internalInAppManager: IterableInternalInAppManagerProtocol? {
         internalAPI?.inAppManager

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -6,7 +6,7 @@ import Foundation
 import UIKit
 import UserNotifications
 
-final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
+final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
     var apiKey: String
     
     var email: String? {
@@ -684,7 +684,7 @@ final class IterableAPIInternal: NSObject, PushTrackerProtocol, AuthProvider {
 
 // MARK: - DEPRECATED
 
-extension IterableAPIInternal {
+extension InternalIterableAPI {
     // deprecated - will be removed in version 6.3.x or above
     @discardableResult
     func trackInAppOpen(_ messageId: String,

--- a/swift-sdk/Internal/IterableHtmlMessageViewController.swift
+++ b/swift-sdk/Internal/IterableHtmlMessageViewController.swift
@@ -55,7 +55,7 @@ class IterableHtmlMessageViewController: UIViewController {
     weak var presenter: InAppPresenter?
     
     init(parameters: Parameters,
-         internalAPIProvider: @escaping @autoclosure () -> IterableAPIInternal? = IterableAPI.internalImplementation,
+         internalAPIProvider: @escaping @autoclosure () -> InternalIterableAPI? = IterableAPI.internalImplementation,
          webViewProvider: @escaping @autoclosure () -> WebViewProtocol = IterableHtmlMessageViewController.createWebView()) {
         ITBInfo()
         self.internalAPIProvider = internalAPIProvider
@@ -144,7 +144,7 @@ class IterableHtmlMessageViewController: UIViewController {
         ITBInfo()
     }
     
-    private var internalAPIProvider: () -> IterableAPIInternal?
+    private var internalAPIProvider: () -> InternalIterableAPI?
     private var webViewProvider: () -> WebViewProtocol
     private var parameters: Parameters
     private let futureClickedURL: Promise<URL, IterableError>
@@ -153,7 +153,7 @@ class IterableHtmlMessageViewController: UIViewController {
     private var clickedLink: String?
     
     private lazy var webView = webViewProvider()
-    private var internalAPI: IterableAPIInternal? {
+    private var internalAPI: InternalIterableAPI? {
         internalAPIProvider()
     }
     
@@ -296,7 +296,7 @@ extension IterableHtmlMessageViewController: WKNavigationDelegate {
         decisionHandler(.cancel)
     }
 
-    private static func trackClickOnDismiss(internalAPI: IterableAPIInternal?,
+    private static func trackClickOnDismiss(internalAPI: InternalIterableAPI?,
                                             params: Parameters,
                                             futureClickedURL: Promise<URL, IterableError>,
                                             withURL url: URL,

--- a/swift-sdk/Internal/OnlineRequestProcessor.swift
+++ b/swift-sdk/Internal/OnlineRequestProcessor.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// `IterableAPIinternal` will delegate all network related calls to this struct.
+/// `InternalIterableAPI` will delegate all network related calls to this struct.
 struct OnlineRequestProcessor: RequestProcessorProtocol {
     init(apiKey: String,
          authProvider: AuthProvider?,

--- a/swift-sdk/Internal/RequestHandlerProtocol.swift
+++ b/swift-sdk/Internal/RequestHandlerProtocol.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// `IterableAPIinternal` will delegate all network related calls to this protocol.
+/// `InternalIterableAPI` will delegate all network related calls to this protocol.
 protocol RequestHandlerProtocol: class {
     var offlineMode: Bool { get set }
 

--- a/swift-sdk/IterableAPI.swift
+++ b/swift-sdk/IterableAPI.swift
@@ -105,7 +105,7 @@ public final class IterableAPI: NSObject {
                                    apiEndPointOverride: String? = nil,
                                    linksEndPointOverride: String? = nil,
                                    callback: ((Bool) -> Void)? = nil) {
-        internalImplementation = IterableAPIInternal(apiKey: apiKey,
+        internalImplementation = InternalIterableAPI(apiKey: apiKey,
                                                      launchOptions: launchOptions,
                                                      config: config,
                                                      apiEndPointOverride: apiEndPointOverride,
@@ -135,7 +135,7 @@ public final class IterableAPI: NSObject {
         if let internalImplementation = internalImplementation {
             return internalImplementation.handleUniversalLink(url)
         } else {
-            IterableAPIInternal.pendingUniversalLink = url
+            InternalIterableAPI.pendingUniversalLink = url
             return false
         }
     }
@@ -616,7 +616,7 @@ public final class IterableAPI: NSObject {
     
     // MARK: - Private/Internal
     
-    static var internalImplementation: IterableAPIInternal?
+    static var internalImplementation: InternalIterableAPI?
     
     override private init() { super.init() }
 }

--- a/swift-sdk/IterableAppIntegration.swift
+++ b/swift-sdk/IterableAppIntegration.swift
@@ -49,7 +49,7 @@ import UserNotifications
                                                   didReceive: UserNotificationResponse(response: response),
                                                   withCompletionHandler: completionHandler)
         } else {
-            IterableAPIInternal.pendingNotificationResponse = UserNotificationResponse(response: response)
+            InternalIterableAPI.pendingNotificationResponse = UserNotificationResponse(response: response)
         }
     }
     

--- a/tests/common/CommonExtensions.swift
+++ b/tests/common/CommonExtensions.swift
@@ -150,7 +150,7 @@ extension IterableAPI {
                                                               notificationCenter: notificationCenter,
                                                               apnsTypeChecker: apnsTypeChecker)
         
-        internalImplementation = IterableAPIInternal(apiKey: apiKey,
+        internalImplementation = InternalIterableAPI(apiKey: apiKey,
                                                      launchOptions: launchOptions,
                                                      config: config,
                                                      apiEndPointOverride: apiEndPointOverride,
@@ -161,7 +161,7 @@ extension IterableAPI {
     }
 }
 
-extension IterableAPIInternal {
+extension InternalIterableAPI {
     // Internal Only used in unit tests.
     @discardableResult static func initializeForTesting(apiKey: String = "zeeApiKey",
                                                         launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil,
@@ -178,7 +178,7 @@ extension IterableAPIInternal {
                                                         urlOpener: UrlOpenerProtocol = MockUrlOpener(),
                                                         applicationStateProvider: ApplicationStateProviderProtocol = UIApplication.shared,
                                                         notificationCenter: NotificationCenterProtocol = NotificationCenter.default,
-                                                        apnsTypeChecker: APNSTypeCheckerProtocol = APNSTypeChecker()) -> IterableAPIInternal {
+                                                        apnsTypeChecker: APNSTypeCheckerProtocol = APNSTypeChecker()) -> InternalIterableAPI {
         let mockDependencyContainer = MockDependencyContainer(dateProvider: dateProvider,
                                                               networkSession: networkSession,
                                                               notificationStateProvider: notificationStateProvider,
@@ -191,7 +191,7 @@ extension IterableAPIInternal {
                                                               notificationCenter: notificationCenter,
                                                               apnsTypeChecker: apnsTypeChecker)
         
-        let internalImplementation = IterableAPIInternal(apiKey: apiKey,
+        let internalImplementation = InternalIterableAPI(apiKey: apiKey,
                                                          launchOptions: launchOptions,
                                                          config: config,
                                                          apiEndPointOverride: apiEndPointOverride,

--- a/tests/common/CommonMocks.swift
+++ b/tests/common/CommonMocks.swift
@@ -308,7 +308,7 @@ class MockInAppFetcher: InAppFetcherProtocol {
         return Promise(value: messagesMap.values)
     }
     
-    @discardableResult func mockMessagesAvailableFromServer(internalApi: IterableAPIInternal?, messages: [IterableInAppMessage]) -> Future<Int, Error> {
+    @discardableResult func mockMessagesAvailableFromServer(internalApi: InternalIterableAPI?, messages: [IterableInAppMessage]) -> Future<Int, Error> {
         ITBInfo()
         
         messagesMap = OrderedDictionary<String, IterableInAppMessage>()
@@ -327,7 +327,7 @@ class MockInAppFetcher: InAppFetcherProtocol {
         return result
     }
     
-    @discardableResult func mockInAppPayloadFromServer(internalApi: IterableAPIInternal?, _ payload: [AnyHashable: Any]) -> Future<Int, Error> {
+    @discardableResult func mockInAppPayloadFromServer(internalApi: InternalIterableAPI?, _ payload: [AnyHashable: Any]) -> Future<Int, Error> {
         ITBInfo()
         return mockMessagesAvailableFromServer(internalApi: internalApi, messages: InAppTestHelper.inAppMessages(fromPayload: payload))
     }

--- a/tests/endpoint-tests/E2EDependencyContainer.swift
+++ b/tests/endpoint-tests/E2EDependencyContainer.swift
@@ -44,13 +44,13 @@ class E2EDependencyContainer: DependencyContainerProtocol {
     }
 }
 
-extension IterableAPIInternal {
+extension InternalIterableAPI {
     @discardableResult static func initializeForE2E(apiKey: String,
                                                     launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil,
                                                     config: IterableConfig = IterableConfig(),
-                                                    localStorage: LocalStorageProtocol = MockLocalStorage()) -> IterableAPIInternal {
+                                                    localStorage: LocalStorageProtocol = MockLocalStorage()) -> InternalIterableAPI {
         let e2eDependencyContainer = E2EDependencyContainer()
-        let internalImplementation = IterableAPIInternal(apiKey: apiKey,
+        let internalImplementation = InternalIterableAPI(apiKey: apiKey,
                                                          launchOptions: launchOptions,
                                                          config: config,
                                                          dependencyContainer: e2eDependencyContainer)

--- a/tests/endpoint-tests/EndpointTests.swift
+++ b/tests/endpoint-tests/EndpointTests.swift
@@ -9,7 +9,7 @@ import XCTest
 class EndpointTests: XCTestCase {
     func test01UpdateUser() throws {
         let expectation1 = expectation(description: #function)
-        let api = IterableAPIInternal.initializeForTesting(apiKey: EndpointTests.apiKey,
+        let api = InternalIterableAPI.initializeForTesting(apiKey: EndpointTests.apiKey,
                                                            networkSession: URLSession(configuration: .default),
                                                            notificationStateProvider: MockNotificationStateProvider(enabled: true))
         api.email = "user@example.com"
@@ -31,7 +31,7 @@ class EndpointTests: XCTestCase {
         
         let email = "user@example.com"
         let newEmail = IterableUtil.generateUUID() + "@example.com"
-        let api = IterableAPIInternal.initializeForTesting(apiKey: EndpointTests.apiKey,
+        let api = InternalIterableAPI.initializeForTesting(apiKey: EndpointTests.apiKey,
                                                            networkSession: URLSession(configuration: .default),
                                                            notificationStateProvider: MockNotificationStateProvider(enabled: true))
         api.email = email
@@ -49,7 +49,7 @@ class EndpointTests: XCTestCase {
     
     func test03TrackPurchase() throws {
         let expectation1 = expectation(description: #function)
-        let api = IterableAPIInternal.initializeForTesting(apiKey: EndpointTests.apiKey,
+        let api = InternalIterableAPI.initializeForTesting(apiKey: EndpointTests.apiKey,
                                                            networkSession: URLSession(configuration: .default),
                                                            notificationStateProvider: MockNotificationStateProvider(enabled: true))
         api.email = "user@example.com"
@@ -71,7 +71,7 @@ class EndpointTests: XCTestCase {
     
     func test04TrackPushOpen() throws {
         let expectation1 = expectation(description: #function)
-        let api = IterableAPIInternal.initializeForTesting(apiKey: EndpointTests.apiKey,
+        let api = InternalIterableAPI.initializeForTesting(apiKey: EndpointTests.apiKey,
                                                            networkSession: URLSession(configuration: .default),
                                                            notificationStateProvider: MockNotificationStateProvider(enabled: true))
         api.email = "user@example.com"
@@ -92,7 +92,7 @@ class EndpointTests: XCTestCase {
     
     func test05TrackPushOpenWithPushPayload() throws {
         let expectation1 = expectation(description: #function)
-        let api = IterableAPIInternal.initializeForTesting(apiKey: EndpointTests.apiKey,
+        let api = InternalIterableAPI.initializeForTesting(apiKey: EndpointTests.apiKey,
                                                            networkSession: URLSession(configuration: .default),
                                                            notificationStateProvider: MockNotificationStateProvider(enabled: true))
         api.email = "user@example.com"
@@ -118,7 +118,7 @@ class EndpointTests: XCTestCase {
     
     func test06TrackEvent() throws {
         let expectation1 = expectation(description: #function)
-        let api = IterableAPIInternal.initializeForTesting(apiKey: EndpointTests.apiKey,
+        let api = InternalIterableAPI.initializeForTesting(apiKey: EndpointTests.apiKey,
                                                            networkSession: URLSession(configuration: .default),
                                                            notificationStateProvider: MockNotificationStateProvider(enabled: true))
         api.email = "user@example.com"
@@ -136,7 +136,7 @@ class EndpointTests: XCTestCase {
     
     func test07UpdateSubscriptions() throws {
         let expectation1 = expectation(description: #function)
-        let api = IterableAPIInternal.initializeForTesting(apiKey: EndpointTests.apiKey,
+        let api = InternalIterableAPI.initializeForTesting(apiKey: EndpointTests.apiKey,
                                                            networkSession: URLSession(configuration: .default),
                                                            notificationStateProvider: MockNotificationStateProvider(enabled: true))
         api.email = "user@example.com"
@@ -158,7 +158,7 @@ class EndpointTests: XCTestCase {
     
     func test08DisableDeviceForCurrentUserFail() throws {
         let expectation1 = expectation(description: #function)
-        let api = IterableAPIInternal.initializeForTesting(apiKey: EndpointTests.apiKey,
+        let api = InternalIterableAPI.initializeForTesting(apiKey: EndpointTests.apiKey,
                                                            networkSession: URLSession(configuration: .default),
                                                            notificationStateProvider: MockNotificationStateProvider(enabled: true))
         api.email = "user@example.com"
@@ -175,7 +175,7 @@ class EndpointTests: XCTestCase {
     
     func test09DisableDeviceForAllUsersFail() throws {
         let expectation1 = expectation(description: #function)
-        let api = IterableAPIInternal.initializeForTesting(apiKey: EndpointTests.apiKey,
+        let api = InternalIterableAPI.initializeForTesting(apiKey: EndpointTests.apiKey,
                                                            networkSession: URLSession(configuration: .default),
                                                            notificationStateProvider: MockNotificationStateProvider(enabled: true))
         api.email = "user@example.com"
@@ -193,7 +193,7 @@ class EndpointTests: XCTestCase {
     func test10GetInAppMessages() throws {
         let config = IterableConfig()
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
-        let api = IterableAPIInternal.initializeForE2E(apiKey: EndpointTests.apiKey, config: config)
+        let api = InternalIterableAPI.initializeForE2E(apiKey: EndpointTests.apiKey, config: config)
         let email = "user@example.com"
         api.email = email
         
@@ -205,7 +205,7 @@ class EndpointTests: XCTestCase {
     func test11InAppConsume() throws {
         let config = IterableConfig()
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
-        let api = IterableAPIInternal.initializeForE2E(apiKey: EndpointTests.apiKey, config: config)
+        let api = InternalIterableAPI.initializeForE2E(apiKey: EndpointTests.apiKey, config: config)
         let email = "user@example.com"
         api.email = email
         
@@ -248,7 +248,7 @@ class EndpointTests: XCTestCase {
         let expectation1 = expectation(description: #function)
         let config = IterableConfig()
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
-        let api = IterableAPIInternal.initializeForE2E(apiKey: EndpointTests.apiKey, config: config)
+        let api = InternalIterableAPI.initializeForE2E(apiKey: EndpointTests.apiKey, config: config)
         let email = "user@example.com"
         api.email = email
         
@@ -287,10 +287,10 @@ class EndpointTests: XCTestCase {
         clearAllInAppMessages(api: api)
     }
     
-    private func verifyTrackInAppRequest(expectation: XCTestExpectation, method: (IterableAPIInternal, IterableInAppMessage) -> Future<SendRequestValue, SendRequestError>) {
+    private func verifyTrackInAppRequest(expectation: XCTestExpectation, method: (InternalIterableAPI, IterableInAppMessage) -> Future<SendRequestValue, SendRequestError>) {
         let config = IterableConfig()
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
-        let api = IterableAPIInternal.initializeForE2E(apiKey: EndpointTests.apiKey, config: config)
+        let api = InternalIterableAPI.initializeForE2E(apiKey: EndpointTests.apiKey, config: config)
         let email = "user@example.com"
         api.email = email
         
@@ -319,7 +319,7 @@ class EndpointTests: XCTestCase {
     private static let inAppCampaignId = Environment.inAppCampaignId!
     private static let inAppTemplateId = Environment.inAppTemplateId!
     
-    fileprivate func ensureInAppMessages(api: IterableAPIInternal, email: String) {
+    fileprivate func ensureInAppMessages(api: InternalIterableAPI, email: String) {
         IterableAPISupport.sendInApp(to: email, withCampaignId: EndpointTests.inAppCampaignId.intValue).wait()
         
         let predicate = NSPredicate { (_, _) -> Bool in
@@ -331,7 +331,7 @@ class EndpointTests: XCTestCase {
         wait(for: [expectation1], timeout: 60)
     }
     
-    private func clearAllInAppMessages(api: IterableAPIInternal) {
+    private func clearAllInAppMessages(api: InternalIterableAPI) {
         api.apiClient.getInAppMessages(100).flatMap {
             self.chainCallConsume(json: $0, apiClient: api.apiClient)
         }.wait()

--- a/tests/endpoint-tests/OfflineModeE2ETests.swift
+++ b/tests/endpoint-tests/OfflineModeE2ETests.swift
@@ -24,7 +24,7 @@ class OfflineModeEndpointTests: XCTestCase {
         let expectation1 = expectation(description: #function)
         let localStorage = MockLocalStorage()
         localStorage.offlineModeBeta = true
-        let api = IterableAPIInternal.initializeForE2E(apiKey: Self.apiKey,
+        let api = InternalIterableAPI.initializeForE2E(apiKey: Self.apiKey,
                                                        localStorage: localStorage)
         api.email = "user@example.com"
         
@@ -47,7 +47,7 @@ class OfflineModeEndpointTests: XCTestCase {
         let expectation1 = expectation(description: #function)
         let localStorage = MockLocalStorage()
         localStorage.offlineModeBeta = true
-        let api = IterableAPIInternal.initializeForE2E(apiKey: Self.apiKey,
+        let api = InternalIterableAPI.initializeForE2E(apiKey: Self.apiKey,
                                                        localStorage: localStorage)
         api.email = "user@example.com"
         
@@ -69,7 +69,7 @@ class OfflineModeEndpointTests: XCTestCase {
         let expectation1 = expectation(description: #function)
         let localStorage = MockLocalStorage()
         localStorage.offlineModeBeta = true
-        let api = IterableAPIInternal.initializeForE2E(apiKey: Self.apiKey,
+        let api = InternalIterableAPI.initializeForE2E(apiKey: Self.apiKey,
                                                        localStorage: localStorage)
         api.email = "user@example.com"
         
@@ -96,7 +96,7 @@ class OfflineModeEndpointTests: XCTestCase {
         let expectation1 = expectation(description: #function)
         let localStorage = MockLocalStorage()
         localStorage.offlineModeBeta = true
-        let api = IterableAPIInternal.initializeForE2E(apiKey: Self.apiKey,
+        let api = InternalIterableAPI.initializeForE2E(apiKey: Self.apiKey,
                                                        localStorage: localStorage)
         api.email = "user@example.com"
         

--- a/tests/offline-events-tests/RequestHandlerTests.swift
+++ b/tests/offline-events-tests/RequestHandlerTests.swift
@@ -598,7 +598,7 @@ class RequestHandlerTests: XCTestCase {
     func testDeleteAllTasksOnLogout() throws {
         let localStorage = MockLocalStorage()
         localStorage.offlineModeBeta = true
-        let internalApi = IterableAPIInternal.initializeForTesting(networkSession: MockNetworkSession(),
+        let internalApi = InternalIterableAPI.initializeForTesting(networkSession: MockNetworkSession(),
                                                                    localStorage: localStorage)
         internalApi.email = "user@example.com"
         

--- a/tests/offline-events-tests/TaskProcessorTests.swift
+++ b/tests/offline-events-tests/TaskProcessorTests.swift
@@ -17,7 +17,7 @@ class TaskProcessorTests: XCTestCase {
         let auth = Auth(userId: nil, email: email, authToken: nil)
         let config = IterableConfig()
         let networkSession = MockNetworkSession()
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession)
         
         let requestCreator = RequestCreator(apiKey: apiKey,
                                             auth: auth,

--- a/tests/swift-sdk-swift-tests/AuthTests.swift
+++ b/tests/swift-sdk-swift-tests/AuthTests.swift
@@ -17,7 +17,7 @@ class AuthTests: XCTestCase {
     }
     
     func testEmailPersistence() {
-        let internalAPI = IterableAPIInternal.initializeForTesting()
+        let internalAPI = InternalIterableAPI.initializeForTesting()
         
         internalAPI.email = AuthTests.email
         
@@ -27,7 +27,7 @@ class AuthTests: XCTestCase {
     }
     
     func testUserIdPersistence() {
-        let internalAPI = IterableAPIInternal.initializeForTesting()
+        let internalAPI = InternalIterableAPI.initializeForTesting()
         
         internalAPI.userId = AuthTests.userId
         
@@ -46,7 +46,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config)
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config)
         
         internalAPI.email = "previous.user@example.com"
         
@@ -67,7 +67,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config)
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config)
         
         internalAPI.userId = "previousUserId"
         
@@ -79,7 +79,7 @@ class AuthTests: XCTestCase {
     }
     
     func testUserLoginAndLogout() {
-        let internalAPI = IterableAPIInternal.initializeForTesting()
+        let internalAPI = InternalIterableAPI.initializeForTesting()
         
         internalAPI.setEmail(AuthTests.email)
         
@@ -95,7 +95,7 @@ class AuthTests: XCTestCase {
     }
     
     func testNewEmailWithTokenChange() {
-        var internalAPI: IterableAPIInternal?
+        var internalAPI: InternalIterableAPI?
         
         let originalEmail = "first@example.com"
         let originalToken = "fdsa"
@@ -111,7 +111,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        internalAPI = IterableAPIInternal.initializeForTesting(config: config)
+        internalAPI = InternalIterableAPI.initializeForTesting(config: config)
         
         guard let API = internalAPI else {
             XCTFail()
@@ -132,7 +132,7 @@ class AuthTests: XCTestCase {
     }
     
     func testNewUserIdWithTokenChange() {
-        var internalAPI: IterableAPIInternal?
+        var internalAPI: InternalIterableAPI?
         
         let originalUserId = "firstUserId"
         let originalToken = "nen"
@@ -148,7 +148,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        internalAPI = IterableAPIInternal.initializeForTesting(config: config)
+        internalAPI = InternalIterableAPI.initializeForTesting(config: config)
         
         guard let API = internalAPI else {
             XCTFail()
@@ -171,7 +171,7 @@ class AuthTests: XCTestCase {
     func testUpdateEmailWithToken() {
         let condition1 = expectation(description: "update email with auth token")
         
-        var internalAPI: IterableAPIInternal?
+        var internalAPI: InternalIterableAPI?
         
         let originalEmail = "first@example.com"
         let originalToken = "fdsa"
@@ -187,7 +187,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        internalAPI = IterableAPIInternal.initializeForTesting(config: config)
+        internalAPI = InternalIterableAPI.initializeForTesting(config: config)
         
         guard let API = internalAPI else {
             XCTFail()
@@ -220,7 +220,7 @@ class AuthTests: XCTestCase {
         
         let localStorage = MockLocalStorage()
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config,
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config,
                                                                    localStorage: localStorage)
         
         XCTAssertNil(localStorage.email)
@@ -251,7 +251,7 @@ class AuthTests: XCTestCase {
     func testAuthTokenChangeWithSameEmail() {
         var authTokenChanged = false
         
-        var internalAPI: IterableAPIInternal?
+        var internalAPI: InternalIterableAPI?
         
         let newAuthToken = AuthTests.authToken + "3984ru398gj893"
         
@@ -267,7 +267,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        internalAPI = IterableAPIInternal.initializeForTesting(config: config)
+        internalAPI = InternalIterableAPI.initializeForTesting(config: config)
         
         guard let API = internalAPI else {
             XCTFail()
@@ -289,7 +289,7 @@ class AuthTests: XCTestCase {
     func testAuthTokenChangeWithSameUserId() {
         var authTokenChanged = false
         
-        var internalAPI: IterableAPIInternal?
+        var internalAPI: InternalIterableAPI?
         
         let newAuthToken = AuthTests.authToken + "3984ru398gj893"
         
@@ -305,7 +305,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        internalAPI = IterableAPIInternal.initializeForTesting(config: config)
+        internalAPI = InternalIterableAPI.initializeForTesting(config: config)
         
         guard let API = internalAPI else {
             XCTFail()
@@ -340,7 +340,7 @@ class AuthTests: XCTestCase {
         let mockNetworkSession = MockNetworkSession(statusCode: 401,
                                                     json: [JsonKey.Response.iterableCode: JsonValue.Code.invalidJwtPayload])
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config,
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config,
                                                                    networkSession: mockNetworkSession)
         
         internalAPI.email = AuthTests.email
@@ -436,7 +436,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config)
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config)
         
         internalAPI.setEmail(AuthTests.email)
         
@@ -456,7 +456,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config)
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config)
         
         internalAPI.setUserId(AuthTests.userId)
         
@@ -473,7 +473,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config)
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config)
         
         internalAPI.email = AuthTests.email
         
@@ -499,7 +499,7 @@ class AuthTests: XCTestCase {
         let mockNetworkSession = MockNetworkSession(statusCode: 401,
                                                     json: [JsonKey.Response.iterableCode: JsonValue.Code.invalidJwtPayload])
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config,
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config,
                                                                    networkSession: mockNetworkSession)
         
         internalAPI.email = AuthTests.email
@@ -581,7 +581,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config,
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config,
                                                                    notificationStateProvider: mockNotificationStateProvider)
         
         internalAPI.email = AuthTests.email
@@ -635,7 +635,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config)
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config)
         
         // setEmail calls gets the new auth token successfully
         internalAPI.email = AuthTests.email
@@ -715,7 +715,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config,
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config,
                                                                    localStorage: localStorage)
         
         XCTAssertNotNil(internalAPI.email)
@@ -740,7 +740,7 @@ class AuthTests: XCTestCase {
         let config = IterableConfig()
         config.authDelegate = authDelegate
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config,
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config,
                                                                    localStorage: localStorage)
         
         XCTAssertNotNil(internalAPI.email)

--- a/tests/swift-sdk-swift-tests/DeprecatedFunctionsTests.swift
+++ b/tests/swift-sdk-swift-tests/DeprecatedFunctionsTests.swift
@@ -21,7 +21,7 @@ class DeprecatedFunctionsTests: XCTestCase {
         let expectation1 = expectation(description: "track in app open (DEPRECATED VERSION)")
         
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: apiKey, networkSession: networkSession)
         internalAPI.email = email
         
         networkSession.callback = { _, response, _ in
@@ -68,7 +68,7 @@ class DeprecatedFunctionsTests: XCTestCase {
         let expectation1 = expectation(description: "track in app click (DEPRECATED VERSION)")
         
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: apiKey, networkSession: networkSession)
         internalAPI.userId = userId
         
         networkSession.callback = { _, response, _ in

--- a/tests/swift-sdk-swift-tests/IterableAPIResponseTests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPIResponseTests.swift
@@ -202,7 +202,7 @@ class IterableAPIResponseTests: XCTestCase {
                   authProvider: self,
                   endPoint: Endpoint.api,
                   networkSession: networkSession,
-                  deviceMetadata: IterableAPIInternal.initializeForTesting().deviceMetadata,
+                  deviceMetadata: InternalIterableAPI.initializeForTesting().deviceMetadata,
                   dateProvider: dateProvider)
     }
     
@@ -211,7 +211,7 @@ class IterableAPIResponseTests: XCTestCase {
                   authProvider: self,
                   endPoint: Endpoint.api,
                   networkSession: MockNetworkSession(),
-                  deviceMetadata: IterableAPIInternal.initializeForTesting().deviceMetadata,
+                  deviceMetadata: InternalIterableAPI.initializeForTesting().deviceMetadata,
                   dateProvider: dateProvider)
     }
 }

--- a/tests/swift-sdk-swift-tests/IterableAPITests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPITests.swift
@@ -17,7 +17,7 @@ class IterableAPITests: XCTestCase {
     }
     
     func testInitialize() {
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey)
         
         XCTAssertEqual(internalAPI.apiKey, IterableAPITests.apiKey)
     }
@@ -29,7 +29,7 @@ class IterableAPITests: XCTestCase {
         config.pushIntegrationName = prodIntegrationName
         config.inAppDisplayInterval = 1.0
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config)
         
         XCTAssertEqual(internalAPI.apiKey, IterableAPITests.apiKey)
     }
@@ -51,7 +51,7 @@ class IterableAPITests: XCTestCase {
         
         let config = IterableConfig()
         config.checkForDeferredDeeplink = true
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: mockNetworkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: mockNetworkSession)
         internalAPI.email = IterableAPITests.email
         internalAPI.track("Some Event")
         
@@ -80,7 +80,7 @@ class IterableAPITests: XCTestCase {
         
         let config = IterableConfig()
         config.checkForDeferredDeeplink = true
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey,
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey,
                                                                    config: config,
                                                                    apiEndPointOverride: newApiEndpoint,
                                                                    linksEndPointOverride: newLinksEndpoint,
@@ -96,7 +96,7 @@ class IterableAPITests: XCTestCase {
     func testTrackEventWithNoEmailOrUser() {
         let eventName = "MyCustomEvent"
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
         internalAPI.email = nil
         internalAPI.userId = nil
         internalAPI.track(eventName)
@@ -108,7 +108,7 @@ class IterableAPITests: XCTestCase {
         
         let eventName = "MyCustomEvent"
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
         internalAPI.email = IterableAPITests.email
 
         internalAPI.track(eventName, dataFields: nil, onSuccess: { _ in
@@ -135,7 +135,7 @@ class IterableAPITests: XCTestCase {
         let expectation = XCTestExpectation(description: "testTrackEventWithEmail using no callback")
         let eventName = "MyCustomEvent"
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
         internalAPI.email = IterableAPITests.email
         internalAPI.track(eventName, dataFields: ["key1": "value1", "key2": "value2"])
         
@@ -160,7 +160,7 @@ class IterableAPITests: XCTestCase {
         
         let eventName = "MyCustomEvent"
         let networkSession = MockNetworkSession(statusCode: 502)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
         internalAPI.email = "user@example.com"
         internalAPI.track(
             eventName,
@@ -177,7 +177,7 @@ class IterableAPITests: XCTestCase {
     }
     
     func testEmailPersistence() {
-        let internalAPI = IterableAPIInternal.initializeForTesting()
+        let internalAPI = InternalIterableAPI.initializeForTesting()
         
         internalAPI.email = IterableAPITests.email
         XCTAssertEqual(internalAPI.email, IterableAPITests.email)
@@ -185,7 +185,7 @@ class IterableAPITests: XCTestCase {
     }
     
     func testUserIdPersistence() {
-        let internalAPI = IterableAPIInternal.initializeForTesting()
+        let internalAPI = InternalIterableAPI.initializeForTesting()
         
         internalAPI.userId = IterableAPITests.userId
         XCTAssertEqual(internalAPI.userId, IterableAPITests.userId)
@@ -196,7 +196,7 @@ class IterableAPITests: XCTestCase {
         let expectation = XCTestExpectation(description: "testUpdateUserWithEmail")
         
         let networkSession = MockNetworkSession()
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
         internalAPI.email = IterableAPITests.email
         let dataFields: [String: String] = ["var1": "val1", "var2": "val2"]
         internalAPI.updateUser(dataFields, mergeNestedObjects: true, onSuccess: { _ in
@@ -228,7 +228,7 @@ class IterableAPITests: XCTestCase {
         
         let userId = UUID().uuidString
         let networkSession = MockNetworkSession()
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
         internalAPI.userId = userId
         let dataFields: [String: String] = ["var1": "val1", "var2": "val2"]
         internalAPI.updateUser(dataFields, mergeNestedObjects: true, onSuccess: { _ in
@@ -261,7 +261,7 @@ class IterableAPITests: XCTestCase {
         
         let newEmail = "new_user@example.com"
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
         internalAPI.email = IterableAPITests.email
         internalAPI.updateEmail(newEmail,
                                 onSuccess: { _ in
@@ -299,7 +299,7 @@ class IterableAPITests: XCTestCase {
         let currentUserId = IterableUtil.generateUUID()
         let newEmail = "new_user@example.com"
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
         internalAPI.userId = currentUserId
         internalAPI.updateEmail(newEmail,
                                 onSuccess: { _ in
@@ -339,7 +339,7 @@ class IterableAPITests: XCTestCase {
         config.pushIntegrationName = nil
         config.sandboxPushIntegrationName = nil
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey,
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey,
                                                                    config: config,
                                                                    networkSession: MockNetworkSession(statusCode: 200))
         
@@ -358,7 +358,7 @@ class IterableAPITests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushIntegrationName = "my-push-integration"
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
         internalAPI.email = nil
         internalAPI.userId = nil
         
@@ -377,7 +377,7 @@ class IterableAPITests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushIntegrationName = "my-push-integration"
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.setDeviceAttribute(name: "reactNativeSDKVersion", value: "x.xx.xxx")
@@ -425,7 +425,7 @@ class IterableAPITests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushIntegrationName = "my-push-integration"
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
         internalAPI.email = "user@example.com"
         
         internalAPI.disableDeviceForCurrentUser(withOnSuccess: { _ in
@@ -444,7 +444,7 @@ class IterableAPITests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushIntegrationName = "my-push-integration"
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token)
@@ -484,7 +484,7 @@ class IterableAPITests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushIntegrationName = "my-push-integration"
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token)
@@ -519,7 +519,7 @@ class IterableAPITests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushIntegrationName = "my-push-integration"
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         
@@ -560,7 +560,7 @@ class IterableAPITests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushIntegrationName = "my-push-integration"
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         networkSession.callback = { _, _, _ in
@@ -597,7 +597,7 @@ class IterableAPITests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushIntegrationName = "my-push-integration"
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
         
         internalAPI.trackPurchase(10.0, items: [], dataFields: nil, onSuccess: { _ in
             // no userid or email should fail
@@ -616,7 +616,7 @@ class IterableAPITests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushIntegrationName = "my-push-integration"
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
         internalAPI.userId = "zeeUserId"
         
         internalAPI.trackPurchase(10.55, items: [], dataFields: nil, onSuccess: { _ in
@@ -654,7 +654,7 @@ class IterableAPITests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushIntegrationName = "my-push-integration"
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
         internalAPI.email = "user@example.com"
         let total = NSNumber(value: 15.32)
         let items = [CommerceItem(id: "id1", name: "myCommerceItem", price: 5.0, quantity: 2)]
@@ -700,7 +700,7 @@ class IterableAPITests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushIntegrationName = "my-push-integration"
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
         internalAPI.email = "user@example.com"
         let total = NSNumber(value: 15.32)
         let items = [CommerceItem(id: "id1", name: "myCommerceItem", price: 5.0, quantity: 2)]
@@ -735,7 +735,7 @@ class IterableAPITests: XCTestCase {
         let config = IterableConfig()
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config, inAppFetcher: mockInAppFetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config, inAppFetcher: mockInAppFetcher)
         internalAPI.email = "user@example.com"
         
         let inAppMsg1 = IterableInAppMessage(messageId: "aswefwdf",
@@ -768,7 +768,7 @@ class IterableAPITests: XCTestCase {
         
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, config: config, networkSession: networkSession)
         internalAPI.email = "user@example.com"
         networkSession.callback = { _, response, _ in
             guard let (request, body) = TestUtils.matchingRequest(networkSession: networkSession,
@@ -803,7 +803,7 @@ class IterableAPITests: XCTestCase {
         let expectation1 = expectation(description: "testTrackInAppConsumeWithSource")
         
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey, networkSession: networkSession)
         internalAPI.email = IterableAPITests.email
         
         networkSession.callback = { _, response, _ in
@@ -870,7 +870,7 @@ class IterableAPITests: XCTestCase {
         let config = IterableConfig()
         let localStorage = MockLocalStorage()
         localStorage.email = "user1@example.com"
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey,
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey,
                                                                    config: config,
                                                                    networkSession: networkSession,
                                                                    localStorage: localStorage)
@@ -904,7 +904,7 @@ class IterableAPITests: XCTestCase {
         }
         let config = IterableConfig()
         config.customActionDelegate = customActionDelegate
-        IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey,
+        InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey,
                                                  launchOptions: launchOptions,
                                                  config: config)
         
@@ -933,7 +933,7 @@ class IterableAPITests: XCTestCase {
         }
         let config = IterableConfig()
         config.urlDelegate = urlDelegate
-        IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey,
+        InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey,
                                                  launchOptions: launchOptions,
                                                  config: config)
         
@@ -958,7 +958,7 @@ class IterableAPITests: XCTestCase {
         
         let networkSession = MockNetworkSession(statusCode: 200)
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey,
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey,
                                                                    networkSession: networkSession)
         networkSession.callback = { _, response, _ in
             guard let (request, body) = TestUtils.matchingRequest(networkSession: networkSession,
@@ -991,7 +991,7 @@ class IterableAPITests: XCTestCase {
         
         let networkSession = MockNetworkSession(statusCode: 200)
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey,
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey,
                                                                    networkSession: networkSession)
         networkSession.callback = { _, response, _ in
             guard let (request, body) = TestUtils.matchingRequest(networkSession: networkSession,
@@ -1026,7 +1026,7 @@ class IterableAPITests: XCTestCase {
         
         let networkSession = MockNetworkSession(statusCode: 200)
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey,
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey,
                                                                    networkSession: networkSession)
         internalAPI.trackPushOpen(userInfo, dataFields: ["key1": "value1"], onSuccess: { _ in
             guard let request = networkSession.getRequest(withEndPoint: Const.Path.trackEvent) else {
@@ -1053,7 +1053,7 @@ class IterableAPITests: XCTestCase {
         
         let networkSession = MockNetworkSession(statusCode: 200)
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey,
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey,
                                                                    networkSession: networkSession)
         networkSession.callback = { _, response, _ in
             guard let (request, body) = TestUtils.matchingRequest(networkSession: networkSession,
@@ -1080,7 +1080,7 @@ class IterableAPITests: XCTestCase {
         
         let networkSession = MockNetworkSession(statusCode: 200)
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAPITests.apiKey,
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey,
                                                                    networkSession: networkSession)
         internalAPI.trackPushOpen(1234,
                                   templateId: 4321,

--- a/tests/swift-sdk-swift-tests/IterableAutoRegistrationTests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAutoRegistrationTests.swift
@@ -53,7 +53,7 @@ class IterableAutoRegistrationTests: XCTestCase {
         
         let notificationStateProvider = MockNotificationStateProvider(enabled: false, expectation: expectation2)
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAutoRegistrationTests.apiKey,
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAutoRegistrationTests.apiKey,
                                                                    config: config,
                                                                    networkSession: networkSession,
                                                                    notificationStateProvider: notificationStateProvider)
@@ -94,7 +94,7 @@ class IterableAutoRegistrationTests: XCTestCase {
         // notifications are enabled
         let notificationStateProvider = MockNotificationStateProvider(enabled: true, expectation: expectation1)
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAutoRegistrationTests.apiKey,
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAutoRegistrationTests.apiKey,
                                                                    config: config, networkSession: networkSession,
                                                                    notificationStateProvider: notificationStateProvider)
         let email = "user1@example.com"
@@ -136,7 +136,7 @@ class IterableAutoRegistrationTests: XCTestCase {
         config.autoPushRegistration = false
         let notificationStateProvider = MockNotificationStateProvider(enabled: true, expectation: expectation1)
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: IterableAutoRegistrationTests.apiKey,
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: IterableAutoRegistrationTests.apiKey,
                                                                    config: config,
                                                                    networkSession: networkSession,
                                                                    notificationStateProvider: notificationStateProvider)
@@ -159,7 +159,7 @@ class IterableAutoRegistrationTests: XCTestCase {
         
         let localStorage = MockLocalStorage()
         localStorage.email = "user1@example.com"
-        IterableAPIInternal.initializeForTesting(apiKey: IterableAutoRegistrationTests.apiKey,
+        InternalIterableAPI.initializeForTesting(apiKey: IterableAutoRegistrationTests.apiKey,
                                                  config: config,
                                                  networkSession: networkSession,
                                                  notificationStateProvider: notificationStateProvider,

--- a/tests/swift-sdk-swift-tests/IterableNotificationResponseTests.swift
+++ b/tests/swift-sdk-swift-tests/IterableNotificationResponseTests.swift
@@ -169,7 +169,7 @@ class IterableNotificationResponseTests: XCTestCase {
         
         // call track push open
         let mockDateProvider = MockDateProvider()
-        let internalAPI = IterableAPIInternal.initializeForTesting(dateProvider: mockDateProvider)
+        let internalAPI = InternalIterableAPI.initializeForTesting(dateProvider: mockDateProvider)
         internalAPI.trackPushOpen(userInfo)
         
         // check the push payload for messageId
@@ -205,7 +205,7 @@ class IterableNotificationResponseTests: XCTestCase {
         
         // call track push open
         let mockDateProvider = MockDateProvider()
-        let internalAPI = IterableAPIInternal.initializeForTesting(dateProvider: mockDateProvider)
+        let internalAPI = InternalIterableAPI.initializeForTesting(dateProvider: mockDateProvider)
         internalAPI.trackPushOpen(userInfo)
         
         // check attribution info

--- a/tests/swift-sdk-swift-tests/RegistrationTests.swift
+++ b/tests/swift-sdk-swift-tests/RegistrationTests.swift
@@ -26,7 +26,7 @@ class RegistrationTests: XCTestCase {
         config.pushIntegrationName = "my-push-integration"
         config.sandboxPushIntegrationName = "my-sandbox-push-integration"
         config.pushPlatform = .production
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: apiKey,
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: apiKey,
                                                                    config: config,
                                                                    networkSession: networkSession,
                                                                    notificationStateProvider: MockNotificationStateProvider(enabled: true))
@@ -79,7 +79,7 @@ class RegistrationTests: XCTestCase {
         config.pushIntegrationName = "my-push-integration"
         config.sandboxPushIntegrationName = "my-sandbox-push-integration"
         config.pushPlatform = .sandbox
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession)
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token, onSuccess: { _ in
@@ -109,7 +109,7 @@ class RegistrationTests: XCTestCase {
         config.pushIntegrationName = "my-push-integration"
         config.sandboxPushIntegrationName = "my-sandbox-push-integration"
         config.pushPlatform = .auto
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession, apnsTypeChecker: MockAPNSTypeChecker(apnsType: .sandbox))
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession, apnsTypeChecker: MockAPNSTypeChecker(apnsType: .sandbox))
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token, onSuccess: { _ in
@@ -139,7 +139,7 @@ class RegistrationTests: XCTestCase {
         config.pushIntegrationName = "my-push-integration"
         config.sandboxPushIntegrationName = "my-sandbox-push-integration"
         config.pushPlatform = .auto
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession, apnsTypeChecker: MockAPNSTypeChecker(apnsType: .production))
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession, apnsTypeChecker: MockAPNSTypeChecker(apnsType: .production))
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token, onSuccess: { _ in
@@ -167,7 +167,7 @@ class RegistrationTests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushPlatform = .auto
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession)
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token, onSuccess: { _ in
@@ -195,7 +195,7 @@ class RegistrationTests: XCTestCase {
         let networkSession = MockNetworkSession(statusCode: 200)
         let config = IterableConfig()
         config.pushPlatform = .auto
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession, apnsTypeChecker: MockAPNSTypeChecker(apnsType: .production))
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession, apnsTypeChecker: MockAPNSTypeChecker(apnsType: .production))
         internalAPI.email = "user@example.com"
         let token = "zeeToken".data(using: .utf8)!
         internalAPI.register(token: token, onSuccess: { _ in

--- a/tests/swift-sdk-swift-tests/deep-linking-tests/DeepLinkTests.swift
+++ b/tests/swift-sdk-swift-tests/deep-linking-tests/DeepLinkTests.swift
@@ -32,7 +32,7 @@ class DeepLinkTests: XCTestCase {
         
         setupRedirectStubResponse(location: redirectLocation, campaignId: campaignId, templateId: templateId, messageId: messageId)
         
-        let internalAPI = IterableAPIInternal.initializeForTesting()
+        let internalAPI = InternalIterableAPI.initializeForTesting()
         
         internalAPI.getAndTrack(deepLink: URL(string: iterableRewriteURL)!) { redirectUrl in
             XCTAssertEqual(redirectUrl, redirectLocation)
@@ -48,7 +48,7 @@ class DeepLinkTests: XCTestCase {
         
         setupStubResponse()
         
-        let internalAPI = IterableAPIInternal.initializeForTesting()
+        let internalAPI = InternalIterableAPI.initializeForTesting()
         internalAPI.getAndTrack(deepLink: URL(string: iterableNoRewriteURL)!) { redirectUrl in
             XCTAssertEqual(redirectUrl, self.iterableNoRewriteURL)
             XCTAssertTrue(Thread.isMainThread)
@@ -77,7 +77,7 @@ class DeepLinkTests: XCTestCase {
         
         let config = IterableConfig()
         config.urlDelegate = mockUrlDelegate
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config)
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config)
         
         internalAPI.handleUniversalLink(URL(string: iterableRewriteURL)!)
         
@@ -94,7 +94,7 @@ class DeepLinkTests: XCTestCase {
         
         setupRedirectStubResponse(location: redirectLocation, campaignId: campaignId, templateId: templateId, messageId: messageId)
         
-        let internalAPI = IterableAPIInternal.initializeForTesting()
+        let internalAPI = InternalIterableAPI.initializeForTesting()
         internalAPI.getAndTrack(deepLink: URL(string: iterableRewriteURL)!) { resolvedURL in
             XCTAssertEqual(resolvedURL, redirectLocation)
         }?.onSuccess(block: { _ in
@@ -117,7 +117,7 @@ class DeepLinkTests: XCTestCase {
         
         setupRedirectStubResponse(location: redirectLocation, campaignId: campaignId, templateId: templateId, messageId: messageId)
         
-        let internalAPI = IterableAPIInternal.initializeForTesting()
+        let internalAPI = InternalIterableAPI.initializeForTesting()
         internalAPI.handleUniversalLink(URL(string: iterableRewriteURL)!)
         internalAPI.attributionInfo = nil
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -137,7 +137,7 @@ class DeepLinkTests: XCTestCase {
         
         setupStubResponse()
         
-        let internalAPI = IterableAPIInternal.initializeForTesting()
+        let internalAPI = InternalIterableAPI.initializeForTesting()
         internalAPI.getAndTrack(deepLink: URL(string: redirectRequest)!) { redirectUrl in
             XCTAssertNotEqual(redirectUrl, self.exampleUrl)
             XCTAssertEqual(redirectUrl, self.redirectRequest)

--- a/tests/swift-sdk-swift-tests/deep-linking-tests/DeferredDeepLinkTests.swift
+++ b/tests/swift-sdk-swift-tests/deep-linking-tests/DeferredDeepLinkTests.swift
@@ -40,7 +40,7 @@ class DeferredDeepLinkTests: XCTestCase {
         
         config.urlDelegate = urlDelegate
         let localStorage = MockLocalStorage()
-        IterableAPIInternal.initializeForTesting(apiKey: DeferredDeepLinkTests.apiKey,
+        InternalIterableAPI.initializeForTesting(apiKey: DeferredDeepLinkTests.apiKey,
                                                  config: config,
                                                  networkSession: networkSession,
                                                  localStorage: localStorage)
@@ -57,7 +57,7 @@ class DeferredDeepLinkTests: XCTestCase {
             expectation2.fulfill()
         }
         config2.urlDelegate = urlDelegate2
-        IterableAPIInternal.initializeForTesting(apiKey: DeferredDeepLinkTests.apiKey,
+        InternalIterableAPI.initializeForTesting(apiKey: DeferredDeepLinkTests.apiKey,
                                                  config: config2,
                                                  networkSession: networkSession,
                                                  localStorage: localStorage)
@@ -81,7 +81,7 @@ class DeferredDeepLinkTests: XCTestCase {
             expectation.fulfill()
         }
         config.urlDelegate = urlDelegate
-        IterableAPIInternal.initializeForTesting(apiKey: DeferredDeepLinkTests.apiKey, config: config, networkSession: networkSession)
+        InternalIterableAPI.initializeForTesting(apiKey: DeferredDeepLinkTests.apiKey, config: config, networkSession: networkSession)
         
         wait(for: [expectation], timeout: 1.0)
     }
@@ -106,7 +106,7 @@ class DeferredDeepLinkTests: XCTestCase {
             expectation.fulfill()
         }
         config.urlDelegate = urlDelegate
-        IterableAPIInternal.initializeForTesting(apiKey: DeferredDeepLinkTests.apiKey, config: config, networkSession: networkSession)
+        InternalIterableAPI.initializeForTesting(apiKey: DeferredDeepLinkTests.apiKey, config: config, networkSession: networkSession)
         
         wait(for: [expectation], timeout: 1.0)
     }

--- a/tests/swift-sdk-swift-tests/foundational-tests/LoggingTests.swift
+++ b/tests/swift-sdk-swift-tests/foundational-tests/LoggingTests.swift
@@ -38,7 +38,7 @@ class LoggingTests: XCTestCase {
         }
         let config = IterableConfig()
         config.logDelegate = logDelegate
-        IterableAPIInternal.initializeForTesting(apiKey: "apiKey", config: config)
+        InternalIterableAPI.initializeForTesting(apiKey: "apiKey", config: config)
         
         ITBDebug(debugMessage)
         

--- a/tests/swift-sdk-swift-tests/in-app-tests/InAppFilePersistenceTests.swift
+++ b/tests/swift-sdk-swift-tests/in-app-tests/InAppFilePersistenceTests.swift
@@ -177,7 +177,7 @@ class InAppFilePersistenceTests: XCTestCase {
         let config = IterableConfig()
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
         
-        let internalApi1 = IterableAPIInternal.initializeForTesting(
+        let internalApi1 = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppPersister: InAppFilePersister()
@@ -194,7 +194,7 @@ class InAppFilePersistenceTests: XCTestCase {
         
         wait(for: [expectation1], timeout: testExpectationTimeout)
         
-        let internalApi2 = IterableAPIInternal.initializeForTesting(
+        let internalApi2 = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppPersister: InAppFilePersister()

--- a/tests/swift-sdk-swift-tests/in-app-tests/InAppParsingTests.swift
+++ b/tests/swift-sdk-swift-tests/in-app-tests/InAppParsingTests.swift
@@ -313,7 +313,7 @@ class InAppParsingTests: XCTestCase {
         let expectation1 = expectation(description: "track in app click")
         
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: InAppParsingTests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: InAppParsingTests.apiKey, networkSession: networkSession)
         internalAPI.userId = InAppParsingTests.userId
         networkSession.callback = { _, response, _ in
             guard let (request, body) = TestUtils.matchingRequest(networkSession: networkSession,
@@ -348,7 +348,7 @@ class InAppParsingTests: XCTestCase {
         let expectation1 = expectation(description: "track in app open")
         
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: InAppParsingTests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: InAppParsingTests.apiKey, networkSession: networkSession)
         internalAPI.email = InAppParsingTests.email
         networkSession.callback = { _, response, _ in
             guard let (request, body) = TestUtils.matchingRequest(networkSession: networkSession,
@@ -374,7 +374,7 @@ class InAppParsingTests: XCTestCase {
         let expectation1 = expectation(description: "track inAppClose event")
         
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: InAppParsingTests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: InAppParsingTests.apiKey, networkSession: networkSession)
         internalAPI.email = InAppParsingTests.email
         
         networkSession.callback = { _, response, _ in
@@ -417,7 +417,7 @@ class InAppParsingTests: XCTestCase {
         let expectation1 = expectation(description: "track inAppClose event")
         
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: InAppParsingTests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: InAppParsingTests.apiKey, networkSession: networkSession)
         internalAPI.email = InAppParsingTests.email
         
         networkSession.callback = { _, response, _ in
@@ -460,7 +460,7 @@ class InAppParsingTests: XCTestCase {
         let expectation1 = expectation(description: "track inAppDelivery event")
         
         let networkSession = MockNetworkSession(statusCode: 200)
-        let internalAPI = IterableAPIInternal.initializeForTesting(apiKey: InAppParsingTests.apiKey, networkSession: networkSession)
+        let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: InAppParsingTests.apiKey, networkSession: networkSession)
         internalAPI.email = InAppParsingTests.email
         
         networkSession.callback = { _, response, _ in

--- a/tests/swift-sdk-swift-tests/in-app-tests/InAppPersistenceTests.swift
+++ b/tests/swift-sdk-swift-tests/in-app-tests/InAppPersistenceTests.swift
@@ -62,7 +62,7 @@ class InAppPersistenceTests: XCTestCase {
         let expectation1 = expectation(description: #function)
         let mockInAppFetcher = MockInAppFetcher()
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(inAppFetcher: mockInAppFetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(inAppFetcher: mockInAppFetcher)
         
         mockInAppFetcher.mockMessagesAvailableFromServer(internalApi: internalAPI, messages: [Self.getInboxMessage(id: "1", read: false)])
             .flatMap { _ in

--- a/tests/swift-sdk-swift-tests/in-app-tests/InAppPriorityTests.swift
+++ b/tests/swift-sdk-swift-tests/in-app-tests/InAppPriorityTests.swift
@@ -34,7 +34,7 @@ class InAppPriorityTests: XCTestCase {
             condition1.fulfill()
         }
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(inAppFetcher: mockInAppFetcher,
+        let internalAPI = InternalIterableAPI.initializeForTesting(inAppFetcher: mockInAppFetcher,
                                                                    inAppDisplayer: mockInAppDisplayer)
         mockInAppFetcher.mockMessagesAvailableFromServer(internalApi: internalAPI, messages: messages)
         
@@ -54,7 +54,7 @@ class InAppPriorityTests: XCTestCase {
         
         let mockInAppFetcher = MockInAppFetcher()
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(inAppFetcher: mockInAppFetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(inAppFetcher: mockInAppFetcher)
         
         mockInAppFetcher.mockMessagesAvailableFromServer(internalApi: internalAPI, messages: messages).onSuccess { [weak internalAPI = internalAPI] _ in
             let originalMessages = messages.dropFirst()
@@ -86,7 +86,7 @@ class InAppPriorityTests: XCTestCase {
         }
 
         // Test will fail without assigning to internalAPI because InAppManager will be deallocated
-        let internalAPI = IterableAPIInternal.initializeForTesting(inAppFetcher: mockInAppFetcher,
+        let internalAPI = InternalIterableAPI.initializeForTesting(inAppFetcher: mockInAppFetcher,
                                                                    inAppDisplayer: mockInAppDisplayer)
         XCTAssertNotNil(internalAPI)
         wait(for: [condition1], timeout: testExpectationTimeout)
@@ -103,7 +103,7 @@ class InAppPriorityTests: XCTestCase {
         let mockInAppFetcher = MockInAppFetcher(messages: messages)
         let mockInAppPersister = MockInAppPersister()
         
-        _ = IterableAPIInternal.initializeForTesting(inAppFetcher: mockInAppFetcher,
+        _ = InternalIterableAPI.initializeForTesting(inAppFetcher: mockInAppFetcher,
                                                      inAppPersister: mockInAppPersister)
         
         XCTAssertEqual(messages.map { $0.priorityLevel }, mockInAppPersister.getMessages().map { $0.priorityLevel })

--- a/tests/swift-sdk-swift-tests/in-app-tests/InAppTests.swift
+++ b/tests/swift-sdk-swift-tests/in-app-tests/InAppTests.swift
@@ -23,7 +23,7 @@ class InAppTests: XCTestCase {
             }
             expectation1.fulfill()
         }
-        let internalApi = IterableAPIInternal.initializeForTesting(networkSession: mockNetworkSession, inAppFetcher: mockInAppFetcher)
+        let internalApi = InternalIterableAPI.initializeForTesting(networkSession: mockNetworkSession, inAppFetcher: mockInAppFetcher)
         internalApi.email = "user@example.com"
         
         let payloadFromServer = """
@@ -74,7 +74,7 @@ class InAppTests: XCTestCase {
         }
         config.urlDelegate = mockUrlDelegate
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer
@@ -107,7 +107,7 @@ class InAppTests: XCTestCase {
         let config = IterableConfig()
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer
@@ -161,7 +161,7 @@ class InAppTests: XCTestCase {
         config.urlDelegate = urlDelegate
         config.inAppDisplayInterval = 1.0
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer
@@ -196,7 +196,7 @@ class InAppTests: XCTestCase {
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
         config.inAppDisplayInterval = 0.5
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer
@@ -233,7 +233,7 @@ class InAppTests: XCTestCase {
             mockInAppDisplayer.click(url: TestInAppPayloadGenerator.getClickedUrl(index: 1))
         }
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer,
             urlOpener: mockUrlOpener
@@ -263,7 +263,7 @@ class InAppTests: XCTestCase {
         let mockUrlDelegate = MockUrlDelegate(returnValue: true)
         let config = IterableConfig()
         config.urlDelegate = mockUrlDelegate
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer,
@@ -280,7 +280,7 @@ class InAppTests: XCTestCase {
         
         let mockInAppFetcher = MockInAppFetcher()
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(
+        let internalAPI = InternalIterableAPI.initializeForTesting(
             config: IterableConfig(),
             inAppFetcher: mockInAppFetcher
         )
@@ -309,7 +309,7 @@ class InAppTests: XCTestCase {
         
         let mockInAppFetcher = MockInAppFetcher()
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(
+        let internalAPI = InternalIterableAPI.initializeForTesting(
             config: IterableConfig(),
             inAppFetcher: mockInAppFetcher
         )
@@ -354,7 +354,7 @@ class InAppTests: XCTestCase {
         let config = IterableConfig()
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer,
@@ -399,7 +399,7 @@ class InAppTests: XCTestCase {
         let config = IterableConfig()
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer,
@@ -447,7 +447,7 @@ class InAppTests: XCTestCase {
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
         config.customActionDelegate = mockCustomActionDelegate
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer
@@ -486,7 +486,7 @@ class InAppTests: XCTestCase {
         config.inAppDelegate = MockInAppDelegate(showInApp: .show)
         config.logDelegate = AllLogDelegate()
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer
@@ -529,7 +529,7 @@ class InAppTests: XCTestCase {
         config.inAppDelegate = MockInAppDelegate(showInApp: .show)
         config.logDelegate = AllLogDelegate()
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer
@@ -592,7 +592,7 @@ class InAppTests: XCTestCase {
         let config = IterableConfig()
         config.inAppDelegate = mockInAppDelegate
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher
         )
@@ -614,7 +614,7 @@ class InAppTests: XCTestCase {
         let config = IterableConfig()
         config.inAppDelegate = mockInAppDelegate
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher
         )
@@ -658,7 +658,7 @@ class InAppTests: XCTestCase {
         let mockApplicationStateProvider = MockApplicationStateProvider(applicationState: .background)
         let mockNotificationCenter = MockNotificationCenter()
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer,
@@ -693,7 +693,7 @@ class InAppTests: XCTestCase {
         let mockApplicationStateProvider = MockApplicationStateProvider(applicationState: .background)
         let mockNotificationCenter = MockNotificationCenter()
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             dateProvider: mockDateProvider,
             inAppFetcher: mockInAppFetcher,
@@ -740,7 +740,7 @@ class InAppTests: XCTestCase {
         let mockApplicationStateProvider = MockApplicationStateProvider(applicationState: .background)
         let mockNotificationCenter = MockNotificationCenter()
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             dateProvider: mockDateProvider,
             inAppFetcher: mockInAppFetcher,
@@ -811,7 +811,7 @@ class InAppTests: XCTestCase {
         let config = IterableConfig()
         config.inAppDisplayInterval = retryInterval
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             dateProvider: mockDateProvider,
             inAppFetcher: mockInAppFetcher,
@@ -847,7 +847,7 @@ class InAppTests: XCTestCase {
             mockInAppDisplayer.click(url: TestInAppPayloadGenerator.getClickedUrl(index: 1))
         }
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer
         )
@@ -918,7 +918,7 @@ class InAppTests: XCTestCase {
         config.urlDelegate = urlDelegate
         config.inAppDisplayInterval = interval
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer
@@ -1009,7 +1009,7 @@ class InAppTests: XCTestCase {
         let config = IterableConfig()
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher
         )
@@ -1072,7 +1072,7 @@ class InAppTests: XCTestCase {
         checkInAppRemoveMessagePayload(location: .inbox, source: .deleteButton, removeFunction: { $0.inAppManager.remove(message: $1, location: .inbox, source: .deleteButton) })
     }
     
-    private func checkInAppRemoveMessagePayload(location: InAppLocation, source: InAppDeleteSource?, removeFunction: @escaping (IterableAPIInternal, IterableInAppMessage) -> Void) {
+    private func checkInAppRemoveMessagePayload(location: InAppLocation, source: InAppDeleteSource?, removeFunction: @escaping (InternalIterableAPI, IterableInAppMessage) -> Void) {
         let expectation1 = expectation(description: "checkInAppRemoveMessagePayload")
         let mockInAppFetcher = MockInAppFetcher()
         let mockNetworkSession = MockNetworkSession()
@@ -1090,7 +1090,7 @@ class InAppTests: XCTestCase {
             }
             expectation1.fulfill()
         }
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             networkSession: mockNetworkSession,
             inAppFetcher: mockInAppFetcher
         )
@@ -1155,7 +1155,7 @@ class InAppTests: XCTestCase {
         XCTAssertNotNil(reference)
         
         let config = IterableConfig()
-        let internalApi = IterableAPIInternal.initializeForTesting(config: config, notificationCenter: mockNotificationCenter)
+        let internalApi = InternalIterableAPI.initializeForTesting(config: config, notificationCenter: mockNotificationCenter)
         
         let appIntegrationInternal = IterableAppIntegrationInternal(tracker: internalApi,
                                                                     urlDelegate: config.urlDelegate,
@@ -1180,7 +1180,7 @@ class InAppTests: XCTestCase {
         let config = IterableConfig()
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher
         )
@@ -1223,7 +1223,7 @@ class InAppTests: XCTestCase {
         config.inAppDelegate = mockInAppDelegate
         config.logDelegate = AllLogDelegate()
         
-        let internalApi = IterableAPIInternal.initializeForTesting(config: config,
+        let internalApi = InternalIterableAPI.initializeForTesting(config: config,
                                                                    inAppFetcher: mockInAppFetcher)
         
         mockInAppFetcher.mockInAppPayloadFromServer(internalApi: internalApi, payload)
@@ -1242,7 +1242,7 @@ class InAppTests: XCTestCase {
         config.logDelegate = AllLogDelegate()
         config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
         
-        let internalApi = IterableAPIInternal.initializeForTesting(config: config,
+        let internalApi = InternalIterableAPI.initializeForTesting(config: config,
                                                                    dateProvider: mockDateProvider,
                                                                    inAppFetcher: mockInAppFetcher)
         
@@ -1349,7 +1349,7 @@ class InAppTests: XCTestCase {
         config.inAppDelegate = MockInAppDelegate(showInApp: .show)
         config.customActionDelegate = mockCustomActionDelegate
         
-        let internalApi = IterableAPIInternal.initializeForTesting(
+        let internalApi = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer

--- a/tests/swift-sdk-swift-tests/inbox-tests/InboxSessionManagerTests.swift
+++ b/tests/swift-sdk-swift-tests/inbox-tests/InboxSessionManagerTests.swift
@@ -12,7 +12,7 @@ class InboxSessionManagerTests: XCTestCase {
     }
     
     func testSessionIsTracking() {
-        let internalApi = IterableAPIInternal.initializeForTesting()
+        let internalApi = InternalIterableAPI.initializeForTesting()
         let inboxSessionManager = InboxSessionManager(provideInAppManager: internalApi.inAppManager)
         
         XCTAssertNil(inboxSessionManager.sessionStartInfo)
@@ -30,7 +30,7 @@ class InboxSessionManagerTests: XCTestCase {
     }
     
     func testSessionInfoStartAndEnd() {
-        let internalApi = IterableAPIInternal.initializeForTesting()
+        let internalApi = InternalIterableAPI.initializeForTesting()
         let inboxSessionManager = InboxSessionManager(provideInAppManager: internalApi.inAppManager)
         
         inboxSessionManager.startSession(visibleRows: [])
@@ -65,7 +65,7 @@ class InboxSessionManagerTests: XCTestCase {
         let rowInfo1 = InboxImpressionTracker.RowInfo(messageId: IterableUtil.generateUUID(), silentInbox: false)
         let rowInfo2 = InboxImpressionTracker.RowInfo(messageId: IterableUtil.generateUUID(), silentInbox: true)
         
-        let internalApi = IterableAPIInternal.initializeForTesting()
+        let internalApi = InternalIterableAPI.initializeForTesting()
         let inboxSessionManager = InboxSessionManager(provideInAppManager: internalApi.inAppManager)
         
         let initialVisibleImpressions = [rowInfo1]

--- a/tests/swift-sdk-swift-tests/inbox-tests/InboxTests.swift
+++ b/tests/swift-sdk-swift-tests/inbox-tests/InboxTests.swift
@@ -17,7 +17,7 @@ class InboxTests: XCTestCase {
         let config = IterableConfig()
         config.logDelegate = AllLogDelegate()
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(
+        let internalAPI = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher
         )
@@ -77,7 +77,7 @@ class InboxTests: XCTestCase {
         let config = IterableConfig()
         config.logDelegate = AllLogDelegate()
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(
+        let internalAPI = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher
         )
@@ -130,7 +130,7 @@ class InboxTests: XCTestCase {
         let expectation1 = expectation(description: "testReceiveReadMessage")
         let mockInAppFetcher = MockInAppFetcher()
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(inAppFetcher: mockInAppFetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(inAppFetcher: mockInAppFetcher)
         
         let payload = """
             {"inAppMessages": [{
@@ -163,7 +163,7 @@ class InboxTests: XCTestCase {
         let config = IterableConfig()
         config.logDelegate = AllLogDelegate()
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(
+        let internalAPI = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher
         )
@@ -212,7 +212,7 @@ class InboxTests: XCTestCase {
         let expectation3 = expectation(description: "Right url callback")
         let expectation4 = expectation(description: "wait for messages")
         
-        var internalAPI: IterableAPIInternal!
+        var internalAPI: InternalIterableAPI!
         let mockInAppFetcher = MockInAppFetcher()
         
         let mockInAppDisplayer = MockInAppDisplayer()
@@ -234,7 +234,7 @@ class InboxTests: XCTestCase {
         config.urlDelegate = mockUrlDelegate
         config.logDelegate = AllLogDelegate()
         
-        internalAPI = IterableAPIInternal.initializeForTesting(
+        internalAPI = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer
@@ -283,7 +283,7 @@ class InboxTests: XCTestCase {
         expectation1.expectedFulfillmentCount = 2
         let expectation2 = expectation(description: "testInboxNewMessagesCallback: finish payload processing")
         
-        var internalAPI: IterableAPIInternal!
+        var internalAPI: InternalIterableAPI!
         let mockInAppFetcher = MockInAppFetcher()
         
         var callbackCount = 0
@@ -307,7 +307,7 @@ class InboxTests: XCTestCase {
         config.inAppDelegate = mockInAppDelegate
         config.logDelegate = AllLogDelegate()
         
-        internalAPI = IterableAPIInternal.initializeForTesting(
+        internalAPI = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             notificationCenter: mockNotificationCenter
@@ -383,7 +383,7 @@ class InboxTests: XCTestCase {
         persister.clear()
         persister.persist(messages)
         
-        var internalAPI: IterableAPIInternal!
+        var internalAPI: InternalIterableAPI!
         let config = IterableConfig()
         let mockInAppDelegate = MockInAppDelegate(showInApp: .skip)
         
@@ -402,7 +402,7 @@ class InboxTests: XCTestCase {
         
         let mockInAppFetcher = MockInAppFetcher(messages: messages)
         
-        internalAPI = IterableAPIInternal.initializeForTesting(
+        internalAPI = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppPersister: persister,
@@ -421,7 +421,7 @@ class InboxTests: XCTestCase {
         let expectation3 = expectation(description: "payload 1 processed")
         let expectation4 = expectation(description: "payload 2 processed")
         
-        var internalAPI: IterableAPIInternal!
+        var internalAPI: InternalIterableAPI!
         let mockInAppFetcher = MockInAppFetcher()
         
         var inAppCallbackCount = 0
@@ -458,7 +458,7 @@ class InboxTests: XCTestCase {
         config.inAppDelegate = mockInAppDelegate
         config.logDelegate = AllLogDelegate()
         
-        internalAPI = IterableAPIInternal.initializeForTesting(
+        internalAPI = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             notificationCenter: mockNotificationCenter
@@ -543,7 +543,7 @@ class InboxTests: XCTestCase {
         let expectation2 = expectation(description: "Unread count decrements after showing")
         let expectation3 = expectation(description: "testShowNowAndInboxMessage: wait for processing")
         
-        var internalAPI: IterableAPIInternal!
+        var internalAPI: InternalIterableAPI!
         let mockInAppFetcher = MockInAppFetcher()
         
         let mockInAppDisplayer = MockInAppDisplayer()
@@ -566,7 +566,7 @@ class InboxTests: XCTestCase {
         config.urlDelegate = mockUrlDelegate
         config.logDelegate = AllLogDelegate()
         
-        internalAPI = IterableAPIInternal.initializeForTesting(
+        internalAPI = InternalIterableAPI.initializeForTesting(
             config: config,
             inAppFetcher: mockInAppFetcher,
             inAppDisplayer: mockInAppDisplayer
@@ -605,11 +605,11 @@ class InboxTests: XCTestCase {
         let expectation1 = expectation(description: "initial messages sent")
         let expectation2 = expectation(description: "inbox change notification is fired on logout")
         
-        var internalAPI: IterableAPIInternal!
+        var internalAPI: InternalIterableAPI!
         let mockInAppFetcher = MockInAppFetcher()
         let mockNotificationCenter = MockNotificationCenter()
         
-        internalAPI = IterableAPIInternal.initializeForTesting(
+        internalAPI = InternalIterableAPI.initializeForTesting(
             config: IterableConfig(),
             inAppFetcher: mockInAppFetcher,
             notificationCenter: mockNotificationCenter

--- a/tests/swift-sdk-swift-tests/inbox-tests/InboxViewControllerViewModelTests.swift
+++ b/tests/swift-sdk-swift-tests/inbox-tests/InboxViewControllerViewModelTests.swift
@@ -20,7 +20,7 @@ class InboxViewControllerViewModelTests: XCTestCase {
         let expectation1 = expectation(description: "testDescendingSorting")
         
         let fetcher = MockInAppFetcher()
-        let internalAPI = IterableAPIInternal.initializeForTesting(inAppFetcher: fetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(inAppFetcher: fetcher)
         let model = InboxViewControllerViewModel(internalAPIProvider: internalAPI)
         model.comparator = IterableInboxViewController.DefaultComparator.descending
         
@@ -60,7 +60,7 @@ class InboxViewControllerViewModelTests: XCTestCase {
         let expectation1 = expectation(description: "testAscendingSorting")
         
         let fetcher = MockInAppFetcher()
-        let internalAPI = IterableAPIInternal.initializeForTesting(inAppFetcher: fetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(inAppFetcher: fetcher)
         let model = InboxViewControllerViewModel(internalAPIProvider: internalAPI)
         model.comparator = IterableInboxViewController.DefaultComparator.ascending
         
@@ -101,7 +101,7 @@ class InboxViewControllerViewModelTests: XCTestCase {
         let expectation1 = expectation(description: "testNoSorting")
         
         let fetcher = MockInAppFetcher()
-        let internalAPI = IterableAPIInternal.initializeForTesting(inAppFetcher: fetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(inAppFetcher: fetcher)
         let model = InboxViewControllerViewModel(internalAPIProvider: internalAPI)
         
         let date1 = Date()
@@ -140,7 +140,7 @@ class InboxViewControllerViewModelTests: XCTestCase {
         let expectation1 = expectation(description: "testWithNoFiltering")
         
         let fetcher = MockInAppFetcher()
-        let internalAPI = IterableAPIInternal.initializeForTesting(inAppFetcher: fetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(inAppFetcher: fetcher)
         let model = InboxViewControllerViewModel(internalAPIProvider: internalAPI)
         
         let date1 = Date()
@@ -180,7 +180,7 @@ class InboxViewControllerViewModelTests: XCTestCase {
         let expectation1 = expectation(description: "testCustomFiltering")
         
         let fetcher = MockInAppFetcher()
-        let internalAPI = IterableAPIInternal.initializeForTesting(inAppFetcher: fetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(inAppFetcher: fetcher)
         let model = InboxViewControllerViewModel(internalAPIProvider: internalAPI)
         model.filter = { $0.messageId == "message1" }
         
@@ -220,7 +220,7 @@ class InboxViewControllerViewModelTests: XCTestCase {
         let expectation1 = expectation(description: "testSampleFilter")
         
         let fetcher = MockInAppFetcher()
-        let internalAPI = IterableAPIInternal.initializeForTesting(inAppFetcher: fetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(inAppFetcher: fetcher)
         let model = InboxViewControllerViewModel(internalAPIProvider: internalAPI)
         model.filter = SampleInboxViewDelegateImplementations.Filter.usingCustomPayloadMessageType(in: "promotional")
         
@@ -261,7 +261,7 @@ class InboxViewControllerViewModelTests: XCTestCase {
         
         let mockNetworkSession = MockNetworkSession(statusCode: 200, data: Data(repeating: 0, count: 100))
         let fetcher = MockInAppFetcher()
-        let internalAPI = IterableAPIInternal.initializeForTesting(networkSession: mockNetworkSession, inAppFetcher: fetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(networkSession: mockNetworkSession, inAppFetcher: fetcher)
         let model = InboxViewControllerViewModel(internalAPIProvider: internalAPI)
         
         let mockView = MockViewModelView()
@@ -299,7 +299,7 @@ class InboxViewControllerViewModelTests: XCTestCase {
         
         let mockNetworkSession = MockNetworkSession(statusCode: 404, data: nil)
         let fetcher = MockInAppFetcher()
-        let internalAPI = IterableAPIInternal.initializeForTesting(networkSession: mockNetworkSession, inAppFetcher: fetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(networkSession: mockNetworkSession, inAppFetcher: fetcher)
         let model = InboxViewControllerViewModel(internalAPIProvider: internalAPI)
         
         let mockView = MockViewModelView()
@@ -335,7 +335,7 @@ class InboxViewControllerViewModelTests: XCTestCase {
         let expectation1 = expectation(description: "testSampleSectionMapper")
         
         let fetcher = MockInAppFetcher()
-        let internalAPI = IterableAPIInternal.initializeForTesting(inAppFetcher: fetcher)
+        let internalAPI = InternalIterableAPI.initializeForTesting(inAppFetcher: fetcher)
         let model = InboxViewControllerViewModel(internalAPIProvider: internalAPI)
         model.sectionMapper = SampleInboxViewDelegateImplementations.SectionMapper.usingCustomPayloadMessageSection
         


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-2626](https://iterable.atlassian.net/browse/MOB-2626)

## ✏️ Description

> Renamed `IterableAPiInternal` to `InternalIterableAPI`.
