### PR TITLE
[MOB-2448] - Refactor consts

### DIFF
--- a/swift-sdk/Constants.swift
+++ b/swift-sdk/Constants.swift
@@ -12,8 +12,8 @@ enum Endpoint {
     static let links = linksHostName + "/"
 }
 
-public enum Const {
-    public static let apiPath = "/api/"
+enum Const {
+    static let apiPath = "/api/"
     
     static let deepLinkRegex = "/a/[a-zA-Z0-9]+"
     static let href = "href"
@@ -74,99 +74,95 @@ public enum Const {
     }
 }
 
-public protocol JsonKeyRepresentable {
-    var jsonKey: String { get }
-}
-
-public enum JsonKey: String, JsonKeyRepresentable {
-    case email
-    case userId
-    case currentEmail
-    case currentUserId
-    case newEmail
-    case emailListIds
-    case unsubscribedChannelIds
-    case unsubscribedMessageTypeIds
-    case subscribedMessageTypeIds
-    case preferUserId
+enum JsonKey {
+    static let email = "email"
+    static let userId = "userId"
+    static let currentEmail = "currentEmail"
+    static let currentUserId = "currentUserId"
+    static let newEmail = "newEmail"
+    static let emailListIds = "emailListIds"
+    static let unsubscribedChannelIds = "unsubscribedChannelIds"
+    static let unsubscribedMessageTypeIds = "unsubscribedMessageTypeIds"
+    static let subscribedMessageTypeIds = "subscribedMessageTypeIds"
+    static let preferUserId = "preferUserId"
     
-    case mergeNestedObjects
+    static let mergeNestedObjects = "mergeNestedObjects"
     
-    case inboxMetadata
-    case inboxTitle = "title"
-    case inboxSubtitle = "subtitle"
-    case inboxIcon = "icon"
+    static let inboxMetadata = "inboxMetadata"
+    static let inboxTitle = "title"
+    static let inboxSubtitle = "subtitle"
+    static let inboxIcon = "icon"
     
-    case inboxExpiresAt = "expiresAt"
-    case inboxCreatedAt = "createdAt"
+    static let inboxExpiresAt = "expiresAt"
+    static let inboxCreatedAt = "createdAt"
     
-    case inAppMessageContext = "messageContext"
+    static let inAppMessageContext = "messageContext"
     
-    case campaignId
-    case templateId
-    case messageId
-    case inboxSessionId
+    static let campaignId = "campaignId"
+    static let templateId = "templateId"
+    static let messageId = "messageId"
+    static let inboxSessionId = "inboxSessionId"
     
-    case saveToInbox
-    case silentInbox
-    case inAppLocation = "location"
-    case clickedUrl
-    case read
-    case priorityLevel
+    static let saveToInbox = "saveToInbox"
+    static let silentInbox = "silentInbox"
+    static let inAppLocation = "location"
+    static let clickedUrl = "clickedUrl"
+    static let read = "read"
+    static let priorityLevel = "priorityLevel"
     
-    case inboxSessionStart
-    case inboxSessionEnd
-    case startTotalMessageCount
-    case startUnreadMessageCount
-    case endTotalMessageCount
-    case endUnreadMessageCount
-    case impressions
-    case closeAction
-    case deleteAction
+    static let inboxSessionStart = "inboxSessionStart"
+    static let inboxSessionEnd = "inboxSessionEnd"
+    static let startTotalMessageCount = "startTotalMessageCount"
+    static let startUnreadMessageCount = "startUnreadMessageCount"
+    static let endTotalMessageCount = "endTotalMessageCount"
+    static let endUnreadMessageCount = "endUnreadMessageCount"
+    static let impressions = "impressions"
+    static let closeAction = "closeAction"
+    static let deleteAction = "deleteAction"
     
-    case url
+    static let url = "url"
     
-    case device
-    case token
-    case dataFields
-    case deviceInfo
-    case identifierForVendor
-    case deviceId
-    case localizedModel
-    case model
-    case userInterfaceIdiom
-    case systemName
-    case systemVersion
-    case platform
-    case appPackageName
-    case appVersion
-    case appBuild
-    case applicationName
-    case eventName
-    case actionIdentifier
-    case userText
-    case appAlreadyRunning
+    static let device = "device"
+    static let token = "token"
+    static let dataFields = "dataFields"
+    static let deviceInfo = "deviceInfo"
+    static let identifierForVendor = "identifierForVendor"
+    static let deviceId = "deviceId"
+    static let localizedModel = "localizedModel"
+    static let model = "model"
+    static let userInterfaceIdiom = "userInterfaceIdiom"
+    static let systemName = "systemName"
+    static let systemVersion = "systemVersion"
+    static let platform = "platform"
+    static let appPackageName = "appPackageName"
+    static let appVersion = "appVersion"
+    static let appBuild = "appBuild"
+    static let applicationName = "applicationName"
+    static let eventName = "eventName"
+    static let actionIdentifier = "actionIdentifier"
+    static let userText = "userText"
+    static let appAlreadyRunning = "appAlreadyRunning"
     
-    case html
+    static let html = "html"
     
-    case iterableSdkVersion
+    static let iterableSdkVersion = "iterableSdkVersion"
     
-    case notificationsEnabled
+    static let notificationsEnabled = "notificationsEnabled"
     
-    case contentType = "Content-Type"
+    static let contentType = "Content-Type"
     
-    public enum ActionButton {
+    enum ActionButton {
         static let identifier = "identifier"
         static let action = "action"
     }
     
-    public enum Commerce {
+    enum Commerce {
         static let items = "items"
         static let total = "total"
         static let user = "user"
     }
     
-    public enum Device {
+    enum Device {
         static let localizedModel = "localizedModel"
         static let vendorId = "identifierForVendor"
         static let model = "model"
@@ -175,7 +171,7 @@ public enum JsonKey: String, JsonKeyRepresentable {
         static let userInterfaceIdiom = "userInterfaceIdiom"
     }
     
-    public enum Header {
+    enum Header {
         static let apiKey = "Api-Key"
         static let sdkVersion = "SDK-Version"
         static let sdkPlatform = "SDK-Platform"
@@ -184,11 +180,11 @@ public enum JsonKey: String, JsonKeyRepresentable {
         static let requestProcessor = "SDK-Request-Processor"
     }
     
-    public enum Body {
+    enum Body {
         static let createdAt = "createdAt"
     }
     
-    public enum InApp {
+    enum InApp {
         static let trigger = "trigger"
         static let type = "type"
         static let contentType = "contentType"
@@ -202,22 +198,18 @@ public enum JsonKey: String, JsonKeyRepresentable {
         static let content = "content"
     }
     
-    public enum Payload {
+    enum Payload {
         static let metadata = "itbl"
         static let actionButtons = "actionButtons"
         static let defaultAction = "defaultAction"
     }
     
-    public enum Response {
+    enum Response {
         static let iterableCode = "code"
     }
     
-    public enum JWT {
+    enum JWT {
         static let exp = "exp"
-    }
-    
-    public var jsonKey: String {
-        rawValue
     }
 }
 

--- a/swift-sdk/Constants.swift
+++ b/swift-sdk/Constants.swift
@@ -46,7 +46,7 @@ public enum Const {
     public enum UserDefault {
         static let payloadKey = "itbl_payload_key"
         static let attributionInfoKey = "itbl_attribution_info_key"
-        public static let emailKey = "itbl_email"
+        static let emailKey = "itbl_email"
         static let userIdKey = "itbl_userid"
         static let authTokenKey = "itbl_auth_token"
         static let ddlChecked = "itbl_ddl_checked"
@@ -72,16 +72,6 @@ public enum Const {
         static let online = "Online"
         static let offline = "Offline"
     }
-}
-
-public protocol JsonKeyValueRepresentable {
-    var key: JsonKeyRepresentable { get }
-    var value: JsonValueRepresentable { get }
-}
-
-public struct JsonKeyValue: JsonKeyValueRepresentable {
-    public let key: JsonKeyRepresentable
-    public let value: JsonValueRepresentable
 }
 
 public protocol JsonKeyRepresentable {

--- a/swift-sdk/Constants.swift
+++ b/swift-sdk/Constants.swift
@@ -213,22 +213,18 @@ enum JsonKey {
     }
 }
 
-public protocol JsonValueRepresentable {
-    var jsonValue: Any { get }
-}
+enum JsonValue {
+    static let applicationJson = "application/json"
+    static let apnsSandbox = "APNS_SANDBOX"
+    static let apnsProduction = "APNS"
+    static let iOS = "iOS"
+    static let bearer = "Bearer"
 
-public enum JsonValue: String, JsonValueRepresentable {
-    case applicationJson = "application/json"
-    case apnsSandbox = "APNS_SANDBOX"
-    case apnsProduction = "APNS"
-    case iOS
-    case bearer = "Bearer"
-    
-    public enum ActionIdentifier {
+    enum ActionIdentifier {
         static let pushOpenDefault = "default"
     }
     
-    public enum DeviceIdiom {
+    enum DeviceIdiom {
         static let pad = "Pad"
         static let phone = "Phone"
         static let carPlay = "CarPlay"
@@ -236,18 +232,14 @@ public enum JsonValue: String, JsonValueRepresentable {
         static let unspecified = "Unspecified"
     }
     
-    public enum Code {
+    enum Code {
         static let badApiKey = "BadApiKey"
         static let invalidJwtPayload = "InvalidJwtPayload"
     }
-    
-    public var jsonStringValue: String {
-        rawValue
-    }
-    
-    public var jsonValue: Any {
-        rawValue
-    }
+}
+
+public protocol JsonValueRepresentable {
+    var jsonValue: Any { get }
 }
 
 @objc public enum InAppLocation: Int, JsonValueRepresentable {

--- a/swift-sdk/Constants.swift
+++ b/swift-sdk/Constants.swift
@@ -43,7 +43,7 @@ public enum Const {
         static let getRemoteConfiguration = "mobile/getRemoteConfiguration"
     }
     
-    public enum UserDefaults {
+    public enum UserDefault {
         static let payloadKey = "itbl_payload_key"
         static let attributionInfoKey = "itbl_attribution_info_key"
         public static let emailKey = "itbl_email"

--- a/swift-sdk/Internal/ClassExtensions.swift
+++ b/swift-sdk/Internal/ClassExtensions.swift
@@ -24,52 +24,24 @@ extension Array where Element: Comparable {
 }
 
 extension Dictionary where Key == AnyHashable, Value == Any {
-    func getValue(for key: JsonKey) -> Any? {
-        self[key.jsonKey]
-    }
-    
-    func getValue(for key: JsonKeyRepresentable) -> Any? {
-        self[key.jsonKey]
-    }
-    
-    func getStringValue(for key: JsonKey, withDefault default: String? = nil) -> String? {
-        getValue(for: key) as? String ?? `default`
+    func getStringValue(for key: AnyHashable, withDefault default: String? = nil) -> String? {
+        self[key] as? String ?? `default`
     }
 
-    func getStringValue(for key: JsonKeyRepresentable, withDefault default: String? = nil) -> String? {
-        getValue(for: key) as? String ?? `default`
+    func getIntValue(for key: AnyHashable) -> Int? {
+        self[key] as? Int
     }
 
-    func getIntValue(for key: JsonKey) -> Int? {
-        getValue(for: key) as? Int
+    func getDoubleValue(for key: AnyHashable) -> Double? {
+        self[key] as? Double
     }
 
-    func getIntValue(for key: JsonKeyRepresentable) -> Int? {
-        getValue(for: key) as? Int
+    func getBoolValue(for key: AnyHashable) -> Bool? {
+        self[key].flatMap ( Self.parseBool(_:) )
     }
 
-    func getDoubleValue(for key: JsonKey) -> Double? {
-        getValue(for: key) as? Double
-    }
-
-    func getDoubleValue(for key: JsonKeyRepresentable) -> Double? {
-        getValue(for: key) as? Double
-    }
-
-    func getBoolValue(for key: JsonKey) -> Bool? {
-        getValue(for: key).flatMap ( Self.parseBool(_:) )
-    }
-
-    func getBoolValue(for key: JsonKeyRepresentable) -> Bool? {
-        getValue(for: key).flatMap ( Self.parseBool(_:) )
-    }
-    
-    mutating func setValue(for key: JsonKey, value: JsonValueRepresentable?) {
-        self[key.jsonKey] = value?.jsonValue
-    }
-    
-    mutating func setValue(for key: JsonKeyRepresentable, value: JsonValueRepresentable?) {
-        self[key.jsonKey] = value?.jsonValue
+    mutating func setValue(for key: AnyHashable, value: JsonValueRepresentable?) {
+        self[key] = value?.jsonValue
     }
 
     private static func parseBool(_ any: Any?) -> Bool? {

--- a/swift-sdk/Internal/DataFieldsHelper.swift
+++ b/swift-sdk/Internal/DataFieldsHelper.swift
@@ -21,13 +21,13 @@ struct DataFieldsHelper {
             dataFields[deviceAttribute.key] = deviceAttribute.value
         }
         
-        dataFields[JsonKey.deviceId.jsonKey] = deviceId
+        dataFields[JsonKey.deviceId] = deviceId
         
         if let sdkVersion = sdkVersion {
-            dataFields[JsonKey.iterableSdkVersion.jsonKey] = sdkVersion
+            dataFields[JsonKey.iterableSdkVersion] = sdkVersion
         }
         
-        dataFields[JsonKey.notificationsEnabled.jsonKey] = notificationsEnabled
+        dataFields[JsonKey.notificationsEnabled] = notificationsEnabled
         
         dataFields.addAll(other: createBundleFields(bundle: bundle))
         
@@ -40,13 +40,13 @@ struct DataFieldsHelper {
         var fields = [String: Any]()
         
         if let appPackageName = bundle.appPackageName {
-            fields[JsonKey.appPackageName.jsonKey] = appPackageName
+            fields[JsonKey.appPackageName] = appPackageName
         }
         if let appVersion = bundle.appVersion {
-            fields[JsonKey.appVersion.jsonKey] = appVersion
+            fields[JsonKey.appVersion] = appVersion
         }
         if let appBuild = bundle.appBuild {
-            fields[JsonKey.appBuild.jsonKey] = appBuild
+            fields[JsonKey.appBuild] = appBuild
         }
         
         return fields

--- a/swift-sdk/Internal/InAppContentParser.swift
+++ b/swift-sdk/Internal/InAppContentParser.swift
@@ -56,21 +56,13 @@ struct HtmlContentParser {
     }
     
     struct InAppDisplaySettingsParser {
-        enum Key: String, JsonKeyRepresentable {
-            case shouldAnimate
-            case bgColor
+        private enum Key {
+            static let shouldAnimate = "shouldAnimate"
+            static let bgColor = "bgColor"
             
-            enum BGColor: String, JsonKeyRepresentable {
-                case hex
-                case alpha
-
-                var jsonKey: String {
-                    rawValue
-                }
-            }
-
-            var jsonKey: String {
-                rawValue
+            enum BGColor {
+                static let hex = "hex"
+                static let alpha = "alpha"
             }
         }
         
@@ -79,8 +71,8 @@ struct HtmlContentParser {
         }
         
         static func parseBackgroundColor(fromInAppSettings settings: [AnyHashable: Any]) -> UIColor? {
-            guard let bgColorSettings = settings.getValue(for: Key.bgColor) as? [AnyHashable: Any],
-                  let hexString = bgColorSettings.getValue(for: Key.BGColor.hex) as? String else {
+            guard let bgColorSettings = settings[Key.bgColor] as? [AnyHashable: Any],
+                  let hexString = bgColorSettings[Key.BGColor.hex] as? String else {
                 return nil
             }
             
@@ -92,15 +84,11 @@ struct HtmlContentParser {
         }
         
         struct PaddingParser {
-            enum PaddingEdge: String, JsonKeyRepresentable {
-                var jsonKey: String {
-                    rawValue
-                }
-
-                case top
-                case left
-                case right
-                case bottom
+            private enum PaddingEdge: String {
+                case top = "top"
+                case left = "left"
+                case right = "right"
+                case bottom = "bottom"
             }
             
             enum PaddingValue: Equatable {
@@ -162,13 +150,9 @@ struct HtmlContentParser {
                 }
             }
             
-            enum PaddingKey: String, JsonKeyRepresentable {
-                var jsonKey: String {
-                    rawValue
-                }
-                
-                case displayOption
-                case percentage
+            private enum PaddingKey {
+                static let displayOption = "displayOption"
+                static let percentage = "percentage"
             }
 
             static let displayOptionAutoExpand = "AutoExpand"
@@ -190,10 +174,10 @@ struct HtmlContentParser {
                     return .percent(value: 0)
                 }
                 
-                if let displayOption = dict.getValue(for: PaddingKey.displayOption) as? String, displayOption == Self.displayOptionAutoExpand {
+                if let displayOption = dict[PaddingKey.displayOption] as? String, displayOption == Self.displayOptionAutoExpand {
                     return .autoExpand
                 } else {
-                    if let percentage = dict.getValue(for: PaddingKey.percentage) as? NSNumber {
+                    if let percentage = dict[PaddingKey.percentage] as? NSNumber {
                         return .percent(value: Int(truncating: percentage))
                     }
                     
@@ -208,7 +192,7 @@ struct HtmlContentParser {
                     return 0
                 }
                 
-                if let percentage = dict.getValue(for: PaddingKey.percentage) as? NSNumber {
+                if let percentage = dict[PaddingKey.percentage] as? NSNumber {
                     return Int(truncating: percentage)
                 }
                 
@@ -236,13 +220,13 @@ struct HtmlContentParser {
 
             private static func getEdgePaddingValue(fromInAppSettings settings: [AnyHashable: Any]?,
                                                edge: PaddingEdge) -> PaddingValue {
-                settings?.getValue(for: edge)
+                settings?[edge.rawValue]
                     .map(decodePaddingValue(_:)) ?? .percent(value: 0)
             }
 
             private static func getEdgePadding(fromInAppSettings settings: [AnyHashable: Any]?,
                                                edge: PaddingEdge) -> Int {
-                settings?.getValue(for: edge)
+                settings?[edge.rawValue]
                     .map(decodePadding(_:)) ?? 0
             }
         }
@@ -251,7 +235,7 @@ struct HtmlContentParser {
 
 extension HtmlContentParser: ContentFromJsonParser {
     fileprivate static func tryCreate(from json: [AnyHashable: Any]) -> InAppContentParseResult {
-        guard let html = json[JsonKey.html.jsonKey] as? String else {
+        guard let html = json[JsonKey.html] as? String else {
             return .failure(reason: "no html")
         }
         

--- a/swift-sdk/Internal/InAppInternal.swift
+++ b/swift-sdk/Internal/InAppInternal.swift
@@ -82,11 +82,11 @@ struct InAppMessageContext {
     func toMessageContextDictionary() -> [AnyHashable: Any] {
         var context = [AnyHashable: Any]()
         
-        context.setValue(for: .saveToInbox, value: saveToInbox)
-        context.setValue(for: .silentInbox, value: silentInbox)
+        context.setValue(for: JsonKey.saveToInbox, value: saveToInbox)
+        context.setValue(for: JsonKey.silentInbox, value: silentInbox)
         
         if let location = location {
-            context.setValue(for: .inAppLocation, value: location)
+            context.setValue(for: JsonKey.inAppLocation, value: location)
         }
         
         return context

--- a/swift-sdk/Internal/InAppMessageParser.swift
+++ b/swift-sdk/Internal/InAppMessageParser.swift
@@ -36,8 +36,8 @@ struct InAppMessageParser {
             return result
         }
         
-        moveValue(withSourceKey: JsonKey.saveToInbox.jsonKey,
-                  andDestinationKey: JsonKey.saveToInbox.jsonKey,
+        moveValue(withSourceKey: JsonKey.saveToInbox,
+                  andDestinationKey: JsonKey.saveToInbox,
                   from: &customPayloadDict,
                   to: &result)
         
@@ -46,9 +46,9 @@ struct InAppMessageParser {
             customPayloadDict[JsonKey.InApp.trigger] = nil
         }
         
-        if let inboxMetadataDict = customPayloadDict[JsonKey.inboxMetadata.jsonKey] as? [AnyHashable: Any] {
-            result[JsonKey.inboxMetadata.jsonKey] = inboxMetadataDict
-            customPayloadDict[JsonKey.inboxMetadata.jsonKey] = nil
+        if let inboxMetadataDict = customPayloadDict[JsonKey.inboxMetadata] as? [AnyHashable: Any] {
+            result[JsonKey.inboxMetadata] = inboxMetadataDict
+            customPayloadDict[JsonKey.inboxMetadata] = nil
         }
         
         if var contentDict = json[JsonKey.InApp.content] as? [AnyHashable: Any] {
@@ -77,7 +77,7 @@ struct InAppMessageParser {
     }
     
     private static func parseOneMessage(fromJson json: [AnyHashable: Any]) -> Result<IterableInAppMessage, ParseError> {
-        guard let messageId = json[JsonKey.messageId.jsonKey] as? String else {
+        guard let messageId = json[JsonKey.messageId] as? String else {
             return .failure(.parseFailed(reason: "no messageId", messageId: nil))
         }
         
@@ -94,16 +94,16 @@ struct InAppMessageParser {
             return .failure(.parseFailed(reason: reason, messageId: messageId))
         }
         
-        let campaignId = json[JsonKey.campaignId.jsonKey] as? NSNumber
+        let campaignId = json[JsonKey.campaignId] as? NSNumber
         
-        let saveToInbox = json[JsonKey.saveToInbox.jsonKey] as? Bool ?? false
+        let saveToInbox = json[JsonKey.saveToInbox] as? Bool ?? false
         let inboxMetadata = parseInboxMetadata(fromPayload: json)
         let trigger = parseTrigger(fromTriggerElement: json[JsonKey.InApp.trigger] as? [AnyHashable: Any])
         let customPayload = parseCustomPayload(fromPayload: json)
-        let createdAt = parseTime(withKey: .inboxCreatedAt, fromJson: json)
-        let expiresAt = parseTime(withKey: .inboxExpiresAt, fromJson: json)
-        let read = json[JsonKey.read.jsonKey] as? Bool ?? false
-        let priorityLevel = json[JsonKey.priorityLevel.jsonKey] as? Double ?? Const.PriorityLevel.unassigned
+        let createdAt = parseTime(withKey: JsonKey.inboxCreatedAt, fromJson: json)
+        let expiresAt = parseTime(withKey: JsonKey.inboxExpiresAt, fromJson: json)
+        let read = json[JsonKey.read] as? Bool ?? false
+        let priorityLevel = json[JsonKey.priorityLevel] as? Double ?? Const.PriorityLevel.unassigned
         
         return .success(IterableInAppMessage(messageId: messageId,
                                              campaignId: campaignId,
@@ -118,8 +118,8 @@ struct InAppMessageParser {
                                              priorityLevel: priorityLevel))
     }
     
-    private static func parseTime(withKey key: JsonKey, fromJson json: [AnyHashable: Any]) -> Date? {
-        json.getIntValue(for: key).map(IterableUtil.date(fromInt:))
+    private static func parseTime(withKey key: AnyHashable, fromJson json: [AnyHashable: Any]) -> Date? {
+        (json[key] as? Int).map(IterableUtil.date(fromInt:))
     }
     
     private static func parseTrigger(fromTriggerElement element: [AnyHashable: Any]?) -> IterableInAppTrigger {
@@ -135,13 +135,13 @@ struct InAppMessageParser {
     }
     
     private static func parseInboxMetadata(fromPayload payload: [AnyHashable: Any]) -> IterableInboxMetadata? {
-        guard let inboxMetadataDict = payload[JsonKey.inboxMetadata.jsonKey] as? [AnyHashable: Any] else {
+        guard let inboxMetadataDict = payload[JsonKey.inboxMetadata] as? [AnyHashable: Any] else {
             return nil
         }
         
-        let title = inboxMetadataDict.getStringValue(for: .inboxTitle)
-        let subtitle = inboxMetadataDict.getStringValue(for: .inboxSubtitle)
-        let icon = inboxMetadataDict.getStringValue(for: .inboxIcon)
+        let title = inboxMetadataDict.getStringValue(for: JsonKey.inboxTitle)
+        let subtitle = inboxMetadataDict.getStringValue(for: JsonKey.inboxSubtitle)
+        let icon = inboxMetadataDict.getStringValue(for: JsonKey.inboxIcon)
         
         return IterableInboxMetadata(title: title, subtitle: subtitle, icon: icon)
     }

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -37,7 +37,7 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
     
     var deviceMetadata: DeviceMetadata {
         DeviceMetadata(deviceId: deviceId,
-                       platform: JsonValue.iOS.jsonStringValue,
+                       platform: JsonValue.iOS,
                        appPackageName: Bundle.main.appPackageName ?? "")
     }
     

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -50,7 +50,7 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
             localStorage.getAttributionInfo(currentDate: dateProvider.currentDate)
         } set {
             let expiration = Calendar.current.date(byAdding: .hour,
-                                                   value: Const.UserDefaults.attributionInfoExpiration,
+                                                   value: Const.UserDefault.attributionInfoExpiration,
                                                    to: dateProvider.currentDate)
             localStorage.save(attributionInfo: newValue, withExpiration: expiration)
         }
@@ -497,7 +497,7 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
     
     private func save(pushPayload payload: [AnyHashable: Any]) {
         let expiration = Calendar.current.date(byAdding: .hour,
-                                               value: Const.UserDefaults.payloadExpiration,
+                                               value: Const.UserDefault.payloadExpiration,
                                                to: dateProvider.currentDate)
         localStorage.save(payload: payload, withExpiration: expiration)
         

--- a/swift-sdk/Internal/IterableAPICallRequest.swift
+++ b/swift-sdk/Internal/IterableAPICallRequest.swift
@@ -54,8 +54,8 @@ struct IterableAPICallRequest {
     }
     
     private func createIterableHeaders(currentDate: Date, processorType: ProcessorType) -> [String: String] {
-        var headers = [JsonKey.contentType: JsonValue.applicationJson.jsonStringValue,
-                       JsonKey.Header.sdkPlatform: JsonValue.iOS.jsonStringValue,
+        var headers = [JsonKey.contentType: JsonValue.applicationJson,
+                       JsonKey.Header.sdkPlatform: JsonValue.iOS,
                        JsonKey.Header.sdkVersion: IterableAPI.sdkVersion,
                        JsonKey.Header.apiKey: apiKey,
                        JsonKey.Header.sentAt: Self.format(sentAt: currentDate),

--- a/swift-sdk/Internal/IterableAPICallRequest.swift
+++ b/swift-sdk/Internal/IterableAPICallRequest.swift
@@ -54,7 +54,7 @@ struct IterableAPICallRequest {
     }
     
     private func createIterableHeaders(currentDate: Date, processorType: ProcessorType) -> [String: String] {
-        var headers = [JsonKey.contentType.jsonKey: JsonValue.applicationJson.jsonStringValue,
+        var headers = [JsonKey.contentType: JsonValue.applicationJson.jsonStringValue,
                        JsonKey.Header.sdkPlatform: JsonValue.iOS.jsonStringValue,
                        JsonKey.Header.sdkVersion: IterableAPI.sdkVersion,
                        JsonKey.Header.apiKey: apiKey,

--- a/swift-sdk/Internal/IterableAppIntegrationInternal.swift
+++ b/swift-sdk/Internal/IterableAppIntegrationInternal.swift
@@ -223,7 +223,7 @@ struct IterableAppIntegrationInternal {
         let action = IterableAppIntegrationInternal.createIterableAction(actionIdentifier: response.actionIdentifier, userText: response.userText, userInfo: userInfo, iterableElement: itbl)
         
         // Track push open
-        if let _ = dataFields[JsonKey.actionIdentifier.jsonKey] { // i.e., if action is not dismiss
+        if let _ = dataFields[JsonKey.actionIdentifier] { // i.e., if action is not dismiss
             tracker?.trackPushOpen(userInfo, dataFields: dataFields)
         }
         
@@ -294,15 +294,15 @@ struct IterableAppIntegrationInternal {
         var dataFields = [AnyHashable: Any]()
         
         if actionIdentifier == UNNotificationDefaultActionIdentifier {
-            dataFields[JsonKey.actionIdentifier.jsonKey] = JsonValue.ActionIdentifier.pushOpenDefault
+            dataFields[JsonKey.actionIdentifier] = JsonValue.ActionIdentifier.pushOpenDefault
         } else if actionIdentifier == UNNotificationDismissActionIdentifier {
             // We don't track dismiss actions yet
         } else {
-            dataFields[JsonKey.actionIdentifier.jsonKey] = actionIdentifier
+            dataFields[JsonKey.actionIdentifier] = actionIdentifier
         }
         
         if let userText = userText {
-            dataFields[JsonKey.userText.jsonKey] = userText
+            dataFields[JsonKey.userText] = userText
         }
         
         return dataFields
@@ -315,7 +315,7 @@ struct IterableAppIntegrationInternal {
         }
         
         // Track push open
-        let dataFields = [JsonKey.actionIdentifier.jsonKey: JsonValue.ActionIdentifier.pushOpenDefault]
+        let dataFields = [JsonKey.actionIdentifier: JsonValue.ActionIdentifier.pushOpenDefault]
         tracker?.trackPushOpen(userInfo, dataFields: dataFields)
         
         guard let itbl = IterableAppIntegrationInternal.itblValue(fromUserInfo: userInfo) else {
@@ -363,7 +363,7 @@ struct IterableAppIntegrationInternal {
     // Normally default action would be stored in key "itbl/"defaultAction"
     // In legacy templates it gets saved in the key "url"
     private static func legacyDefaultActionFromPayload(userInfo: [AnyHashable: Any]) -> IterableAction? {
-        if let deepLinkUrl = userInfo[JsonKey.url.jsonKey] as? String {
+        if let deepLinkUrl = userInfo[JsonKey.url] as? String {
             return IterableAction.actionOpenUrl(fromUrlString: deepLinkUrl)
         }
         

--- a/swift-sdk/Internal/RequestCreator.swift
+++ b/swift-sdk/Internal/RequestCreator.swift
@@ -203,7 +203,7 @@ struct RequestCreator {
         }
 
         var args: [AnyHashable: Any] = [JsonKey.InApp.count: count.description,
-                                        JsonKey.platform: JsonValue.iOS.jsonStringValue,
+                                        JsonKey.platform: JsonValue.iOS,
                                         JsonKey.systemVersion: UIDevice.current.systemVersion,
                                         JsonKey.InApp.sdkVersion: IterableAPI.sdkVersion]
         
@@ -400,7 +400,7 @@ struct RequestCreator {
     }
     
     func createGetRemoteConfigurationRequest() -> Result<IterableRequest, IterableError> {
-        var args: [AnyHashable: Any] = [JsonKey.platform: JsonValue.iOS.jsonStringValue,
+        var args: [AnyHashable: Any] = [JsonKey.platform: JsonValue.iOS,
                                         JsonKey.systemVersion: UIDevice.current.systemVersion,
                                         JsonKey.InApp.sdkVersion: IterableAPI.sdkVersion]
         
@@ -427,11 +427,11 @@ struct RequestCreator {
     private static func pushServicePlatformToString(_ pushServicePlatform: PushServicePlatform, apnsType: APNSType) -> String {
         switch pushServicePlatform {
         case .production:
-            return JsonValue.apnsProduction.jsonStringValue
+            return JsonValue.apnsProduction
         case .sandbox:
-            return JsonValue.apnsSandbox.jsonStringValue
+            return JsonValue.apnsSandbox
         case .auto:
-            return apnsType == .sandbox ? JsonValue.apnsSandbox.jsonStringValue : JsonValue.apnsProduction.jsonStringValue
+            return apnsType == .sandbox ? JsonValue.apnsSandbox : JsonValue.apnsProduction
         }
     }
     

--- a/swift-sdk/Internal/RequestCreator.swift
+++ b/swift-sdk/Internal/RequestCreator.swift
@@ -16,12 +16,12 @@ struct RequestCreator {
     // MARK: - API REQUEST CALLS
     
     func createUpdateEmailRequest(newEmail: String) -> Result<IterableRequest, IterableError> {
-        var body: [String: Any] = [JsonKey.newEmail.jsonKey: newEmail]
+        var body: [String: Any] = [JsonKey.newEmail: newEmail]
         
         if let email = auth.email {
-            body[JsonKey.currentEmail.jsonKey] = email
+            body[JsonKey.currentEmail] = email
         } else if let userId = auth.userId {
-            body[JsonKey.currentUserId.jsonKey] = userId
+            body[JsonKey.currentUserId] = userId
         } else {
             ITBError("Both email and userId are nil")
             return .failure(IterableError.general(description: "Both email and userId are nil"))
@@ -45,21 +45,21 @@ struct RequestCreator {
                                                            deviceAttributes: registerTokenInfo.deviceAttributes)
         
         let deviceDictionary: [String: Any] = [
-            JsonKey.token.jsonKey: registerTokenInfo.hexToken,
-            JsonKey.platform.jsonKey: RequestCreator.pushServicePlatformToString(registerTokenInfo.pushServicePlatform,
+            JsonKey.token: registerTokenInfo.hexToken,
+            JsonKey.platform: RequestCreator.pushServicePlatformToString(registerTokenInfo.pushServicePlatform,
                                                                                  apnsType: registerTokenInfo.apnsType),
-            JsonKey.applicationName.jsonKey: registerTokenInfo.appName,
-            JsonKey.dataFields.jsonKey: dataFields,
+            JsonKey.applicationName: registerTokenInfo.appName,
+            JsonKey.dataFields: dataFields,
         ]
         
         var body = [AnyHashable: Any]()
         
-        body[JsonKey.device.jsonKey] = deviceDictionary
+        body[JsonKey.device] = deviceDictionary
         
         setCurrentUser(inDict: &body)
         
         if auth.email == nil, auth.userId != nil {
-            body[JsonKey.preferUserId.jsonKey] = true
+            body[JsonKey.preferUserId] = true
         }
         
         return .success(.post(createPostRequest(path: Const.Path.registerDeviceToken, body: body)))
@@ -73,12 +73,12 @@ struct RequestCreator {
 
         var body = [AnyHashable: Any]()
         
-        body[JsonKey.dataFields.jsonKey] = dataFields
-        body[JsonKey.mergeNestedObjects.jsonKey] = NSNumber(value: mergeNestedObjects)
+        body[JsonKey.dataFields] = dataFields
+        body[JsonKey.mergeNestedObjects] = NSNumber(value: mergeNestedObjects)
         setCurrentUser(inDict: &body)
         
         if auth.email == nil, auth.userId != nil {
-            body[JsonKey.preferUserId.jsonKey] = true
+            body[JsonKey.preferUserId] = true
         }
         
         return .success(.post(createPostRequest(path: Const.Path.updateUser, body: body)))
@@ -105,7 +105,7 @@ struct RequestCreator {
                                    JsonKey.Commerce.total: total]
         
         if let dataFields = dataFields {
-            body[JsonKey.dataFields.jsonKey] = dataFields
+            body[JsonKey.dataFields] = dataFields
         }
         
         return .success(.post(createPostRequest(path: Const.Path.trackPurchase, body: body)))
@@ -119,18 +119,18 @@ struct RequestCreator {
             reqDataFields = dataFields
         }
         
-        reqDataFields[JsonKey.appAlreadyRunning.jsonKey] = appAlreadyRunning
-        body[JsonKey.dataFields.jsonKey] = reqDataFields
+        reqDataFields[JsonKey.appAlreadyRunning] = appAlreadyRunning
+        body[JsonKey.dataFields] = reqDataFields
         
         setCurrentUser(inDict: &body)
         
-        body[JsonKey.campaignId.jsonKey] = campaignId
+        body[JsonKey.campaignId] = campaignId
         
         if let templateId = templateId {
-            body[JsonKey.templateId.jsonKey] = templateId
+            body[JsonKey.templateId] = templateId
         }
         
-        body.setValue(for: .messageId, value: messageId)
+        body.setValue(for: JsonKey.messageId, value: messageId)
         
         return .success(.post(createPostRequest(path: Const.Path.trackPushOpen, body: body)))
     }
@@ -145,10 +145,10 @@ struct RequestCreator {
         
         setCurrentUser(inDict: &body)
 
-        body.setValue(for: .eventName, value: eventName)
+        body.setValue(for: JsonKey.eventName, value: eventName)
         
         if let dataFields = dataFields {
-            body[JsonKey.dataFields.jsonKey] = dataFields
+            body[JsonKey.dataFields] = dataFields
         }
         
         return .success(.post(createPostRequest(path: Const.Path.trackEvent, body: body)))
@@ -170,27 +170,27 @@ struct RequestCreator {
         setCurrentUser(inDict: &body)
         
         if let emailListIds = emailListIds {
-            body[JsonKey.emailListIds.jsonKey] = emailListIds
+            body[JsonKey.emailListIds] = emailListIds
         }
         
         if let unsubscribedChannelIds = unsubscribedChannelIds {
-            body[JsonKey.unsubscribedChannelIds.jsonKey] = unsubscribedChannelIds
+            body[JsonKey.unsubscribedChannelIds] = unsubscribedChannelIds
         }
         
         if let unsubscribedMessageTypeIds = unsubscribedMessageTypeIds {
-            body[JsonKey.unsubscribedMessageTypeIds.jsonKey] = unsubscribedMessageTypeIds
+            body[JsonKey.unsubscribedMessageTypeIds] = unsubscribedMessageTypeIds
         }
         
         if let subscribedMessageTypeIds = subscribedMessageTypeIds {
-            body[JsonKey.subscribedMessageTypeIds.jsonKey] = subscribedMessageTypeIds
+            body[JsonKey.subscribedMessageTypeIds] = subscribedMessageTypeIds
         }
         
         if let campaignId = campaignId?.intValue {
-            body[JsonKey.campaignId.jsonKey] = campaignId
+            body[JsonKey.campaignId] = campaignId
         }
         
         if let templateId = templateId?.intValue {
-            body[JsonKey.templateId.jsonKey] = templateId
+            body[JsonKey.templateId] = templateId
         }
         
         return .success(.post(createPostRequest(path: Const.Path.updateSubscriptions, body: body)))
@@ -203,8 +203,8 @@ struct RequestCreator {
         }
 
         var args: [AnyHashable: Any] = [JsonKey.InApp.count: count.description,
-                                        JsonKey.platform.jsonKey: JsonValue.iOS.jsonStringValue,
-                                        JsonKey.systemVersion.jsonKey: UIDevice.current.systemVersion,
+                                        JsonKey.platform: JsonValue.iOS.jsonStringValue,
+                                        JsonKey.systemVersion: UIDevice.current.systemVersion,
                                         JsonKey.InApp.sdkVersion: IterableAPI.sdkVersion]
         
         if let packageName = Bundle.main.appPackageName {
@@ -224,15 +224,15 @@ struct RequestCreator {
 
         var body = [AnyHashable: Any]()
         
-        body.setValue(for: .messageId, value: inAppMessageContext.messageId)
+        body.setValue(for: JsonKey.messageId, value: inAppMessageContext.messageId)
         
         setCurrentUser(inDict: &body)
         
-        body.setValue(for: .inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
-        body.setValue(for: .deviceInfo, value: deviceMetadata.asDictionary())
+        body.setValue(for: JsonKey.inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
+        body.setValue(for: JsonKey.deviceInfo, value: deviceMetadata.asDictionary())
         
         if let inboxSessionId = inAppMessageContext.inboxSessionId {
-            body.setValue(for: .inboxSessionId, value: inboxSessionId)
+            body.setValue(for: JsonKey.inboxSessionId, value: inboxSessionId)
         }
         
         return .success(.post(createPostRequest(path: Const.Path.trackInAppOpen, body: body)))
@@ -246,17 +246,17 @@ struct RequestCreator {
 
         var body = [AnyHashable: Any]()
         
-        body.setValue(for: .messageId, value: inAppMessageContext.messageId)
+        body.setValue(for: JsonKey.messageId, value: inAppMessageContext.messageId)
         
         setCurrentUser(inDict: &body)
         
-        body.setValue(for: .clickedUrl, value: clickedUrl)
+        body.setValue(for: JsonKey.clickedUrl, value: clickedUrl)
         
-        body.setValue(for: .inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
-        body.setValue(for: .deviceInfo, value: deviceMetadata.asDictionary())
+        body.setValue(for: JsonKey.inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
+        body.setValue(for: JsonKey.deviceInfo, value: deviceMetadata.asDictionary())
         
         if let inboxSessionId = inAppMessageContext.inboxSessionId {
-            body.setValue(for: .inboxSessionId, value: inboxSessionId)
+            body.setValue(for: JsonKey.inboxSessionId, value: inboxSessionId)
         }
         
         return .success(.post(createPostRequest(path: Const.Path.trackInAppClick, body: body)))
@@ -270,21 +270,21 @@ struct RequestCreator {
 
         var body = [AnyHashable: Any]()
         
-        body.setValue(for: .messageId, value: inAppMessageContext.messageId)
+        body.setValue(for: JsonKey.messageId, value: inAppMessageContext.messageId)
         
         if let source = source {
-            body.setValue(for: .closeAction, value: source)
+            body.setValue(for: JsonKey.closeAction, value: source)
         }
         
         if let clickedUrl = clickedUrl {
-            body.setValue(for: .clickedUrl, value: clickedUrl)
+            body.setValue(for: JsonKey.clickedUrl, value: clickedUrl)
         }
         
-        body.setValue(for: .inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
-        body.setValue(for: .deviceInfo, value: deviceMetadata.asDictionary())
+        body.setValue(for: JsonKey.inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
+        body.setValue(for: JsonKey.deviceInfo, value: deviceMetadata.asDictionary())
         
         if let inboxSessionId = inAppMessageContext.inboxSessionId {
-            body.setValue(for: .inboxSessionId, value: inboxSessionId)
+            body.setValue(for: JsonKey.inboxSessionId, value: inboxSessionId)
         }
         
         setCurrentUser(inDict: &body)
@@ -300,12 +300,12 @@ struct RequestCreator {
 
         var body = [AnyHashable: Any]()
         
-        body.setValue(for: .messageId, value: inAppMessageContext.messageId)
+        body.setValue(for: JsonKey.messageId, value: inAppMessageContext.messageId)
         
         setCurrentUser(inDict: &body)
         
-        body.setValue(for: .inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
-        body.setValue(for: .deviceInfo, value: deviceMetadata.asDictionary())
+        body.setValue(for: JsonKey.inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
+        body.setValue(for: JsonKey.deviceInfo, value: deviceMetadata.asDictionary())
         
         return .success(.post(createPostRequest(path: Const.Path.trackInAppDelivery, body: body)))
     }
@@ -318,7 +318,7 @@ struct RequestCreator {
 
         var body = [AnyHashable: Any]()
         
-        body.setValue(for: .messageId, value: messageId)
+        body.setValue(for: JsonKey.messageId, value: messageId)
         
         setCurrentUser(inDict: &body)
         
@@ -333,17 +333,17 @@ struct RequestCreator {
 
         var body = [AnyHashable: Any]()
         
-        body.setValue(for: .messageId, value: inAppMessageContext.messageId)
+        body.setValue(for: JsonKey.messageId, value: inAppMessageContext.messageId)
         
         if let source = source {
-            body.setValue(for: .deleteAction, value: source)
+            body.setValue(for: JsonKey.deleteAction, value: source)
         }
         
-        body.setValue(for: .inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
-        body.setValue(for: .deviceInfo, value: deviceMetadata.asDictionary())
+        body.setValue(for: JsonKey.inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
+        body.setValue(for: JsonKey.deviceInfo, value: deviceMetadata.asDictionary())
         
         if let inboxSessionId = inAppMessageContext.inboxSessionId {
-            body.setValue(for: .inboxSessionId, value: inboxSessionId)
+            body.setValue(for: JsonKey.inboxSessionId, value: inboxSessionId)
         }
         
         setCurrentUser(inDict: &body)
@@ -373,16 +373,16 @@ struct RequestCreator {
 
         setCurrentUser(inDict: &body)
         
-        body.setValue(for: .inboxSessionId, value: inboxSessionId)
-        body.setValue(for: .inboxSessionStart, value: IterableUtil.int(fromDate: sessionStartTime))
-        body.setValue(for: .inboxSessionEnd, value: IterableUtil.int(fromDate: sessionEndTime))
-        body.setValue(for: .startTotalMessageCount, value: inboxSession.startTotalMessageCount)
-        body.setValue(for: .endTotalMessageCount, value: inboxSession.endTotalMessageCount)
-        body.setValue(for: .startUnreadMessageCount, value: inboxSession.startUnreadMessageCount)
-        body.setValue(for: .endUnreadMessageCount, value: inboxSession.endUnreadMessageCount)
-        body.setValue(for: .impressions, value: inboxSession.impressions.compactMap { $0.asDictionary() })
+        body.setValue(for: JsonKey.inboxSessionId, value: inboxSessionId)
+        body.setValue(for: JsonKey.inboxSessionStart, value: IterableUtil.int(fromDate: sessionStartTime))
+        body.setValue(for: JsonKey.inboxSessionEnd, value: IterableUtil.int(fromDate: sessionEndTime))
+        body.setValue(for: JsonKey.startTotalMessageCount, value: inboxSession.startTotalMessageCount)
+        body.setValue(for: JsonKey.endTotalMessageCount, value: inboxSession.endTotalMessageCount)
+        body.setValue(for: JsonKey.startUnreadMessageCount, value: inboxSession.startUnreadMessageCount)
+        body.setValue(for: JsonKey.endUnreadMessageCount, value: inboxSession.endUnreadMessageCount)
+        body.setValue(for: JsonKey.impressions, value: inboxSession.impressions.compactMap { $0.asDictionary() })
         
-        body.setValue(for: .deviceInfo, value: deviceMetadata.asDictionary())
+        body.setValue(for: JsonKey.deviceInfo, value: deviceMetadata.asDictionary())
         
         return .success(.post(createPostRequest(path: Const.Path.trackInboxSession, body: body)))
     }
@@ -390,7 +390,7 @@ struct RequestCreator {
     func createDisableDeviceRequest(forAllUsers allUsers: Bool, hexToken: String) -> Result<IterableRequest, IterableError> {
         var body = [AnyHashable: Any]()
         
-        body.setValue(for: .token, value: hexToken)
+        body.setValue(for: JsonKey.token, value: hexToken)
         
         if !allUsers {
             setCurrentUser(inDict: &body)
@@ -400,8 +400,8 @@ struct RequestCreator {
     }
     
     func createGetRemoteConfigurationRequest() -> Result<IterableRequest, IterableError> {
-        var args: [AnyHashable: Any] = [JsonKey.platform.jsonKey: JsonValue.iOS.jsonStringValue,
-                                        JsonKey.systemVersion.jsonKey: UIDevice.current.systemVersion,
+        var args: [AnyHashable: Any] = [JsonKey.platform: JsonValue.iOS.jsonStringValue,
+                                        JsonKey.systemVersion: UIDevice.current.systemVersion,
                                         JsonKey.InApp.sdkVersion: IterableAPI.sdkVersion]
         
         if let packageName = Bundle.main.appPackageName {
@@ -438,9 +438,9 @@ struct RequestCreator {
     private func setCurrentUser(inDict dict: inout [AnyHashable: Any]) {
         switch auth.emailOrUserId {
         case let .email(email):
-            dict.setValue(for: .email, value: email)
+            dict.setValue(for: JsonKey.email, value: email)
         case let .userId(userId):
-            dict.setValue(for: .userId, value: userId)
+            dict.setValue(for: JsonKey.userId, value: userId)
         case .none:
             ITBInfo("Current user is unavailable")
         }
@@ -460,13 +460,13 @@ extension RequestCreator {
         
         var body = [AnyHashable: Any]()
         
-        body.setValue(for: .messageId, value: messageId)
+        body.setValue(for: JsonKey.messageId, value: messageId)
         
         setCurrentUser(inDict: &body)
         
         let inAppMessageContext = InAppMessageContext.from(messageId: messageId, deviceMetadata: deviceMetadata)
-        body.setValue(for: .inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
-        body.setValue(for: .deviceInfo, value: deviceMetadata.asDictionary())
+        body.setValue(for: JsonKey.inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
+        body.setValue(for: JsonKey.deviceInfo, value: deviceMetadata.asDictionary())
         
         return .success(.post(createPostRequest(path: Const.Path.trackInAppOpen, body: body)))
     }
@@ -480,14 +480,14 @@ extension RequestCreator {
 
         var body = [AnyHashable: Any]()
         
-        body.setValue(for: .messageId, value: messageId)
-        body.setValue(for: .clickedUrl, value: clickedUrl)
+        body.setValue(for: JsonKey.messageId, value: messageId)
+        body.setValue(for: JsonKey.clickedUrl, value: clickedUrl)
         
         setCurrentUser(inDict: &body)
         
         let inAppMessageContext = InAppMessageContext.from(messageId: messageId, deviceMetadata: deviceMetadata)
-        body.setValue(for: .inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
-        body.setValue(for: .deviceInfo, value: deviceMetadata.asDictionary())
+        body.setValue(for: JsonKey.inAppMessageContext, value: inAppMessageContext.toMessageContextDictionary())
+        body.setValue(for: JsonKey.deviceInfo, value: deviceMetadata.asDictionary())
         
         return .success(.post(createPostRequest(path: Const.Path.trackInAppClick, body: body)))
     }

--- a/swift-sdk/Internal/UserDefaultsLocalStorage.swift
+++ b/swift-sdk/Internal/UserDefaultsLocalStorage.swift
@@ -194,16 +194,16 @@ struct UserDefaultsLocalStorage: LocalStorageProtocol {
             self.value = value
         }
         
-        static let payload = LocalStorageKey(value: Const.UserDefaults.payloadKey)
-        static let attributionInfo = LocalStorageKey(value: Const.UserDefaults.attributionInfoKey)
-        static let email = LocalStorageKey(value: Const.UserDefaults.emailKey)
-        static let userId = LocalStorageKey(value: Const.UserDefaults.userIdKey)
-        static let authToken = LocalStorageKey(value: Const.UserDefaults.authTokenKey)
-        static let ddlChecked = LocalStorageKey(value: Const.UserDefaults.ddlChecked)
-        static let deviceId = LocalStorageKey(value: Const.UserDefaults.deviceId)
-        static let sdkVersion = LocalStorageKey(value: Const.UserDefaults.sdkVersion)
-        static let offlineMode = LocalStorageKey(value: Const.UserDefaults.offlineMode)
-        static let offlineModeBeta = LocalStorageKey(value: Const.UserDefaults.offlineModeBeta)
+        static let payload = LocalStorageKey(value: Const.UserDefault.payloadKey)
+        static let attributionInfo = LocalStorageKey(value: Const.UserDefault.attributionInfoKey)
+        static let email = LocalStorageKey(value: Const.UserDefault.emailKey)
+        static let userId = LocalStorageKey(value: Const.UserDefault.userIdKey)
+        static let authToken = LocalStorageKey(value: Const.UserDefault.authTokenKey)
+        static let ddlChecked = LocalStorageKey(value: Const.UserDefault.ddlChecked)
+        static let deviceId = LocalStorageKey(value: Const.UserDefault.deviceId)
+        static let sdkVersion = LocalStorageKey(value: Const.UserDefault.sdkVersion)
+        static let offlineMode = LocalStorageKey(value: Const.UserDefault.offlineMode)
+        static let offlineModeBeta = LocalStorageKey(value: Const.UserDefault.offlineModeBeta)
     }
     
     private struct Envelope: Codable {

--- a/tests/endpoint-tests/IterableAPISupport.swift
+++ b/tests/endpoint-tests/IterableAPISupport.swift
@@ -54,8 +54,8 @@ struct IterableAPISupport {
     }
     
     private static func createIterableHeaders() -> [String: String] {
-        [JsonKey.contentType.jsonKey: JsonValue.applicationJson.jsonStringValue,
-         JsonKey.Header.sdkPlatform: JsonValue.iOS.jsonStringValue,
+        [JsonKey.contentType.jsonKey: JsonValue.applicationJson,
+         JsonKey.Header.sdkPlatform: JsonValue.iOS,
          JsonKey.Header.sdkVersion: IterableAPI.sdkVersion,
          JsonKey.Header.apiKey: apiKey]
     }

--- a/tests/endpoint-tests/IterableAPISupport.swift
+++ b/tests/endpoint-tests/IterableAPISupport.swift
@@ -54,7 +54,7 @@ struct IterableAPISupport {
     }
     
     private static func createIterableHeaders() -> [String: String] {
-        [JsonKey.contentType.jsonKey: JsonValue.applicationJson,
+        [JsonKey.contentType: JsonValue.applicationJson,
          JsonKey.Header.sdkPlatform: JsonValue.iOS,
          JsonKey.Header.sdkVersion: IterableAPI.sdkVersion,
          JsonKey.Header.apiKey: apiKey]

--- a/tests/inbox-ui-tests-app-ui-tests/InboxUITests.swift
+++ b/tests/inbox-ui-tests-app-ui-tests/InboxUITests.swift
@@ -60,8 +60,9 @@ class InboxUITests: XCTestCase, IterableInboxUITestsProtocol {
         sleep(2)
         gotoTab(.network)
         
+        
         let dict = body(forEvent: Const.Path.trackInboxSession)
-        let impressions = dict[keyPath: KeyPath(JsonKey.impressions)] as! [[String: Any]]
+        let impressions = dict[keyPath: KeyPath(keys: JsonKey.impressions)] as! [[String: Any]]
         XCTAssertEqual(impressions.count, 3)
     }
     
@@ -80,7 +81,7 @@ class InboxUITests: XCTestCase, IterableInboxUITestsProtocol {
         
         gotoTab(.network)
         let dict = body(forEvent: Const.Path.inAppConsume)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.deleteAction), value: InAppDeleteSource.inboxSwipe.jsonValue as! String, inDictionary: dict)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.deleteAction), value: InAppDeleteSource.inboxSwipe.jsonValue as! String, inDictionary: dict)
     }
     
     func testDeleteActionDeleteButton() {
@@ -105,7 +106,7 @@ class InboxUITests: XCTestCase, IterableInboxUITestsProtocol {
         
         gotoTab(.network)
         let dict = body(forEvent: Const.Path.inAppConsume)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.deleteAction), value: InAppDeleteSource.deleteButton.jsonValue as! String, inDictionary: dict)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.deleteAction), value: InAppDeleteSource.deleteButton.jsonValue as! String, inDictionary: dict)
     }
     
     func testPullToRefresh() {

--- a/tests/inbox-ui-tests-app-ui-tests/InboxUITestsHelper.swift
+++ b/tests/inbox-ui-tests-app-ui-tests/InboxUITestsHelper.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import IterableSDK
+@testable import IterableSDK
 import XCTest
 
 enum TabName: String {

--- a/tests/offline-events-tests/RequestHandlerTests.swift
+++ b/tests/offline-events-tests/RequestHandlerTests.swift
@@ -935,7 +935,7 @@ class RequestHandlerTests: XCTestCase {
     }
     
     private static let deviceMetadata = DeviceMetadata(deviceId: IterableUtil.generateUUID(),
-                                                       platform: JsonValue.iOS.jsonStringValue,
+                                                       platform: JsonValue.iOS,
                                                        appPackageName: Bundle.main.appPackageName ?? "")
     
     private let dateProvider = MockDateProvider()

--- a/tests/offline-events-tests/TaskProcessorTests.swift
+++ b/tests/offline-events-tests/TaskProcessorTests.swift
@@ -51,8 +51,8 @@ class TaskProcessorTests: XCTestCase {
         try processor.process(task: found).onSuccess { _ in
             let request = networkSession.getRequest(withEndPoint: Const.Path.trackEvent)!
             let body = request.httpBody!.json() as! [String: Any]
-            TestUtils.validateMatch(keyPath: KeyPath(.email), value: email, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.dataFields), value: dataFields, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.email), value: email, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.dataFields), value: dataFields, inDictionary: body)
             expectation1.fulfill()
         }
         

--- a/tests/offline-events-tests/TaskProcessorTests.swift
+++ b/tests/offline-events-tests/TaskProcessorTests.swift
@@ -251,7 +251,7 @@ class TaskProcessorTests: XCTestCase {
     }
 
     private let deviceMetadata = DeviceMetadata(deviceId: IterableUtil.generateUUID(),
-                                                platform: JsonValue.iOS.jsonStringValue,
+                                                platform: JsonValue.iOS,
                                                 appPackageName: Bundle.main.appPackageName ?? "")
 
     private lazy var persistenceProvider: IterablePersistenceContextProvider = {

--- a/tests/offline-events-tests/TaskRunnerTests.swift
+++ b/tests/offline-events-tests/TaskRunnerTests.swift
@@ -330,7 +330,7 @@ class TaskRunnerTests: XCTestCase {
     }
 
     private let deviceMetadata = DeviceMetadata(deviceId: IterableUtil.generateUUID(),
-                                                platform: JsonValue.iOS.jsonStringValue,
+                                                platform: JsonValue.iOS,
                                                 appPackageName: Bundle.main.appPackageName ?? "")
     
     private lazy var persistenceContextProvider: IterablePersistenceContextProvider = {

--- a/tests/offline-events-tests/TaskSchedulerTests.swift
+++ b/tests/offline-events-tests/TaskSchedulerTests.swift
@@ -55,7 +55,7 @@ class TaskSchedulerTests: XCTestCase {
     }
     
     private let deviceMetadata = DeviceMetadata(deviceId: IterableUtil.generateUUID(),
-                                                platform: JsonValue.iOS.jsonStringValue,
+                                                platform: JsonValue.iOS,
                                                 appPackageName: Bundle.main.appPackageName ?? "")
 
     private lazy var persistenceContextProvider: IterablePersistenceContextProvider = {

--- a/tests/swift-sdk-swift-tests/DeprecatedFunctionsTests.swift
+++ b/tests/swift-sdk-swift-tests/DeprecatedFunctionsTests.swift
@@ -93,7 +93,7 @@ class DeprecatedFunctionsTests: XCTestCase {
             
             TestUtils.validateDeviceInfo(inBody: body, withDeviceId: internalAPI.deviceId)
             
-            TestUtils.validateMatch(keyPath: KeyPath(.clickedUrl), value: buttonUrl, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.clickedUrl), value: buttonUrl, inDictionary: body)
             
             expectation1.fulfill()
         }
@@ -110,12 +110,12 @@ class DeprecatedFunctionsTests: XCTestCase {
 
 extension TestUtils {
     static func validateDeprecatedMessageContext(messageId: String, email: String? = nil, userId: String? = nil, saveToInbox: Bool, silentInbox: Bool, inBody body: [String: Any]) {
-        validateMatch(keyPath: KeyPath(JsonKey.messageId), value: messageId, inDictionary: body)
+        validateMatch(keyPath: KeyPath(keys: JsonKey.messageId), value: messageId, inDictionary: body)
         
         validateEmailOrUserId(email: email, userId: userId, inBody: body)
         
-        let contextKey = "\(JsonKey.inAppMessageContext.jsonKey)"
-        validateMatch(keyPath: KeyPath("\(contextKey).\(JsonKey.saveToInbox.jsonKey)"), value: saveToInbox, inDictionary: body)
-        validateMatch(keyPath: KeyPath("\(contextKey).\(JsonKey.silentInbox.jsonKey)"), value: silentInbox, inDictionary: body)
+        let contextKey = "\(JsonKey.inAppMessageContext)"
+        validateMatch(keyPath: KeyPath(string: "\(contextKey).\(JsonKey.saveToInbox)"), value: saveToInbox, inDictionary: body)
+        validateMatch(keyPath: KeyPath(string: "\(contextKey).\(JsonKey.silentInbox)"), value: silentInbox, inDictionary: body)
     }
 }

--- a/tests/swift-sdk-swift-tests/IterableAPIResponseTests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPIResponseTests.swift
@@ -190,7 +190,7 @@ class IterableAPIResponseTests: XCTestCase {
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.sdkPlatform), JsonValue.iOS.jsonStringValue)
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.sdkVersion), IterableAPI.sdkVersion)
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.apiKey), apiKey)
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.contentType.jsonKey), JsonValue.applicationJson.jsonStringValue)
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.contentType), JsonValue.applicationJson.jsonStringValue)
     }
     
     private func verifyAuthTokenInHeader(_ urlRequest: URLRequest, _ authToken: String) {

--- a/tests/swift-sdk-swift-tests/IterableAPIResponseTests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPIResponseTests.swift
@@ -187,14 +187,14 @@ class IterableAPIResponseTests: XCTestCase {
     }
     
     private func verifyIterableHeaders(_ urlRequest: URLRequest) {
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.sdkPlatform), JsonValue.iOS.jsonStringValue)
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.sdkPlatform), JsonValue.iOS)
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.sdkVersion), IterableAPI.sdkVersion)
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.apiKey), apiKey)
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.contentType), JsonValue.applicationJson.jsonStringValue)
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.contentType), JsonValue.applicationJson)
     }
     
     private func verifyAuthTokenInHeader(_ urlRequest: URLRequest, _ authToken: String) {
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.authorization), "\(JsonValue.bearer.rawValue) \(authToken)")
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: JsonKey.Header.authorization), "\(JsonValue.bearer) \(authToken)")
     }
     
     private func createApiClient(networkSession: NetworkSessionProtocol = MockNetworkSession()) -> ApiClient {

--- a/tests/swift-sdk-swift-tests/IterableAPITests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPITests.swift
@@ -115,8 +115,8 @@ class IterableAPITests: XCTestCase {
             let request = networkSession.getRequest(withEndPoint: Const.Path.trackEvent)!
             TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackEvent, queryParams: [])
             let body = request.httpBody!.json() as! [String: Any]
-            TestUtils.validateElementPresent(withName: JsonKey.eventName.jsonKey, andValue: eventName, inDictionary: body)
-            TestUtils.validateElementPresent(withName: JsonKey.email.jsonKey, andValue: IterableAPITests.email, inDictionary: body)
+            TestUtils.validateElementPresent(withName: JsonKey.eventName, andValue: eventName, inDictionary: body)
+            TestUtils.validateElementPresent(withName: JsonKey.email, andValue: IterableAPITests.email, inDictionary: body)
             expectation.fulfill()
         }) { reason, _ in
             expectation.fulfill()
@@ -146,9 +146,9 @@ class IterableAPITests: XCTestCase {
                 return
             }
             TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackEvent, queryParams: [])
-            TestUtils.validateElementPresent(withName: JsonKey.eventName.jsonKey, andValue: eventName, inDictionary: body)
-            TestUtils.validateElementPresent(withName: JsonKey.email.jsonKey, andValue: IterableAPITests.email, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("dataFields"), value: ["key1": "value1", "key2": "value2"], inDictionary: body, message: "data fields did not match")
+            TestUtils.validateElementPresent(withName: JsonKey.eventName, andValue: eventName, inDictionary: body)
+            TestUtils.validateElementPresent(withName: JsonKey.email, andValue: IterableAPITests.email, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "dataFields"), value: ["key1": "value1", "key2": "value2"], inDictionary: body, message: "data fields did not match")
             expectation.fulfill()
         }
         
@@ -207,9 +207,9 @@ class IterableAPITests: XCTestCase {
                 return
             }
             TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.updateUser, queryParams: [])
-            TestUtils.validateElementPresent(withName: JsonKey.email.jsonKey, andValue: IterableAPITests.email, inDictionary: body)
-            TestUtils.validateElementPresent(withName: JsonKey.mergeNestedObjects.jsonKey, andValue: true, inDictionary: body)
-            TestUtils.validateElementPresent(withName: JsonKey.dataFields.jsonKey, andValue: dataFields, inDictionary: body)
+            TestUtils.validateElementPresent(withName: JsonKey.email, andValue: IterableAPITests.email, inDictionary: body)
+            TestUtils.validateElementPresent(withName: JsonKey.mergeNestedObjects, andValue: true, inDictionary: body)
+            TestUtils.validateElementPresent(withName: JsonKey.dataFields, andValue: dataFields, inDictionary: body)
             expectation.fulfill()
         }) { reason, _ in
             if let reason = reason {
@@ -239,10 +239,10 @@ class IterableAPITests: XCTestCase {
                 return
             }
             TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.updateUser, queryParams: [])
-            TestUtils.validateElementPresent(withName: JsonKey.userId.jsonKey, andValue: userId, inDictionary: body)
-            TestUtils.validateElementPresent(withName: JsonKey.preferUserId.jsonKey, andValue: true, inDictionary: body)
-            TestUtils.validateElementPresent(withName: JsonKey.mergeNestedObjects.jsonKey, andValue: true, inDictionary: body)
-            TestUtils.validateElementPresent(withName: JsonKey.dataFields.jsonKey, andValue: dataFields, inDictionary: body)
+            TestUtils.validateElementPresent(withName: JsonKey.userId, andValue: userId, inDictionary: body)
+            TestUtils.validateElementPresent(withName: JsonKey.preferUserId, andValue: true, inDictionary: body)
+            TestUtils.validateElementPresent(withName: JsonKey.mergeNestedObjects, andValue: true, inDictionary: body)
+            TestUtils.validateElementPresent(withName: JsonKey.dataFields, andValue: dataFields, inDictionary: body)
             expectation.fulfill()
         }) { reason, _ in
             if let reason = reason {
@@ -276,8 +276,8 @@ class IterableAPITests: XCTestCase {
                                                        apiEndPoint: Endpoint.api,
                                                        path: Const.Path.updateEmail,
                                                        queryParams: [])
-                                    TestUtils.validateElementPresent(withName: JsonKey.newEmail.jsonKey, andValue: newEmail, inDictionary: body)
-                                    TestUtils.validateElementPresent(withName: JsonKey.currentEmail.jsonKey, andValue: IterableAPITests.email, inDictionary: body)
+                                    TestUtils.validateElementPresent(withName: JsonKey.newEmail, andValue: newEmail, inDictionary: body)
+                                    TestUtils.validateElementPresent(withName: JsonKey.currentEmail, andValue: IterableAPITests.email, inDictionary: body)
                                     XCTAssertEqual(internalAPI.email, newEmail)
                                     expectation.fulfill()
                                 },
@@ -314,8 +314,8 @@ class IterableAPITests: XCTestCase {
                                                        apiEndPoint: Endpoint.api,
                                                        path: Const.Path.updateEmail,
                                                        queryParams: [])
-                                    TestUtils.validateElementPresent(withName: JsonKey.newEmail.jsonKey, andValue: newEmail, inDictionary: body)
-                                    TestUtils.validateElementPresent(withName: JsonKey.currentUserId.jsonKey, andValue: currentUserId, inDictionary: body)
+                                    TestUtils.validateElementPresent(withName: JsonKey.newEmail, andValue: newEmail, inDictionary: body)
+                                    TestUtils.validateElementPresent(withName: JsonKey.currentUserId, andValue: currentUserId, inDictionary: body)
                                     XCTAssertEqual(internalAPI.userId, currentUserId)
                                     XCTAssertNil(internalAPI.email)
                                     expectation.fulfill()
@@ -389,21 +389,21 @@ class IterableAPITests: XCTestCase {
             let body = request.httpBody!.json() as! [String: Any]
             
             TestUtils.validateElementPresent(withName: "email", andValue: "user@example.com", inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("device.applicationName"), value: "my-push-integration", inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("device.platform"), value: JsonValue.apnsSandbox.jsonStringValue, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("device.token"), value: token.hexString(), inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "device.applicationName"), value: "my-push-integration", inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "device.platform"), value: JsonValue.apnsSandbox.jsonStringValue, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "device.token"), value: token.hexString(), inDictionary: body)
             
             // more device fields
             let appPackageName = "iterable.host-app"
             let appVersion = "1.0.0"
             let appBuild = "2"
-            TestUtils.validateExists(keyPath: KeyPath("device.dataFields.deviceId"), type: String.self, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("device.dataFields.appPackageName"), value: appPackageName, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("device.dataFields.appVersion"), value: appVersion, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("device.dataFields.appBuild"), value: appBuild, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("device.dataFields.iterableSdkVersion"), value: IterableAPI.sdkVersion, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("device.dataFields.reactNativeSDKVersion"), value: "x.xx.xxx", inDictionary: body)
-            TestUtils.validateNil(keyPath: KeyPath("device.dataFields.\(attributeToAddAndRemove)"), inDictionary: body)
+            TestUtils.validateExists(keyPath: KeyPath(string: "device.dataFields.deviceId"), type: String.self, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "device.dataFields.appPackageName"), value: appPackageName, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "device.dataFields.appVersion"), value: appVersion, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "device.dataFields.appBuild"), value: appBuild, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "device.dataFields.iterableSdkVersion"), value: IterableAPI.sdkVersion, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "device.dataFields.reactNativeSDKVersion"), value: "x.xx.xxx", inDictionary: body)
+            TestUtils.validateNil(keyPath: KeyPath(string: "device.dataFields.\(attributeToAddAndRemove)"), inDictionary: body)
             
             expectation.fulfill()
         }) { reason, _ in
@@ -464,8 +464,8 @@ class IterableAPITests: XCTestCase {
                                    path: Const.Path.disableDevice,
                                    queryParams: [])
                 
-                TestUtils.validateElementPresent(withName: JsonKey.token.jsonKey, andValue: token.hexString(), inDictionary: body)
-                TestUtils.validateElementPresent(withName: JsonKey.email.jsonKey, andValue: "user@example.com", inDictionary: body)
+                TestUtils.validateElementPresent(withName: JsonKey.token, andValue: token.hexString(), inDictionary: body)
+                TestUtils.validateElementPresent(withName: JsonKey.email, andValue: "user@example.com", inDictionary: body)
                 
                 expectation.fulfill()
             }) { _, _ in
@@ -502,8 +502,8 @@ class IterableAPITests: XCTestCase {
                                    path: Const.Path.disableDevice,
                                    queryParams: [])
                 
-                TestUtils.validateElementPresent(withName: JsonKey.token.jsonKey, andValue: token.hexString(), inDictionary: body)
-                TestUtils.validateElementPresent(withName: JsonKey.email.jsonKey, andValue: "user@example.com", inDictionary: body)
+                TestUtils.validateElementPresent(withName: JsonKey.token, andValue: token.hexString(), inDictionary: body)
+                TestUtils.validateElementPresent(withName: JsonKey.email, andValue: "user@example.com", inDictionary: body)
                 expectation.fulfill()
             }
             internalAPI.disableDeviceForCurrentUser()
@@ -538,9 +538,9 @@ class IterableAPITests: XCTestCase {
                                    path: Const.Path.disableDevice,
                                    queryParams: [])
                 
-                TestUtils.validateElementPresent(withName: JsonKey.token.jsonKey, andValue: token.hexString(), inDictionary: body)
-                TestUtils.validateElementNotPresent(withName: JsonKey.email.jsonKey, inDictionary: body)
-                TestUtils.validateElementNotPresent(withName: JsonKey.userId.jsonKey, inDictionary: body)
+                TestUtils.validateElementPresent(withName: JsonKey.token, andValue: token.hexString(), inDictionary: body)
+                TestUtils.validateElementNotPresent(withName: JsonKey.email, inDictionary: body)
+                TestUtils.validateElementNotPresent(withName: JsonKey.userId, inDictionary: body)
                 expectation.fulfill()
             }) { _, _ in
                 expectation.fulfill()
@@ -577,9 +577,9 @@ class IterableAPITests: XCTestCase {
                                    path: Const.Path.disableDevice,
                                    queryParams: [])
                 
-                TestUtils.validateElementPresent(withName: JsonKey.token.jsonKey, andValue: token.hexString(), inDictionary: body)
-                TestUtils.validateElementNotPresent(withName: JsonKey.email.jsonKey, inDictionary: body)
-                TestUtils.validateElementNotPresent(withName: JsonKey.userId.jsonKey, inDictionary: body)
+                TestUtils.validateElementPresent(withName: JsonKey.token, andValue: token.hexString(), inDictionary: body)
+                TestUtils.validateElementNotPresent(withName: JsonKey.email, inDictionary: body)
+                TestUtils.validateElementNotPresent(withName: JsonKey.userId, inDictionary: body)
                 
                 expectation.fulfill()
             }
@@ -632,7 +632,7 @@ class IterableAPITests: XCTestCase {
                                path: Const.Path.trackPurchase,
                                queryParams: [])
             
-            TestUtils.validateMatch(keyPath: KeyPath("\(JsonKey.Commerce.user).\(JsonKey.userId.jsonKey)"), value: "zeeUserId", inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "\(JsonKey.Commerce.user).\(JsonKey.userId)"), value: "zeeUserId", inDictionary: body)
             TestUtils.validateElementPresent(withName: JsonKey.Commerce.total, andValue: 10.55, inDictionary: body)
             
             expectation.fulfill()
@@ -672,7 +672,7 @@ class IterableAPITests: XCTestCase {
                                path: Const.Path.trackPurchase,
                                queryParams: [])
             
-            TestUtils.validateMatch(keyPath: KeyPath("\(JsonKey.Commerce.user).\(JsonKey.email.jsonKey)"), value: "user@example.com", inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "\(JsonKey.Commerce.user).\(JsonKey.email)"), value: "user@example.com", inDictionary: body)
             TestUtils.validateElementPresent(withName: JsonKey.Commerce.total, andValue: total, inDictionary: body)
             let itemsElement = body[JsonKey.Commerce.items] as! [[AnyHashable: Any]]
             XCTAssertEqual(itemsElement.count, 1)
@@ -712,7 +712,7 @@ class IterableAPITests: XCTestCase {
                 return
             }
             TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackPurchase, queryParams: [])
-            TestUtils.validateMatch(keyPath: KeyPath("\(JsonKey.Commerce.user).\(JsonKey.email.jsonKey)"), value: "user@example.com", inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "\(JsonKey.Commerce.user).\(JsonKey.email)"), value: "user@example.com", inDictionary: body)
             TestUtils.validateElementPresent(withName: JsonKey.Commerce.total, andValue: total, inDictionary: body)
             let itemsElement = body[JsonKey.Commerce.items] as! [[AnyHashable: Any]]
             XCTAssertEqual(itemsElement.count, 1)
@@ -819,7 +819,7 @@ class IterableAPITests: XCTestCase {
                                queryParams: [])
             TestUtils.validateMessageContext(messageId: messageId, email: IterableAPITests.email, saveToInbox: true, silentInbox: true, location: .inbox, inBody: body)
             TestUtils.validateDeviceInfo(inBody: body, withDeviceId: internalAPI.deviceId)
-            TestUtils.validateMatch(keyPath: KeyPath("\(JsonKey.deleteAction.jsonKey)"), value: InAppDeleteSource.deleteButton.jsonValue as! String, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "\(JsonKey.deleteAction)"), value: InAppDeleteSource.deleteButton.jsonValue as! String, inDictionary: body)
             
             expectation1.fulfill()
         }
@@ -859,11 +859,11 @@ class IterableAPITests: XCTestCase {
                                apiEndPoint: Endpoint.api,
                                path: Const.Path.updateSubscriptions,
                                queryParams: [])
-            TestUtils.validateMatch(keyPath: KeyPath(JsonKey.emailListIds.jsonKey), value: emailListIds, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(JsonKey.unsubscribedChannelIds.jsonKey), value: unsubscibedChannelIds, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(JsonKey.unsubscribedMessageTypeIds.jsonKey), value: unsubscribedMessageTypeIds, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(JsonKey.campaignId.jsonKey), value: campaignId, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(JsonKey.templateId.jsonKey), value: templateId, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.emailListIds), value: emailListIds, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.unsubscribedChannelIds), value: unsubscibedChannelIds, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.unsubscribedMessageTypeIds), value: unsubscribedMessageTypeIds, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.campaignId), value: campaignId, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.templateId), value: templateId, inDictionary: body)
             expectation1.fulfill()
         }
         
@@ -967,9 +967,9 @@ class IterableAPITests: XCTestCase {
                 return
             }
             TestUtils.validate(request: request, apiEndPoint: Endpoint.api, path: Const.Path.trackEvent)
-            TestUtils.validateMatch(keyPath: KeyPath("campaignId"), value: 1234, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("templateId"), value: 4321, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("messageId"), value: messageId, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "campaignId"), value: 1234, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "templateId"), value: 4321, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "messageId"), value: messageId, inDictionary: body)
             expectation1.fulfill()
         }
         internalAPI.trackPushOpen(userInfo)
@@ -1000,11 +1000,11 @@ class IterableAPITests: XCTestCase {
                 return
             }
             TestUtils.validate(request: request, apiEndPoint: Endpoint.api, path: Const.Path.trackEvent)
-            TestUtils.validateMatch(keyPath: KeyPath("campaignId"), value: 1234, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("templateId"), value: 4321, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("messageId"), value: messageId, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "campaignId"), value: 1234, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "templateId"), value: 4321, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "messageId"), value: messageId, inDictionary: body)
             let dataFields: [String: AnyHashable] = ["appAlreadyRunning": false, "key1": "value1"]
-            TestUtils.validateMatch(keyPath: KeyPath("dataFields"), value: dataFields, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "dataFields"), value: dataFields, inDictionary: body)
             expectation1.fulfill()
         }
         internalAPI.trackPushOpen(userInfo, dataFields: ["key1": "value1"])
@@ -1036,11 +1036,11 @@ class IterableAPITests: XCTestCase {
                 return
             }
             TestUtils.validate(request: request, apiEndPoint: Endpoint.api, path: Const.Path.trackEvent)
-            TestUtils.validateMatch(keyPath: KeyPath("campaignId"), value: 1234, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("templateId"), value: 4321, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("messageId"), value: messageId, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "campaignId"), value: 1234, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "templateId"), value: 4321, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "messageId"), value: messageId, inDictionary: body)
             let dataFields: [String: AnyHashable] = ["appAlreadyRunning": false, "key1": "value1"]
-            TestUtils.validateMatch(keyPath: KeyPath("dataFields"), value: dataFields, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "dataFields"), value: dataFields, inDictionary: body)
             expectation1.fulfill()
         }, onFailure: nil)
         
@@ -1062,11 +1062,11 @@ class IterableAPITests: XCTestCase {
                 return
             }
             TestUtils.validate(request: request, apiEndPoint: Endpoint.api, path: Const.Path.trackEvent)
-            TestUtils.validateMatch(keyPath: KeyPath("campaignId"), value: 1234, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("templateId"), value: 4321, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("messageId"), value: messageId, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "campaignId"), value: 1234, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "templateId"), value: 4321, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "messageId"), value: messageId, inDictionary: body)
             let dataFields: [String: AnyHashable] = ["appAlreadyRunning": true, "key1": "value1"]
-            TestUtils.validateMatch(keyPath: KeyPath("dataFields"), value: dataFields, inDictionary: body, message: "dataFields did not match")
+            TestUtils.validateMatch(keyPath: KeyPath(string: "dataFields"), value: dataFields, inDictionary: body, message: "dataFields did not match")
             expectation1.fulfill()
         }
         internalAPI.trackPushOpen(1234, templateId: 4321, messageId: messageId, appAlreadyRunning: true, dataFields: ["key1": "value1"])
@@ -1095,11 +1095,11 @@ class IterableAPITests: XCTestCase {
                                         return
                                     }
                                     TestUtils.validate(request: request, apiEndPoint: Endpoint.api, path: Const.Path.trackEvent)
-                                    TestUtils.validateMatch(keyPath: KeyPath("campaignId"), value: 1234, inDictionary: body)
-                                    TestUtils.validateMatch(keyPath: KeyPath("templateId"), value: 4321, inDictionary: body)
-                                    TestUtils.validateMatch(keyPath: KeyPath("messageId"), value: messageId, inDictionary: body)
+                                    TestUtils.validateMatch(keyPath: KeyPath(string: "campaignId"), value: 1234, inDictionary: body)
+                                    TestUtils.validateMatch(keyPath: KeyPath(string: "templateId"), value: 4321, inDictionary: body)
+                                    TestUtils.validateMatch(keyPath: KeyPath(string: "messageId"), value: messageId, inDictionary: body)
                                     let dataFields: [String: AnyHashable] = ["appAlreadyRunning": true, "key1": "value1"]
-                                    TestUtils.validateMatch(keyPath: KeyPath("dataFields"), value: dataFields, inDictionary: body, message: "dataFields did not match")
+                                    TestUtils.validateMatch(keyPath: KeyPath(string: "dataFields"), value: dataFields, inDictionary: body, message: "dataFields did not match")
                                     expectation1.fulfill()
                                   },
                                   onFailure: nil)

--- a/tests/swift-sdk-swift-tests/IterableAPITests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAPITests.swift
@@ -390,7 +390,7 @@ class IterableAPITests: XCTestCase {
             
             TestUtils.validateElementPresent(withName: "email", andValue: "user@example.com", inDictionary: body)
             TestUtils.validateMatch(keyPath: KeyPath(string: "device.applicationName"), value: "my-push-integration", inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(string: "device.platform"), value: JsonValue.apnsSandbox.jsonStringValue, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "device.platform"), value: JsonValue.apnsSandbox, inDictionary: body)
             TestUtils.validateMatch(keyPath: KeyPath(string: "device.token"), value: token.hexString(), inDictionary: body)
             
             // more device fields

--- a/tests/swift-sdk-swift-tests/IterableAutoRegistrationTests.swift
+++ b/tests/swift-sdk-swift-tests/IterableAutoRegistrationTests.swift
@@ -33,7 +33,7 @@ class IterableAutoRegistrationTests: XCTestCase {
                 // First call, API call to register endpoint
                 expectation1.fulfill()
                 TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.registerDeviceToken, queryParams: [])
-                TestUtils.validateMatch(keyPath: KeyPath("device.dataFields.notificationsEnabled"), value: false, inDictionary: body)
+                TestUtils.validateMatch(keyPath: KeyPath(string: "device.dataFields.notificationsEnabled"), value: false, inDictionary: body)
             }
 
             if let (request, body) = TestUtils.matchingRequest(networkSession: networkSession,
@@ -42,8 +42,8 @@ class IterableAutoRegistrationTests: XCTestCase {
                 // Second call, API call to disable endpoint
                 expectation3.fulfill()
                 TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.disableDevice, queryParams: [])
-                TestUtils.validateElementPresent(withName: JsonKey.token.jsonKey, andValue: token.hexString(), inDictionary: body)
-                TestUtils.validateElementPresent(withName: JsonKey.email.jsonKey, andValue: "user1@example.com", inDictionary: body)
+                TestUtils.validateElementPresent(withName: JsonKey.token, andValue: token.hexString(), inDictionary: body)
+                TestUtils.validateElementPresent(withName: JsonKey.email, andValue: "user1@example.com", inDictionary: body)
             }
         }
 

--- a/tests/swift-sdk-swift-tests/IterableNotificationResponseTests.swift
+++ b/tests/swift-sdk-swift-tests/IterableNotificationResponseTests.swift
@@ -64,7 +64,7 @@ class IterableNotificationResponseTests: XCTestCase {
         XCTAssertEqual(pushTracker.messageId, messageId)
         XCTAssertFalse(pushTracker.appAlreadyRunnnig)
         
-        XCTAssertEqual(pushTracker.dataFields?[JsonKey.actionIdentifier.jsonKey] as? String, JsonValue.ActionIdentifier.pushOpenDefault)
+        XCTAssertEqual(pushTracker.dataFields?[JsonKey.actionIdentifier] as? String, JsonValue.ActionIdentifier.pushOpenDefault)
     }
     
     func testActionButtonDismiss() {
@@ -111,7 +111,7 @@ class IterableNotificationResponseTests: XCTestCase {
         XCTAssertEqual(pushTracker.templateId, 4321)
         XCTAssertEqual(pushTracker.messageId, messageId)
         
-        XCTAssertEqual(pushTracker.dataFields?[JsonKey.actionIdentifier.jsonKey] as? String, "buttonIdentifier")
+        XCTAssertEqual(pushTracker.dataFields?[JsonKey.actionIdentifier] as? String, "buttonIdentifier")
     }
     
     func testForegroundPushActionBeforeiOS10() {

--- a/tests/swift-sdk-swift-tests/RegistrationTests.swift
+++ b/tests/swift-sdk-swift-tests/RegistrationTests.swift
@@ -35,28 +35,28 @@ class RegistrationTests: XCTestCase {
         internalAPI.register(token: token, onSuccess: { _ in
             let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
             let body = request.httpBody!.json() as! [String: Any]
-            TestUtils.validateMatch(keyPath: KeyPath(.email), value: "user@example.com", inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .applicationName), value: "my-push-integration", inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .platform), value: JsonValue.apnsProduction.jsonValue as! String, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .token), value: token.hexString(), inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.email), value: "user@example.com", inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.applicationName), value: "my-push-integration", inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.platform), value: JsonValue.apnsProduction.jsonValue as! String, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.token), value: token.hexString(), inDictionary: body)
             
             // device dictionary
             let appPackageName = TestUtils.appPackageName
             let appVersion = TestUtils.appVersion
             let appBuild = TestUtils.appBuild
-            TestUtils.validateExists(keyPath: KeyPath(.device, .dataFields, .identifierForVendor), type: String.self, inDictionary: body)
-            TestUtils.validateExists(keyPath: KeyPath(.device, .dataFields, .deviceId), type: String.self, inDictionary: body)
-            TestUtils.validateExists(keyPath: KeyPath(.device, .dataFields, .localizedModel), type: String.self, inDictionary: body)
-            TestUtils.validateExists(keyPath: KeyPath(.device, .dataFields, .userInterfaceIdiom), type: String.self, inDictionary: body)
-            TestUtils.validateExists(keyPath: KeyPath(.device, .dataFields, .systemName), type: String.self, inDictionary: body)
-            TestUtils.validateExists(keyPath: KeyPath(.device, .dataFields, .systemVersion), type: String.self, inDictionary: body)
-            TestUtils.validateExists(keyPath: KeyPath(.device, .dataFields, .model), type: String.self, inDictionary: body)
+            TestUtils.validateExists(keyPath: KeyPath(keys: JsonKey.device, JsonKey.dataFields, JsonKey.identifierForVendor), type: String.self, inDictionary: body)
+            TestUtils.validateExists(keyPath: KeyPath(keys: JsonKey.device, JsonKey.dataFields, JsonKey.deviceId), type: String.self, inDictionary: body)
+            TestUtils.validateExists(keyPath: KeyPath(keys: JsonKey.device, JsonKey.dataFields, JsonKey.localizedModel), type: String.self, inDictionary: body)
+            TestUtils.validateExists(keyPath: KeyPath(keys: JsonKey.device, JsonKey.dataFields, JsonKey.userInterfaceIdiom), type: String.self, inDictionary: body)
+            TestUtils.validateExists(keyPath: KeyPath(keys: JsonKey.device, JsonKey.dataFields, JsonKey.systemName), type: String.self, inDictionary: body)
+            TestUtils.validateExists(keyPath: KeyPath(keys: JsonKey.device, JsonKey.dataFields, JsonKey.systemVersion), type: String.self, inDictionary: body)
+            TestUtils.validateExists(keyPath: KeyPath(keys: JsonKey.device, JsonKey.dataFields, JsonKey.model), type: String.self, inDictionary: body)
             
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .dataFields, .iterableSdkVersion), value: IterableAPI.sdkVersion, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .dataFields, .appPackageName), value: appPackageName, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .dataFields, .appVersion), value: appVersion, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .dataFields, .appBuild), value: appBuild, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .dataFields, .notificationsEnabled), value: true, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.dataFields, JsonKey.iterableSdkVersion), value: IterableAPI.sdkVersion, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.dataFields, JsonKey.appPackageName), value: appPackageName, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.dataFields, JsonKey.appVersion), value: appVersion, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.dataFields, JsonKey.appBuild), value: appBuild, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.dataFields, JsonKey.notificationsEnabled), value: true, inDictionary: body)
             expectation.fulfill()
         }) { reason, _ in
             // failure
@@ -85,8 +85,8 @@ class RegistrationTests: XCTestCase {
         internalAPI.register(token: token, onSuccess: { _ in
             let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
             let body = request.httpBody!.json() as! [String: Any]
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .applicationName), value: config.sandboxPushIntegrationName, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .platform), value: JsonValue.apnsSandbox.jsonValue as! String, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.applicationName), value: config.sandboxPushIntegrationName, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.platform), value: JsonValue.apnsSandbox.jsonValue as! String, inDictionary: body)
             expectation.fulfill()
         }) { reason, _ in
             // failure
@@ -115,8 +115,8 @@ class RegistrationTests: XCTestCase {
         internalAPI.register(token: token, onSuccess: { _ in
             let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
             let body = request.httpBody!.json() as! [String: Any]
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .applicationName), value: config.sandboxPushIntegrationName, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .platform), value: JsonValue.apnsSandbox.jsonValue as! String, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.applicationName), value: config.sandboxPushIntegrationName, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.platform), value: JsonValue.apnsSandbox.jsonValue as! String, inDictionary: body)
             expectation.fulfill()
         }) { reason, _ in
             // failure
@@ -145,8 +145,8 @@ class RegistrationTests: XCTestCase {
         internalAPI.register(token: token, onSuccess: { _ in
             let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
             let body = request.httpBody!.json() as! [String: Any]
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .applicationName), value: config.pushIntegrationName, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .platform), value: JsonValue.apnsProduction.jsonValue as! String, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.applicationName), value: config.pushIntegrationName, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.platform), value: JsonValue.apnsProduction.jsonValue as! String, inDictionary: body)
             expectation.fulfill()
         }) { reason, _ in
             // failure
@@ -173,8 +173,8 @@ class RegistrationTests: XCTestCase {
         internalAPI.register(token: token, onSuccess: { _ in
             let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
             let body = request.httpBody!.json() as! [String: Any]
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .applicationName), value: TestUtils.appPackageName, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .platform), value: JsonValue.apnsSandbox.jsonValue as! String, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.applicationName), value: TestUtils.appPackageName, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.platform), value: JsonValue.apnsSandbox.jsonValue as! String, inDictionary: body)
             expectation.fulfill()
         }) { reason, _ in
             // failure
@@ -201,8 +201,8 @@ class RegistrationTests: XCTestCase {
         internalAPI.register(token: token, onSuccess: { _ in
             let request = networkSession.getRequest(withEndPoint: Const.Path.registerDeviceToken)!
             let body = request.httpBody!.json() as! [String: Any]
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .applicationName), value: TestUtils.appPackageName, inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath(.device, .platform), value: JsonValue.apnsProduction.jsonValue as! String, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.applicationName), value: TestUtils.appPackageName, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.device, JsonKey.platform), value: JsonValue.apnsProduction.jsonValue as! String, inDictionary: body)
             expectation.fulfill()
         }) { reason, _ in
             // failure

--- a/tests/swift-sdk-swift-tests/RequestCreatorTests.swift
+++ b/tests/swift-sdk-swift-tests/RequestCreatorTests.swift
@@ -28,14 +28,14 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validate(request: urlRequest, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackInboxSession)
         
         let body = urlRequest.bodyDict
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.email), value: auth.email, inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.inboxSessionId), value: inboxSession.id, inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.inboxSessionStart), value: IterableUtil.int(fromDate: startDate), inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.inboxSessionEnd), value: IterableUtil.int(fromDate: endDate), inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.startTotalMessageCount), value: inboxSession.startTotalMessageCount, inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.startUnreadMessageCount), value: inboxSession.startUnreadMessageCount, inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.endTotalMessageCount), value: inboxSession.endTotalMessageCount, inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.endUnreadMessageCount), value: inboxSession.endUnreadMessageCount, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.email), value: auth.email, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.inboxSessionId), value: inboxSession.id, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.inboxSessionStart), value: IterableUtil.int(fromDate: startDate), inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.inboxSessionEnd), value: IterableUtil.int(fromDate: endDate), inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.startTotalMessageCount), value: inboxSession.startTotalMessageCount, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.startUnreadMessageCount), value: inboxSession.startUnreadMessageCount, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.endTotalMessageCount), value: inboxSession.endTotalMessageCount, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.endUnreadMessageCount), value: inboxSession.endUnreadMessageCount, inDictionary: body)
         
         TestUtils.validateDeviceInfo(inBody: body, withDeviceId: deviceMetadata.deviceId)
         
@@ -57,10 +57,10 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validate(request: request1, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackInAppOpen)
         
         let body1 = request1.bodyDict
-        TestUtils.validateMatch(keyPath: KeyPath(.email), value: email, inDictionary: body1)
-        TestUtils.validateMatch(keyPath: KeyPath(.messageId), value: messageId, inDictionary: body1)
-        TestUtils.validateMatch(keyPath: KeyPath(.inboxSessionId), value: inboxSessionId, inDictionary: body1)
-        TestUtils.validateMatch(keyPath: KeyPath(locationKeyPath), value: locValue, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.email), value: email, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.messageId), value: messageId, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.inboxSessionId), value: inboxSessionId, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(string: locationKeyPath), value: locValue, inDictionary: body1)
         
         let messageContext2 = InAppMessageContext.from(message: message, location: location)
         let request2 = convertToUrlRequest(createRequestCreator().createTrackInAppOpenRequest(inAppMessageContext: messageContext2))
@@ -68,10 +68,10 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validate(request: request2, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackInAppOpen)
         
         let body2 = request2.bodyDict
-        TestUtils.validateMatch(keyPath: KeyPath(.email), value: email, inDictionary: body2)
-        TestUtils.validateMatch(keyPath: KeyPath(.messageId), value: messageId, inDictionary: body2)
-        TestUtils.validateNil(keyPath: KeyPath(.inboxSessionId), inDictionary: body2)
-        TestUtils.validateMatch(keyPath: KeyPath(locationKeyPath), value: locValue, inDictionary: body2)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.email), value: email, inDictionary: body2)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.messageId), value: messageId, inDictionary: body2)
+        TestUtils.validateNil(keyPath: KeyPath(keys: JsonKey.inboxSessionId), inDictionary: body2)
+        TestUtils.validateMatch(keyPath: KeyPath(string: locationKeyPath), value: locValue, inDictionary: body2)
     }
     
     func testTrackInAppClickRequest() {
@@ -90,11 +90,11 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validate(request: request1, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackInAppClick)
         
         let body1 = request1.bodyDict
-        TestUtils.validateMatch(keyPath: KeyPath(.email), value: email, inDictionary: body1)
-        TestUtils.validateMatch(keyPath: KeyPath(.messageId), value: messageId, inDictionary: body1)
-        TestUtils.validateMatch(keyPath: KeyPath(.inboxSessionId), value: inboxSessionId, inDictionary: body1)
-        TestUtils.validateMatch(keyPath: KeyPath(.clickedUrl), value: clickedUrl, inDictionary: body1)
-        TestUtils.validateMatch(keyPath: KeyPath(locationKeyPath), value: inboxLocValue, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.email), value: email, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.messageId), value: messageId, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.inboxSessionId), value: inboxSessionId, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.clickedUrl), value: clickedUrl, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(string: locationKeyPath), value: inboxLocValue, inDictionary: body1)
         
         let messageContext2 = InAppMessageContext.from(message: message, location: inboxLoc)
         let request2 = convertToUrlRequest(createRequestCreator().createTrackInAppClickRequest(inAppMessageContext: messageContext2, clickedUrl: clickedUrl))
@@ -102,11 +102,11 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validate(request: request2, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackInAppClick)
         
         let body2 = request2.bodyDict
-        TestUtils.validateMatch(keyPath: KeyPath(.email), value: email, inDictionary: body2)
-        TestUtils.validateMatch(keyPath: KeyPath(.messageId), value: messageId, inDictionary: body2)
-        TestUtils.validateNil(keyPath: KeyPath(.inboxSessionId), inDictionary: body2)
-        TestUtils.validateMatch(keyPath: KeyPath(.clickedUrl), value: clickedUrl, inDictionary: body2)
-        TestUtils.validateMatch(keyPath: KeyPath(locationKeyPath), value: inboxLocValue, inDictionary: body2)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.email), value: email, inDictionary: body2)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.messageId), value: messageId, inDictionary: body2)
+        TestUtils.validateNil(keyPath: KeyPath(keys: JsonKey.inboxSessionId), inDictionary: body2)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.clickedUrl), value: clickedUrl, inDictionary: body2)
+        TestUtils.validateMatch(keyPath: KeyPath(string: locationKeyPath), value: inboxLocValue, inDictionary: body2)
     }
     
     func testTrackInAppCloseRequest() {
@@ -128,11 +128,11 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validate(request: request1, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackInAppClose)
         
         let body1 = request1.bodyDict
-        TestUtils.validateMatch(keyPath: KeyPath(.email), value: email, inDictionary: body1)
-        TestUtils.validateMatch(keyPath: KeyPath(.messageId), value: messageId, inDictionary: body1)
-        TestUtils.validateMatch(keyPath: KeyPath(.inboxSessionId), value: inboxSessionId, inDictionary: body1)
-        TestUtils.validateMatch(keyPath: KeyPath(.clickedUrl), value: clickedUrl, inDictionary: body1)
-        TestUtils.validateMatch(keyPath: KeyPath(locationKeyPath), value: inboxLocValue, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.email), value: email, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.messageId), value: messageId, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.inboxSessionId), value: inboxSessionId, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.clickedUrl), value: clickedUrl, inDictionary: body1)
+        TestUtils.validateMatch(keyPath: KeyPath(string: locationKeyPath), value: inboxLocValue, inDictionary: body1)
         
         let messageContext2 = InAppMessageContext.from(message: message, location: inAppLoc)
         let request2 = convertToUrlRequest(createRequestCreator().createTrackInAppCloseRequest(inAppMessageContext: messageContext2, source: .link, clickedUrl: nil))
@@ -140,11 +140,11 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validate(request: request2, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackInAppClose)
         
         let body2 = request2.bodyDict
-        TestUtils.validateMatch(keyPath: KeyPath(.email), value: email, inDictionary: body2)
-        TestUtils.validateMatch(keyPath: KeyPath(.messageId), value: messageId, inDictionary: body2)
-        TestUtils.validateNil(keyPath: KeyPath(.inboxSessionId), inDictionary: body2)
-        TestUtils.validateNil(keyPath: KeyPath(.clickedUrl), inDictionary: body2)
-        TestUtils.validateMatch(keyPath: KeyPath(locationKeyPath), value: inAppLocValue, inDictionary: body2)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.email), value: email, inDictionary: body2)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.messageId), value: messageId, inDictionary: body2)
+        TestUtils.validateNil(keyPath: KeyPath(keys: JsonKey.inboxSessionId), inDictionary: body2)
+        TestUtils.validateNil(keyPath: KeyPath(keys: JsonKey.clickedUrl), inDictionary: body2)
+        TestUtils.validateMatch(keyPath: KeyPath(string: locationKeyPath), value: inAppLocValue, inDictionary: body2)
     }
     
     func testGetInAppMessagesRequestFailure() {
@@ -172,10 +172,10 @@ class RequestCreatorTests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(args[JsonKey.email.jsonKey], auth.email)
+        XCTAssertEqual(args[JsonKey.email], auth.email)
         XCTAssertEqual(args[JsonKey.InApp.packageName], Bundle.main.appPackageName)
         XCTAssertEqual(args[JsonKey.InApp.count], inAppMessageRequestCount.stringValue)
-        XCTAssertEqual(args[JsonKey.systemVersion.jsonKey], UIDevice.current.systemVersion)
+        XCTAssertEqual(args[JsonKey.systemVersion], UIDevice.current.systemVersion)
     }
     
     func testTrackEventRequest() {
@@ -187,8 +187,8 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackEvent)
         
         let body = request.bodyDict
-        TestUtils.validateMatch(keyPath: KeyPath(.eventName), value: eventName, inDictionary: body)
-        TestUtils.validateNil(keyPath: KeyPath(.dataFields), inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.eventName), value: eventName, inDictionary: body)
+        TestUtils.validateNil(keyPath: KeyPath(keys: JsonKey.dataFields), inDictionary: body)
     }
     
     func testTrackInAppDeliveryRequest() {
@@ -203,8 +203,8 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackInAppDelivery)
         
         let body = request.bodyDict
-        TestUtils.validateMatch(keyPath: KeyPath(.email), value: email, inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(.messageId), value: messageId, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.email), value: email, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.messageId), value: messageId, inDictionary: body)
         TestUtils.validateDeviceInfo(inBody: body, withDeviceId: deviceMetadata.deviceId)
     }
     
@@ -216,7 +216,7 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validateHeader(request, apiKey)
         TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.inAppConsume)
         
-        TestUtils.validateMatch(keyPath: KeyPath(.messageId), value: messageId, inDictionary: request.bodyDict)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.messageId), value: messageId, inDictionary: request.bodyDict)
     }
     
     func testUpdateSubscriptionsRequest() {
@@ -238,12 +238,12 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.updateSubscriptions)
         
         let body = request.bodyDict
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.emailListIds.jsonKey), value: emailListIds, inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.unsubscribedChannelIds.jsonKey), value: unsubscriptedChannelIds, inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.unsubscribedMessageTypeIds.jsonKey), value: unsubscribedMessageTypeIds, inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.subscribedMessageTypeIds.jsonKey), value: subscribedMessageTypeIds, inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.campaignId.jsonKey), value: campaignId, inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.templateId.jsonKey), value: templateId, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.emailListIds), value: emailListIds, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.unsubscribedChannelIds), value: unsubscriptedChannelIds, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.unsubscribedMessageTypeIds), value: unsubscribedMessageTypeIds, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.subscribedMessageTypeIds), value: subscribedMessageTypeIds, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.campaignId), value: campaignId, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.templateId), value: templateId, inDictionary: body)
     }
     
     func testUserlessUpdateUserRequest() {
@@ -341,8 +341,8 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validate(request: urlRequest, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.registerDeviceToken)
         
         let body = urlRequest.bodyDict
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.userId), value: userIdAuth.userId, inDictionary: body)
-        TestUtils.validateMatch(keyPath: KeyPath(JsonKey.preferUserId), value: true, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.userId), value: userIdAuth.userId, inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.preferUserId), value: true, inDictionary: body)
     }
     
     func testProcessorTypeOfflineInHeader() throws {
@@ -361,15 +361,15 @@ class RequestCreatorTests: XCTestCase {
         TestUtils.validate(request: request, requestType: .post, apiEndPoint: Endpoint.api, path: Const.Path.trackEvent)
         
         let body = request.bodyDict
-        TestUtils.validateMatch(keyPath: KeyPath(.eventName), value: eventName, inDictionary: body)
-        TestUtils.validateNil(keyPath: KeyPath(.dataFields), inDictionary: body)
+        TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.eventName), value: eventName, inDictionary: body)
+        TestUtils.validateNil(keyPath: KeyPath(keys: JsonKey.dataFields), inDictionary: body)
     }
 
     private let apiKey = "zee-api-key"
     
     private let email = "user@example.com"
     
-    private let locationKeyPath = "\(JsonKey.inAppMessageContext.jsonKey).\(JsonKey.inAppLocation.jsonKey)"
+    private let locationKeyPath = "\(JsonKey.inAppMessageContext).\(JsonKey.inAppLocation)"
     
     private let userlessAuth = Auth(userId: nil, email: nil, authToken: nil)
     

--- a/tests/swift-sdk-swift-tests/RequestCreatorTests.swift
+++ b/tests/swift-sdk-swift-tests/RequestCreatorTests.swift
@@ -376,7 +376,7 @@ class RequestCreatorTests: XCTestCase {
     private let userIdAuth = Auth(userId: "ein", email: nil, authToken: nil)
     
     private let deviceMetadata = DeviceMetadata(deviceId: IterableUtil.generateUUID(),
-                                                platform: JsonValue.iOS.jsonStringValue,
+                                                platform: JsonValue.iOS,
                                                 appPackageName: Bundle.main.appPackageName ?? "")
     private let dateProvider = MockDateProvider()
     

--- a/tests/swift-sdk-swift-tests/TestInAppPayloadGenerator.swift
+++ b/tests/swift-sdk-swift-tests/TestInAppPayloadGenerator.swift
@@ -72,10 +72,10 @@ struct TestInAppPayloadGenerator {
             dict["trigger"] = trigger.dict
         }
         if saveToInbox {
-            dict[JsonKey.saveToInbox.jsonKey] = true
-            dict[JsonKey.inboxMetadata.jsonKey] = [
-                JsonKey.inboxTitle.jsonKey: "title\(index)",
-                JsonKey.inboxSubtitle.jsonKey: "subTitle\(index)",
+            dict[JsonKey.saveToInbox] = true
+            dict[JsonKey.inboxMetadata] = [
+                JsonKey.inboxTitle: "title\(index)",
+                JsonKey.inboxSubtitle: "subTitle\(index)",
             ]
         }
         return dict

--- a/tests/swift-sdk-swift-tests/TestUtils.swift
+++ b/tests/swift-sdk-swift-tests/TestUtils.swift
@@ -74,8 +74,8 @@ struct TestUtils {
             return
         }
         
-        XCTAssertEqual(header[JsonKey.contentType], JsonValue.applicationJson.jsonStringValue)
-        XCTAssertEqual(header[JsonKey.Header.sdkPlatform], JsonValue.iOS.jsonStringValue)
+        XCTAssertEqual(header[JsonKey.contentType], JsonValue.applicationJson)
+        XCTAssertEqual(header[JsonKey.Header.sdkPlatform], JsonValue.iOS)
         XCTAssertEqual(header[JsonKey.Header.sdkVersion], IterableAPI.sdkVersion)
         XCTAssertEqual(header[JsonKey.Header.apiKey], apiKey)
         XCTAssertEqual(header[JsonKey.Header.requestProcessor], processorType == .online ? "Online" : "Offline")
@@ -108,7 +108,7 @@ struct TestUtils {
     
     static func validateDeviceInfo(inBody body: [String: Any], withDeviceId deviceId: String) {
         validateMatch(keyPath: KeyPath(keys: JsonKey.deviceInfo, JsonKey.deviceId), value: deviceId, inDictionary: body)
-        validateMatch(keyPath: KeyPath(keys: JsonKey.deviceInfo, JsonKey.platform), value: JsonValue.iOS.jsonStringValue, inDictionary: body)
+        validateMatch(keyPath: KeyPath(keys: JsonKey.deviceInfo, JsonKey.platform), value: JsonValue.iOS, inDictionary: body)
         validateMatch(keyPath: KeyPath(keys: JsonKey.deviceInfo, JsonKey.appPackageName), value: Bundle.main.appPackageName, inDictionary: body)
     }
 

--- a/tests/swift-sdk-swift-tests/TestUtils.swift
+++ b/tests/swift-sdk-swift-tests/TestUtils.swift
@@ -74,7 +74,7 @@ struct TestUtils {
             return
         }
         
-        XCTAssertEqual(header[JsonKey.contentType.jsonKey], JsonValue.applicationJson.jsonStringValue)
+        XCTAssertEqual(header[JsonKey.contentType], JsonValue.applicationJson.jsonStringValue)
         XCTAssertEqual(header[JsonKey.Header.sdkPlatform], JsonValue.iOS.jsonStringValue)
         XCTAssertEqual(header[JsonKey.Header.sdkVersion], IterableAPI.sdkVersion)
         XCTAssertEqual(header[JsonKey.Header.apiKey], apiKey)
@@ -83,33 +83,33 @@ struct TestUtils {
     
     static func validateEmailOrUserId(email: String? = nil, userId: String? = nil, inBody body: [String: Any]) {
         if let email = email {
-            validateMatch(keyPath: KeyPath(JsonKey.email), value: email, inDictionary: body)
+            validateMatch(keyPath: KeyPath(keys: JsonKey.email), value: email, inDictionary: body)
         }
         
         if let userId = userId {
-            validateMatch(keyPath: KeyPath(JsonKey.userId), value: userId, inDictionary: body)
+            validateMatch(keyPath: KeyPath(keys: JsonKey.userId), value: userId, inDictionary: body)
         }
     }
     
     static func validateMessageContext(messageId: String, email: String? = nil, userId: String? = nil, saveToInbox: Bool, silentInbox: Bool, location: InAppLocation?, inBody body: [String: Any]) {
-        validateMatch(keyPath: KeyPath(JsonKey.messageId), value: messageId, inDictionary: body)
+        validateMatch(keyPath: KeyPath(keys: JsonKey.messageId), value: messageId, inDictionary: body)
         
         validateEmailOrUserId(email: email, userId: userId, inBody: body)
         
-        let contextKey = "\(JsonKey.inAppMessageContext.jsonKey)"
-        validateMatch(keyPath: KeyPath("\(contextKey).\(JsonKey.saveToInbox.jsonKey)"), value: saveToInbox, inDictionary: body)
-        validateMatch(keyPath: KeyPath("\(contextKey).\(JsonKey.silentInbox.jsonKey)"), value: silentInbox, inDictionary: body)
+        let contextKey = "\(JsonKey.inAppMessageContext)"
+        validateMatch(keyPath: KeyPath(string: "\(contextKey).\(JsonKey.saveToInbox)"), value: saveToInbox, inDictionary: body)
+        validateMatch(keyPath: KeyPath(string: "\(contextKey).\(JsonKey.silentInbox)"), value: silentInbox, inDictionary: body)
         if let location = location {
-            validateMatch(keyPath: KeyPath("\(contextKey).\(JsonKey.inAppLocation.jsonKey)"), value: location.jsonValue as! String, inDictionary: body)
+            validateMatch(keyPath: KeyPath(string: "\(contextKey).\(JsonKey.inAppLocation)"), value: location.jsonValue as! String, inDictionary: body)
         } else {
-            XCTAssertNil(body[keyPath: KeyPath("\(contextKey).\(JsonKey.inAppLocation.jsonKey)")])
+            XCTAssertNil(body[keyPath: KeyPath(string: "\(contextKey).\(JsonKey.inAppLocation)")])
         }
     }
     
     static func validateDeviceInfo(inBody body: [String: Any], withDeviceId deviceId: String) {
-        validateMatch(keyPath: KeyPath(.deviceInfo, .deviceId), value: deviceId, inDictionary: body)
-        validateMatch(keyPath: KeyPath(.deviceInfo, .platform), value: JsonValue.iOS.jsonStringValue, inDictionary: body)
-        validateMatch(keyPath: KeyPath(.deviceInfo, .appPackageName), value: Bundle.main.appPackageName, inDictionary: body)
+        validateMatch(keyPath: KeyPath(keys: JsonKey.deviceInfo, JsonKey.deviceId), value: deviceId, inDictionary: body)
+        validateMatch(keyPath: KeyPath(keys: JsonKey.deviceInfo, JsonKey.platform), value: JsonValue.iOS.jsonStringValue, inDictionary: body)
+        validateMatch(keyPath: KeyPath(keys: JsonKey.deviceInfo, JsonKey.appPackageName), value: Bundle.main.appPackageName, inDictionary: body)
     }
 
     static func areEqual(dict1: [AnyHashable: Any], dict2: [AnyHashable: Any]) -> Bool {
@@ -197,15 +197,15 @@ struct TestUtils {
 struct KeyPath {
     let segments: [String]
     
-    init(_ string: String) {
+    init(string: String) {
         segments = string.components(separatedBy: ".")
     }
-    
-    init(_ jsonKeys: JsonKey...) {
-        segments = jsonKeys.map { $0.jsonKey }
+
+    init(keys: String...) {
+        segments = keys.map { $0 }
     }
-    
-    init(segments: [String]) {
+
+    private init(segments: [String]) {
         self.segments = segments
     }
     
@@ -221,33 +221,16 @@ struct KeyPath {
     }
 }
 
-protocol StringKey {
-    init(string: String)
-}
-
-extension String: StringKey {
-    init(string: String) {
-        self = string
-    }
-}
-
-extension JsonKey: StringKey {
-    init(string: String) {
-        self = JsonKey(rawValue: string)!
-    }
-}
-
-extension Dictionary where Key: StringKey {
+extension Dictionary where Key == String {
     subscript(keyPath keyPath: KeyPath) -> Any? {
         switch keyPath.firstAndRest() {
         case nil:
             return nil
         case let (first, rest)? where rest.isEmpty:
             // nothing else left
-            return self[Key(string: first)]
+            return self[first]
         case let (first, rest)?:
-            let key = Key(string: first)
-            if let value = self[key] as? [Key: Any] {
+            if let value = self[first] as? [Key: Any] {
                 return value[keyPath: rest]
             } else {
                 return nil

--- a/tests/swift-sdk-swift-tests/foundational-tests/LocalStorageTests.swift
+++ b/tests/swift-sdk-swift-tests/foundational-tests/LocalStorageTests.swift
@@ -59,7 +59,7 @@ class LocalStorageTests: XCTestCase {
         XCTAssertNil(fromLocalStorage2)
         
         XCTAssertEqual(attributionInfo.description,
-                       "\(JsonKey.campaignId.jsonKey): \(attributionInfo.campaignId), \(JsonKey.templateId.jsonKey): \(attributionInfo.templateId), \(JsonKey.messageId.jsonKey): \(attributionInfo.messageId)")
+                       "\(JsonKey.campaignId): \(attributionInfo.campaignId), \(JsonKey.templateId): \(attributionInfo.templateId), \(JsonKey.messageId): \(attributionInfo.messageId)")
     }
     
     func testPayload() throws {

--- a/tests/swift-sdk-swift-tests/in-app-tests/InAppFilePersistenceTests.swift
+++ b/tests/swift-sdk-swift-tests/in-app-tests/InAppFilePersistenceTests.swift
@@ -135,7 +135,7 @@ class InAppFilePersistenceTests: XCTestCase {
         
         XCTAssertEqual(obtained[3].trigger.type, IterableInAppTriggerType.never)
         let dict = obtained[3].trigger.dict as! [String: Any]
-        TestUtils.validateMatch(keyPath: KeyPath("nested.var1"), value: "val1", inDictionary: dict, message: "Expected to find val1 in persisted dictionary")
+        TestUtils.validateMatch(keyPath: KeyPath(string: "nested.var1"), value: "val1", inDictionary: dict, message: "Expected to find val1 in persisted dictionary")
         
         persister.clear()
     }

--- a/tests/swift-sdk-swift-tests/in-app-tests/InAppParsingTests.swift
+++ b/tests/swift-sdk-swift-tests/in-app-tests/InAppParsingTests.swift
@@ -328,7 +328,7 @@ class InAppParsingTests: XCTestCase {
                                queryParams: [])
             TestUtils.validateMessageContext(messageId: message.messageId, userId: InAppParsingTests.userId, saveToInbox: false, silentInbox: false, location: .inApp, inBody: body)
             TestUtils.validateDeviceInfo(inBody: body, withDeviceId: internalAPI.deviceId)
-            TestUtils.validateMatch(keyPath: KeyPath("clickedUrl"), value: buttonUrl, inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "clickedUrl"), value: buttonUrl, inDictionary: body)
             expectation1.fulfill()
         }
         internalAPI.trackInAppClick(message, clickedUrl: buttonUrl)
@@ -391,8 +391,8 @@ class InAppParsingTests: XCTestCase {
             
             TestUtils.validateMessageContext(messageId: messageId, email: InAppParsingTests.email, saveToInbox: true, silentInbox: true, location: .inbox, inBody: body)
             TestUtils.validateDeviceInfo(inBody: body, withDeviceId: internalAPI.deviceId)
-            TestUtils.validateMatch(keyPath: KeyPath("\(JsonKey.closeAction.jsonKey)"), value: "back", inDictionary: body)
-            TestUtils.validateMatch(keyPath: KeyPath("\(JsonKey.clickedUrl.jsonKey)"), value: "https://somewhere.com", inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "\(JsonKey.closeAction)"), value: "back", inDictionary: body)
+            TestUtils.validateMatch(keyPath: KeyPath(string: "\(JsonKey.clickedUrl)"), value: "https://somewhere.com", inDictionary: body)
             
             expectation1.fulfill()
         }
@@ -434,8 +434,8 @@ class InAppParsingTests: XCTestCase {
             
             TestUtils.validateMessageContext(messageId: messageId, email: InAppParsingTests.email, saveToInbox: true, silentInbox: true, location: .inbox, inBody: body)
             TestUtils.validateDeviceInfo(inBody: body, withDeviceId: internalAPI.deviceId)
-            XCTAssertNil(body[keyPath: KeyPath("\(JsonKey.closeAction.jsonKey)")])
-            TestUtils.validateMatch(keyPath: KeyPath("\(JsonKey.clickedUrl.jsonKey)"), value: "https://somewhere.com", inDictionary: body)
+            XCTAssertNil(body[keyPath: KeyPath(string: "\(JsonKey.closeAction)")])
+            TestUtils.validateMatch(keyPath: KeyPath(string: "\(JsonKey.clickedUrl)"), value: "https://somewhere.com", inDictionary: body)
             
             expectation1.fulfill()
         }
@@ -573,7 +573,7 @@ class InAppParsingTests: XCTestCase {
         let messages = InAppTestHelper.inAppMessages(fromPayload: payload)
         XCTAssertEqual(messages[0].trigger.type, IterableInAppTriggerType.never)
         let dict = messages[0].trigger.dict as! [String: Any]
-        TestUtils.validateMatch(keyPath: KeyPath("myPayload.var1"), value: "val1", inDictionary: dict, message: "Expected to find val1")
+        TestUtils.validateMatch(keyPath: KeyPath(string: "myPayload.var1"), value: "val1", inDictionary: dict, message: "Expected to find val1")
     }
     
     // Remove this test when backend is fixed

--- a/tests/swift-sdk-swift-tests/in-app-tests/InAppPriorityTests.swift
+++ b/tests/swift-sdk-swift-tests/in-app-tests/InAppPriorityTests.swift
@@ -48,7 +48,7 @@ class InAppPriorityTests: XCTestCase {
         let config = IterableConfig()
         config.inAppDisplayInterval = 1.0
         
-        let internalAPI = IterableAPIInternal.initializeForTesting(config: config,
+        let internalAPI = InternalIterableAPI.initializeForTesting(config: config,
                                                                    inAppFetcher: mockInAppFetcher,
                                                                    inAppDisplayer: mockInAppDisplayer)
         

--- a/tests/swift-sdk-swift-tests/in-app-tests/InAppTests.swift
+++ b/tests/swift-sdk-swift-tests/in-app-tests/InAppTests.swift
@@ -1319,9 +1319,9 @@ class InAppTests: XCTestCase {
             let body = urlRequest.httpBody!.json() as! [String: Any]
             TestUtils.validateMessageContext(messageId: "message1", saveToInbox: true, silentInbox: true, location: location, inBody: body)
             if let deleteAction = source {
-                TestUtils.validateMatch(keyPath: KeyPath(.deleteAction), value: deleteAction.jsonValue as! String, inDictionary: body, message: "deleteAction should be nil")
+                TestUtils.validateMatch(keyPath: KeyPath(keys: JsonKey.deleteAction), value: deleteAction.jsonValue as! String, inDictionary: body, message: "deleteAction should be nil")
             } else {
-                TestUtils.validateNil(keyPath: KeyPath(.deleteAction), inDictionary: body, message: "deleteAction should be nil")
+                TestUtils.validateNil(keyPath: KeyPath(keys: JsonKey.deleteAction), inDictionary: body, message: "deleteAction should be nil")
             }
             expectation1.fulfill()
         }


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-2448](https://iterable.atlassian.net/browse/MOB-2448)

## ✏️ Description

> 
We were not using constants consistently. `JsonKeyRepresentable` was too much abstraction. Now are Json keys are simple string constants.
`JsonValueRepresentable` is also clearer now. It is mostly needed for objc enums where we are mapping int values in enums to string.
