### PR TITLE
[MOB-2646]- Deferred deeplinking returning error

### DIFF
--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -609,7 +609,10 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         
         guard let request = IterableRequestUtil.createPostRequest(forApiEndPoint: linksEndPoint,
                                                                   path: Const.Path.ddlMatch,
-                                                                  headers: [JsonKey.Header.apiKey: apiKey],
+                                                                  headers: [
+                                                                    JsonKey.Header.apiKey: apiKey,
+                                                                    JsonKey.contentType: JsonValue.applicationJson,
+                                                                  ],
                                                                   args: nil,
                                                                   body: DeviceInfo.createDeviceInfo()) else {
             ITBError("Could not create request")


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-2646](https://iterable.atlassian.net/browse/MOB-2646)

## ✏️ Description

> Mobile deeplinking request to server was returning a failure from server. Turns out that we were not sending "application/json" header to server.
