### PR TITLE
[MOB-2778] - Limit width of "no-messages" labels.

### DIFF
--- a/swift-sdk/IterableInboxViewController.swift
+++ b/swift-sdk/IterableInboxViewController.swift
@@ -567,6 +567,7 @@ extension UITableView {
             titleLabel?.textColor = UIColor.black
             titleLabel?.font = UIFont(name: "HelveticaNeue-Bold", size: 20)
             titleLabel?.text = title
+            titleLabel?.widthAnchor.constraint(equalTo: emptyView.widthAnchor, multiplier: 1.0, constant: -20).isActive = true
             titleLabel?.centerXAnchor.constraint(equalTo: emptyView.centerXAnchor).isActive = true
             titleLabel?.centerYAnchor.constraint(equalTo: emptyView.centerYAnchor).isActive = true
         } else {
@@ -584,6 +585,7 @@ extension UITableView {
             messageLabel.textAlignment = .center
 
             messageLabel.centerXAnchor.constraint(equalTo: emptyView.centerXAnchor).isActive = true
+            messageLabel.widthAnchor.constraint(equalTo: emptyView.widthAnchor, multiplier: 1.0, constant: -20).isActive = true
             if let titleLabel = titleLabel {
                 messageLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 25).isActive = true
             } else {


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-2778](https://iterable.atlassian.net/browse/MOB-2778)

## ✏️ Description

> No message labels were being cut off when they were too long. Limited the width.
