### PR TITLE
fix(#488): 'shared' is unavailable: not available on iOS (App Extension) on Xcode 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "IterableSDK",
-    // This is a test due to another Xcode bug that prevents archiving on iOS versions below 12
-    platforms: [.iOS(.v12)],
+    platforms: [.iOS(.v10)],
     products: [
         // The external product of our package is an importable
         // library that has the same name as the package itself:

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 
 let package = Package(
     name: "IterableSDK",
-    platforms: [.iOS(.v10)],
+    // This is a test due to another Xcode bug that prevents archiving on iOS versions below 12
+    platforms: [.iOS(.v12)],
     products: [
         // The external product of our package is an importable
         // library that has the same name as the package itself:

--- a/swift-sdk/Internal/ApiClient.swift
+++ b/swift-sdk/Internal/ApiClient.swift
@@ -11,7 +11,7 @@ struct DeviceMetadata: Codable {
 }
 
 // MARK: - API CLIENT FUNCTIONS
-
+@available(iOSApplicationExtension, unavailable)
 class ApiClient {
     init(apiKey: String,
          authProvider: AuthProvider?,
@@ -93,7 +93,7 @@ class ApiClient {
 }
 
 // MARK: - API REQUEST CALLS
-
+@available(iOSApplicationExtension, unavailable)
 extension ApiClient: ApiClientProtocol {
     func register(registerTokenInfo: RegisterTokenInfo, notificationsEnabled: Bool) -> Future<SendRequestValue, SendRequestError> {
         let result = createRequestCreator().flatMap { $0.createRegisterTokenRequest(registerTokenInfo: registerTokenInfo,

--- a/swift-sdk/Internal/ApiClient.swift
+++ b/swift-sdk/Internal/ApiClient.swift
@@ -11,6 +11,7 @@ struct DeviceMetadata: Codable {
 }
 
 // MARK: - API CLIENT FUNCTIONS
+
 @available(iOSApplicationExtension, unavailable)
 class ApiClient {
     init(apiKey: String,
@@ -93,6 +94,7 @@ class ApiClient {
 }
 
 // MARK: - API REQUEST CALLS
+
 @available(iOSApplicationExtension, unavailable)
 extension ApiClient: ApiClientProtocol {
     func register(registerTokenInfo: RegisterTokenInfo, notificationsEnabled: Bool) -> Future<SendRequestValue, SendRequestError> {

--- a/swift-sdk/Internal/DependencyContainer.swift
+++ b/swift-sdk/Internal/DependencyContainer.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 import UIKit
-
+@available(iOSApplicationExtension, unavailable)
 protocol DependencyContainerProtocol {
     var dateProvider: DateProviderProtocol { get }
     var networkSession: NetworkSessionProtocol { get }
@@ -28,7 +28,7 @@ protocol DependencyContainerProtocol {
                               offlineMode: Bool) -> RequestHandlerProtocol
     func createHealthMonitorDataProvider(persistenceContextProvider: IterablePersistenceContextProvider) -> HealthMonitorDataProviderProtocol
 }
-
+@available(iOSApplicationExtension, unavailable)
 extension DependencyContainerProtocol {
     func createInAppManager(config: IterableConfig,
                             apiClient: ApiClientProtocol,
@@ -138,7 +138,7 @@ extension DependencyContainerProtocol {
                            connectivityManager: NetworkConnectivityManager())
     }
 }
-
+@available(iOSApplicationExtension, unavailable)
 struct DependencyContainer: DependencyContainerProtocol {
     func createInAppFetcher(apiClient: ApiClientProtocol) -> InAppFetcherProtocol {
         InAppFetcher(apiClient: apiClient)

--- a/swift-sdk/Internal/DependencyContainer.swift
+++ b/swift-sdk/Internal/DependencyContainer.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import UIKit
+
 @available(iOSApplicationExtension, unavailable)
 protocol DependencyContainerProtocol {
     var dateProvider: DateProviderProtocol { get }
@@ -28,6 +29,7 @@ protocol DependencyContainerProtocol {
                               offlineMode: Bool) -> RequestHandlerProtocol
     func createHealthMonitorDataProvider(persistenceContextProvider: IterablePersistenceContextProvider) -> HealthMonitorDataProviderProtocol
 }
+
 @available(iOSApplicationExtension, unavailable)
 extension DependencyContainerProtocol {
     func createInAppManager(config: IterableConfig,
@@ -138,6 +140,7 @@ extension DependencyContainerProtocol {
                            connectivityManager: NetworkConnectivityManager())
     }
 }
+
 @available(iOSApplicationExtension, unavailable)
 struct DependencyContainer: DependencyContainerProtocol {
     func createInAppFetcher(apiClient: ApiClientProtocol) -> InAppFetcherProtocol {

--- a/swift-sdk/Internal/EmptyInAppManager.swift
+++ b/swift-sdk/Internal/EmptyInAppManager.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 import UIKit
-
+@available(iOSApplicationExtension, unavailable)
 class EmptyInAppManager: IterableInternalInAppManagerProtocol {
     func start() -> Future<Bool, Error> {
         Promise<Bool, Error>(value: true)

--- a/swift-sdk/Internal/EmptyInAppManager.swift
+++ b/swift-sdk/Internal/EmptyInAppManager.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import UIKit
+
 @available(iOSApplicationExtension, unavailable)
 class EmptyInAppManager: IterableInternalInAppManagerProtocol {
     func start() -> Future<Bool, Error> {

--- a/swift-sdk/Internal/HealthMonitor.swift
+++ b/swift-sdk/Internal/HealthMonitor.swift
@@ -28,7 +28,7 @@ struct HealthMonitorDataProvider: HealthMonitorDataProviderProtocol {
 protocol HealthMonitorDelegate: AnyObject {
     func onDBError()
 }
-
+@available(iOSApplicationExtension, unavailable)
 class HealthMonitor {
     init(dataProvider: HealthMonitorDataProviderProtocol,
          dateProvider: DateProviderProtocol,

--- a/swift-sdk/Internal/HealthMonitor.swift
+++ b/swift-sdk/Internal/HealthMonitor.swift
@@ -28,6 +28,7 @@ struct HealthMonitorDataProvider: HealthMonitorDataProviderProtocol {
 protocol HealthMonitorDelegate: AnyObject {
     func onDBError()
 }
+
 @available(iOSApplicationExtension, unavailable)
 class HealthMonitor {
     init(dataProvider: HealthMonitorDataProviderProtocol,

--- a/swift-sdk/Internal/InAppDisplayer.swift
+++ b/swift-sdk/Internal/InAppDisplayer.swift
@@ -18,7 +18,7 @@ protocol InAppDisplayerProtocol {
     /// `.notShown` with reason if the message could not be shown.
     func showInApp(message: IterableInAppMessage) -> ShowResult
 }
-
+@available(iOSApplicationExtension, unavailable)
 class InAppDisplayer: InAppDisplayerProtocol {
     func isShowingInApp() -> Bool {
         InAppDisplayer.isShowingIterableMessage()
@@ -83,7 +83,6 @@ class InAppDisplayer: InAppDisplayerProtocol {
         
         return topViewController is IterableHtmlMessageViewController
     }
-    
     private static func getTopViewController() -> UIViewController? {
         guard let rootViewController = IterableUtil.rootViewController else {
             return nil

--- a/swift-sdk/Internal/InAppDisplayer.swift
+++ b/swift-sdk/Internal/InAppDisplayer.swift
@@ -18,6 +18,7 @@ protocol InAppDisplayerProtocol {
     /// `.notShown` with reason if the message could not be shown.
     func showInApp(message: IterableInAppMessage) -> ShowResult
 }
+
 @available(iOSApplicationExtension, unavailable)
 class InAppDisplayer: InAppDisplayerProtocol {
     func isShowingInApp() -> Bool {
@@ -83,6 +84,7 @@ class InAppDisplayer: InAppDisplayerProtocol {
         
         return topViewController is IterableHtmlMessageViewController
     }
+
     private static func getTopViewController() -> UIViewController? {
         guard let rootViewController = IterableUtil.rootViewController else {
             return nil

--- a/swift-sdk/Internal/InAppManager.swift
+++ b/swift-sdk/Internal/InAppManager.swift
@@ -8,7 +8,7 @@ import UIKit
 protocol InAppDisplayChecker {
     func isOkToShowNow(message: IterableInAppMessage) -> Bool
 }
-
+@available(iOSApplicationExtension, unavailable)
 protocol IterableInternalInAppManagerProtocol: IterableInAppManagerProtocol, InAppNotifiable, InAppDisplayChecker {
     func start() -> Future<Bool, Error>
     
@@ -25,7 +25,7 @@ protocol IterableInternalInAppManagerProtocol: IterableInAppManagerProtocol, InA
     /// - parameter inboxSessionId: The ID of the inbox session that the message originates from.
     func remove(message: IterableInAppMessage, location: InAppLocation, source: InAppDeleteSource, inboxSessionId: String?)
 }
-
+@available(iOSApplicationExtension, unavailable)
 class InAppManager: NSObject, IterableInternalInAppManagerProtocol {
     init(requestHandler: RequestHandlerProtocol,
          deviceMetadata: DeviceMetadata,
@@ -558,7 +558,7 @@ class InAppManager: NSObject, IterableInternalInAppManagerProtocol {
     private let moveToForegroundSyncInterval: Double = 1.0 * 60.0 // don't sync within sixty seconds
     private var autoDisplayPaused = false
 }
-
+@available(iOSApplicationExtension, unavailable)
 extension InAppManager: InAppNotifiable {
     func scheduleSync() -> Future<Bool, Error> {
         ITBInfo()
@@ -631,7 +631,7 @@ extension InAppManager: InAppNotifiable {
         return result
     }
 }
-
+@available(iOSApplicationExtension, unavailable)
 extension InAppManager: InAppDisplayChecker {
     func isOkToShowNow(message: IterableInAppMessage) -> Bool {
         guard !isAutoDisplayPaused else {

--- a/swift-sdk/Internal/InAppManager.swift
+++ b/swift-sdk/Internal/InAppManager.swift
@@ -8,6 +8,7 @@ import UIKit
 protocol InAppDisplayChecker {
     func isOkToShowNow(message: IterableInAppMessage) -> Bool
 }
+
 @available(iOSApplicationExtension, unavailable)
 protocol IterableInternalInAppManagerProtocol: IterableInAppManagerProtocol, InAppNotifiable, InAppDisplayChecker {
     func start() -> Future<Bool, Error>
@@ -25,6 +26,7 @@ protocol IterableInternalInAppManagerProtocol: IterableInAppManagerProtocol, InA
     /// - parameter inboxSessionId: The ID of the inbox session that the message originates from.
     func remove(message: IterableInAppMessage, location: InAppLocation, source: InAppDeleteSource, inboxSessionId: String?)
 }
+
 @available(iOSApplicationExtension, unavailable)
 class InAppManager: NSObject, IterableInternalInAppManagerProtocol {
     init(requestHandler: RequestHandlerProtocol,
@@ -558,6 +560,7 @@ class InAppManager: NSObject, IterableInternalInAppManagerProtocol {
     private let moveToForegroundSyncInterval: Double = 1.0 * 60.0 // don't sync within sixty seconds
     private var autoDisplayPaused = false
 }
+
 @available(iOSApplicationExtension, unavailable)
 extension InAppManager: InAppNotifiable {
     func scheduleSync() -> Future<Bool, Error> {
@@ -631,6 +634,7 @@ extension InAppManager: InAppNotifiable {
         return result
     }
 }
+
 @available(iOSApplicationExtension, unavailable)
 extension InAppManager: InAppDisplayChecker {
     func isOkToShowNow(message: IterableInAppMessage) -> Bool {

--- a/swift-sdk/Internal/InAppPresenter.swift
+++ b/swift-sdk/Internal/InAppPresenter.swift
@@ -3,7 +3,7 @@
 //
 
 import UIKit
-
+@available(iOSApplicationExtension, unavailable)
 class InAppPresenter {
     static var isPresenting = false
     

--- a/swift-sdk/Internal/InAppPresenter.swift
+++ b/swift-sdk/Internal/InAppPresenter.swift
@@ -3,6 +3,7 @@
 //
 
 import UIKit
+
 @available(iOSApplicationExtension, unavailable)
 class InAppPresenter {
     static var isPresenting = false

--- a/swift-sdk/Internal/InboxSessionManager.swift
+++ b/swift-sdk/Internal/InboxSessionManager.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-
+@available(iOSApplicationExtension, unavailable)
 class InboxSessionManager {
     struct SessionInfo {
         let startInfo: SessionStartInfo

--- a/swift-sdk/Internal/InboxSessionManager.swift
+++ b/swift-sdk/Internal/InboxSessionManager.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+
 @available(iOSApplicationExtension, unavailable)
 class InboxSessionManager {
     struct SessionInfo {

--- a/swift-sdk/Internal/InboxViewControllerViewModel.swift
+++ b/swift-sdk/Internal/InboxViewControllerViewModel.swift
@@ -13,7 +13,7 @@ enum RowDiff {
     case sectionDelete(IndexSet)
     case sectionUpdate(IndexSet)
 }
-
+@available(iOSApplicationExtension, unavailable)
 class InboxViewControllerViewModel: InboxViewControllerViewModelProtocol {
     init(internalAPIProvider: @escaping @autoclosure () -> InternalIterableAPI? = IterableAPI.internalImplementation) {
         ITBInfo()

--- a/swift-sdk/Internal/InboxViewControllerViewModel.swift
+++ b/swift-sdk/Internal/InboxViewControllerViewModel.swift
@@ -13,6 +13,7 @@ enum RowDiff {
     case sectionDelete(IndexSet)
     case sectionUpdate(IndexSet)
 }
+
 @available(iOSApplicationExtension, unavailable)
 class InboxViewControllerViewModel: InboxViewControllerViewModelProtocol {
     init(internalAPIProvider: @escaping @autoclosure () -> InternalIterableAPI? = IterableAPI.internalImplementation) {

--- a/swift-sdk/Internal/InboxViewControllerViewModelProtocol.swift
+++ b/swift-sdk/Internal/InboxViewControllerViewModelProtocol.swift
@@ -3,7 +3,7 @@
 //
 
 import UIKit
-
+@available(iOSApplicationExtension, unavailable)
 protocol InboxViewControllerViewModelProtocol {
     var view: InboxViewControllerViewModelView? { get set }
     var unreadCount: Int { get }

--- a/swift-sdk/Internal/InboxViewControllerViewModelProtocol.swift
+++ b/swift-sdk/Internal/InboxViewControllerViewModelProtocol.swift
@@ -3,6 +3,7 @@
 //
 
 import UIKit
+
 @available(iOSApplicationExtension, unavailable)
 protocol InboxViewControllerViewModelProtocol {
     var view: InboxViewControllerViewModelView? { get set }

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 import UIKit
-
+@available(iOSApplicationExtension, unavailable)
 final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
     var apiKey: String
     

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import UIKit
+
 @available(iOSApplicationExtension, unavailable)
 final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
     var apiKey: String

--- a/swift-sdk/Internal/IterableAPICallRequest.swift
+++ b/swift-sdk/Internal/IterableAPICallRequest.swift
@@ -6,6 +6,7 @@ import Foundation
 
 /// This struct encapsulates all the data that needs to be sent to Iterable backend.
 /// This struct must be `Codable`.
+@available(iOSApplicationExtension, unavailable)
 struct IterableAPICallRequest {
     let apiKey: String
     let endPoint: String
@@ -87,5 +88,5 @@ struct IterableAPICallRequest {
         }
     }
 }
-
+@available(iOSApplicationExtension, unavailable)
 extension IterableAPICallRequest: Codable {}

--- a/swift-sdk/Internal/IterableAPICallRequest.swift
+++ b/swift-sdk/Internal/IterableAPICallRequest.swift
@@ -88,5 +88,6 @@ struct IterableAPICallRequest {
         }
     }
 }
+
 @available(iOSApplicationExtension, unavailable)
 extension IterableAPICallRequest: Codable {}

--- a/swift-sdk/Internal/IterableAPICallTaskProcessor.swift
+++ b/swift-sdk/Internal/IterableAPICallTaskProcessor.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-
+@available(iOSApplicationExtension, unavailable)
 struct IterableAPICallTaskProcessor: IterableTaskProcessor {
     let networkSession: NetworkSessionProtocol
     

--- a/swift-sdk/Internal/IterableAPICallTaskProcessor.swift
+++ b/swift-sdk/Internal/IterableAPICallTaskProcessor.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+
 @available(iOSApplicationExtension, unavailable)
 struct IterableAPICallTaskProcessor: IterableTaskProcessor {
     let networkSession: NetworkSessionProtocol

--- a/swift-sdk/Internal/IterableActionRunner.swift
+++ b/swift-sdk/Internal/IterableActionRunner.swift
@@ -6,11 +6,14 @@ import Foundation
 import UIKit
 
 /// handles opening of Urls
+
+@available(iOSApplicationExtension, unavailable)
 @objc protocol UrlOpenerProtocol: AnyObject {
     @objc func open(url: URL)
 }
 
 /// Default app opener. Defers to UIApplication open
+@available(iOSApplicationExtension, unavailable)
 class AppUrlOpener: UrlOpenerProtocol {
     public init() {}
     
@@ -30,6 +33,7 @@ class AppUrlOpener: UrlOpenerProtocol {
 struct IterableActionRunner {
     // returns true if an action is performed either by us or by the calling app.
     @discardableResult
+  @available(iOSApplicationExtension, unavailable)
     static func execute(action: IterableAction,
                         context: IterableActionContext,
                         urlHandler: UrlHandler? = nil,

--- a/swift-sdk/Internal/IterableAppIntegrationInternal.swift
+++ b/swift-sdk/Internal/IterableAppIntegrationInternal.swift
@@ -7,12 +7,13 @@ import UIKit
 import UserNotifications
 
 // Returns whether notifications are enabled
+@available(iOSApplicationExtension, unavailable)
 protocol NotificationStateProviderProtocol {
     var notificationsEnabled: Bool { get }
     
     func registerForRemoteNotifications()
 }
-
+@available(iOSApplicationExtension, unavailable)
 struct SystemNotificationStateProvider: NotificationStateProviderProtocol {
     var notificationsEnabled: Bool {
         if #available(iOS 10.0, *) {
@@ -129,7 +130,7 @@ extension PushTrackerProtocol {
 }
 
 extension UIApplication: ApplicationStateProviderProtocol {}
-
+@available(iOSApplicationExtension, unavailable)
 struct IterableAppIntegrationInternal {
     private weak var tracker: PushTrackerProtocol?
     private let urlDelegate: IterableURLDelegate?

--- a/swift-sdk/Internal/IterableAppIntegrationInternal.swift
+++ b/swift-sdk/Internal/IterableAppIntegrationInternal.swift
@@ -13,6 +13,7 @@ protocol NotificationStateProviderProtocol {
     
     func registerForRemoteNotifications()
 }
+
 @available(iOSApplicationExtension, unavailable)
 struct SystemNotificationStateProvider: NotificationStateProviderProtocol {
     var notificationsEnabled: Bool {
@@ -130,6 +131,7 @@ extension PushTrackerProtocol {
 }
 
 extension UIApplication: ApplicationStateProviderProtocol {}
+
 @available(iOSApplicationExtension, unavailable)
 struct IterableAppIntegrationInternal {
     private weak var tracker: PushTrackerProtocol?

--- a/swift-sdk/Internal/IterableDeepLinkManager.swift
+++ b/swift-sdk/Internal/IterableDeepLinkManager.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-
+@available(iOSApplicationExtension, unavailable)
 class IterableDeepLinkManager: NSObject {
     /// Handles a Universal Link
     /// For Iterable links, it will track the click and retrieve the original URL,
@@ -101,7 +101,7 @@ class IterableDeepLinkManager: NSObject {
     private var deepLinkTemplateId: NSNumber?
     private var deepLinkMessageId: String?
 }
-
+@available(iOSApplicationExtension, unavailable)
 extension IterableDeepLinkManager: URLSessionDelegate, URLSessionTaskDelegate {
     /**
      Delegate handler when a redirect occurs. Stores a reference to the redirect url and does not execute the redirect.

--- a/swift-sdk/Internal/IterableDeepLinkManager.swift
+++ b/swift-sdk/Internal/IterableDeepLinkManager.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+
 @available(iOSApplicationExtension, unavailable)
 class IterableDeepLinkManager: NSObject {
     /// Handles a Universal Link
@@ -101,6 +102,7 @@ class IterableDeepLinkManager: NSObject {
     private var deepLinkTemplateId: NSNumber?
     private var deepLinkMessageId: String?
 }
+
 @available(iOSApplicationExtension, unavailable)
 extension IterableDeepLinkManager: URLSessionDelegate, URLSessionTaskDelegate {
     /**

--- a/swift-sdk/Internal/IterableHtmlMessageViewController.swift
+++ b/swift-sdk/Internal/IterableHtmlMessageViewController.swift
@@ -11,7 +11,7 @@ enum IterableMessageLocation: Int {
     case center
     case bottom
 }
-
+@available(iOSApplicationExtension, unavailable)
 class IterableHtmlMessageViewController: UIViewController {
     struct Parameters {
         let html: String
@@ -256,7 +256,7 @@ class IterableHtmlMessageViewController: UIViewController {
         }
     }
 }
-
+@available(iOSApplicationExtension, unavailable)
 extension IterableHtmlMessageViewController: WKNavigationDelegate {
     func webView(_: WKWebView, didFinish _: WKNavigation!) {
         ITBInfo()

--- a/swift-sdk/Internal/IterableHtmlMessageViewController.swift
+++ b/swift-sdk/Internal/IterableHtmlMessageViewController.swift
@@ -11,6 +11,7 @@ enum IterableMessageLocation: Int {
     case center
     case bottom
 }
+
 @available(iOSApplicationExtension, unavailable)
 class IterableHtmlMessageViewController: UIViewController {
     struct Parameters {
@@ -256,6 +257,7 @@ class IterableHtmlMessageViewController: UIViewController {
         }
     }
 }
+
 @available(iOSApplicationExtension, unavailable)
 extension IterableHtmlMessageViewController: WKNavigationDelegate {
     func webView(_: WKWebView, didFinish _: WKNavigation!) {

--- a/swift-sdk/Internal/IterableTaskRunner.swift
+++ b/swift-sdk/Internal/IterableTaskRunner.swift
@@ -6,6 +6,7 @@ import Foundation
 import UIKit
 
 @available(iOS 10.0, *)
+@available(iOSApplicationExtension, unavailable)
 class IterableTaskRunner: NSObject {
     init(networkSession: NetworkSessionProtocol = URLSession(configuration: .default),
          persistenceContextProvider: IterablePersistenceContextProvider,

--- a/swift-sdk/Internal/IterableTaskScheduler.swift
+++ b/swift-sdk/Internal/IterableTaskScheduler.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 @available(iOS 10.0, *)
+@available(iOSApplicationExtension, unavailable)
 class IterableTaskScheduler {
     init(persistenceContextProvider: IterablePersistenceContextProvider,
          notificationCenter: NotificationCenterProtocol = NotificationCenter.default,

--- a/swift-sdk/Internal/IterableUtil.swift
+++ b/swift-sdk/Internal/IterableUtil.swift
@@ -7,6 +7,7 @@ import os
 import UIKit
 
 @objc final class IterableUtil: NSObject {
+  @available(iOSApplicationExtension, unavailable)
     static var rootViewController: UIViewController? {
         if let rootViewController = UIApplication.shared.delegate?.window??.rootViewController {
             return rootViewController

--- a/swift-sdk/Internal/LegacyRequestHandler.swift
+++ b/swift-sdk/Internal/LegacyRequestHandler.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 /// Request handling pre iOS 10.0
+@available(iOSApplicationExtension, unavailable)
 class LegacyRequestHandler: RequestHandlerProtocol {
     init(apiKey: String,
          authProvider: AuthProvider?,

--- a/swift-sdk/Internal/OfflineRequestProcessor.swift
+++ b/swift-sdk/Internal/OfflineRequestProcessor.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 @available(iOS 10.0, *)
+@available(iOSApplicationExtension, unavailable)
 struct OfflineRequestProcessor: RequestProcessorProtocol {
     init(apiKey: String,
          authProvider: AuthProvider?,

--- a/swift-sdk/Internal/OnlineRequestProcessor.swift
+++ b/swift-sdk/Internal/OnlineRequestProcessor.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 /// `InternalIterableAPI` will delegate all network related calls to this struct.
+@available(iOSApplicationExtension, unavailable)
 struct OnlineRequestProcessor: RequestProcessorProtocol {
     init(apiKey: String,
          authProvider: AuthProvider?,

--- a/swift-sdk/Internal/RequestCreator.swift
+++ b/swift-sdk/Internal/RequestCreator.swift
@@ -8,6 +8,7 @@ import UIKit
 /// This is a stateless pure functional class
 /// This will create IterableRequest
 /// The API Endpoint and request endpoint is not defined yet
+@available(iOSApplicationExtension, unavailable)
 struct RequestCreator {
     let apiKey: String
     let auth: Auth

--- a/swift-sdk/Internal/RequestHandler.swift
+++ b/swift-sdk/Internal/RequestHandler.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 @available(iOS 10.0, *)
+@available(iOSApplicationExtension, unavailable)
 class RequestHandler: RequestHandlerProtocol {
     init(onlineProcessor: OnlineRequestProcessor,
          offlineProcessor: OfflineRequestProcessor?,
@@ -252,6 +253,7 @@ class RequestHandler: RequestHandlerProtocol {
 }
 
 @available(iOS 10.0, *)
+@available(iOSApplicationExtension, unavailable)
 extension RequestHandler: HealthMonitorDelegate {
     func onDBError() {
         self.offlineMode = false

--- a/swift-sdk/Internal/RequestHandlerProtocol.swift
+++ b/swift-sdk/Internal/RequestHandlerProtocol.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 /// `InternalIterableAPI` will delegate all network related calls to this protocol.
+@available(iOSApplicationExtension, unavailable)
 protocol RequestHandlerProtocol: AnyObject {
     var offlineMode: Bool { get set }
 

--- a/swift-sdk/IterableAPI.swift
+++ b/swift-sdk/IterableAPI.swift
@@ -5,6 +5,7 @@
 import Foundation
 import UIKit
 
+@available(iOSApplicationExtension, unavailable)
 @objcMembers
 public final class IterableAPI: NSObject {
     /// The current SDK version

--- a/swift-sdk/IterableAppIntegration.swift
+++ b/swift-sdk/IterableAppIntegration.swift
@@ -5,7 +5,7 @@
 import Foundation
 import UIKit
 import UserNotifications
-
+@available(iOSApplicationExtension, unavailable)
 @objc public class IterableAppIntegration: NSObject {
     /**
      * This method handles incoming Iterable notifications and actions for iOS < 10.

--- a/swift-sdk/IterableAppIntegration.swift
+++ b/swift-sdk/IterableAppIntegration.swift
@@ -5,6 +5,7 @@
 import Foundation
 import UIKit
 import UserNotifications
+
 @available(iOSApplicationExtension, unavailable)
 @objc public class IterableAppIntegration: NSObject {
     /**

--- a/swift-sdk/IterableInboxNavigationViewController.swift
+++ b/swift-sdk/IterableInboxNavigationViewController.swift
@@ -5,6 +5,7 @@
 import UIKit
 
 @IBDesignable
+@available(iOSApplicationExtension, unavailable)
 open class IterableInboxNavigationViewController: UINavigationController {
     // MARK: Settable properties
     

--- a/swift-sdk/IterableInboxViewController.swift
+++ b/swift-sdk/IterableInboxViewController.swift
@@ -5,6 +5,7 @@
 import UIKit
 
 @IBDesignable
+@available(iOSApplicationExtension, unavailable)
 open class IterableInboxViewController: UITableViewController {
     public enum InboxMode {
         case popup
@@ -351,7 +352,7 @@ open class IterableInboxViewController: UITableViewController {
         }
     }
 }
-
+@available(iOSApplicationExtension, unavailable)
 extension IterableInboxViewController: InboxViewControllerViewModelView {
     func onViewModelChanged(diffs: [RowDiff]) {
         ITBInfo()

--- a/swift-sdk/IterableInboxViewController.swift
+++ b/swift-sdk/IterableInboxViewController.swift
@@ -352,6 +352,7 @@ open class IterableInboxViewController: UITableViewController {
         }
     }
 }
+
 @available(iOSApplicationExtension, unavailable)
 extension IterableInboxViewController: InboxViewControllerViewModelView {
     func onViewModelChanged(diffs: [RowDiff]) {


### PR DESCRIPTION
## 🔹 Jira Ticket(s)
No Jira ticket
Fixes #488

## ✏️ Description
With Xcode 13, packages are all compiled with a flag as if they are for an application extension. This causes compiler issues due to the use of APIs that aren't available within app extension. This PR adds the needed availability checks for use of problematic APIs in app extensions.
More context on this issue can be found below
- https://bugs.swift.org/browse/SR-13345?jql=project%20%3D%20SR%20AND%20issuetype%20%3D%20Bug%20AND%20component%20%3D%20%22Package%20Manager%22%20AND%20environment%20~%20%22Xcode%2013%20beta%22

- https://forums.swift.org/t/set-application-extension-api-only-on-a-spm-package/39333/28
Fixes # 1824
> Please provide a brief description of what this pull request does.
