### PR TITLE
[MOB-3251] add header_dir to podspec

### DIFF
--- a/Iterable-iOS-SDK.podspec
+++ b/Iterable-iOS-SDK.podspec
@@ -24,4 +24,6 @@ Pod::Spec.new do |s|
   s.swift_version = '5.3'
 
   s.resource_bundles = {'Resources' => 'swift-sdk/Resources/**/*.{storyboard,xib,xcassets,xcdatamodeld}' }
+
+  s.header_dir = 'IterableSDK'
 end


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-3251](https://iterable.atlassian.net/browse/MOB-3251)

## ✏️ Description

* add `header_dir` to the SDK Podspec so that `use_frameworks!` doesn't need to be in the Podfile anymore
