### PR TITLE
[MOB-3277] - Move all app extension unsafe code to AppExtensionHelper class

### DIFF
--- a/swift-sdk.xcodeproj/project.pbxproj
+++ b/swift-sdk.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		AC819186227139230014955E /* SectionedValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC819185227139230014955E /* SectionedValues.swift */; };
 		AC81918822713A110014955E /* Dwifft+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC81918722713A110014955E /* Dwifft+UIKit.swift */; };
 		AC81918A22713A400014955E /* AbstractDiffCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC81918922713A400014955E /* AbstractDiffCalculator.swift */; };
+		AC84256226D6167E0066C627 /* AppExtensionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC84256126D6167E0066C627 /* AppExtensionHelper.swift */; };
 		AC845107228DF54E0052BB8F /* ApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC845106228DF54E0052BB8F /* ApiClient.swift */; };
 		AC84510922910A0C0052BB8F /* RequestCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC84510822910A0C0052BB8F /* RequestCreator.swift */; };
 		AC84EC3726C136F3007FBEF7 /* NotificationContentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC84EC3626C136F3007FBEF7 /* NotificationContentParser.swift */; };
@@ -486,6 +487,7 @@
 		AC819185227139230014955E /* SectionedValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionedValues.swift; sourceTree = "<group>"; };
 		AC81918722713A110014955E /* Dwifft+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dwifft+UIKit.swift"; sourceTree = "<group>"; };
 		AC81918922713A400014955E /* AbstractDiffCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractDiffCalculator.swift; sourceTree = "<group>"; };
+		AC84256126D6167E0066C627 /* AppExtensionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppExtensionHelper.swift; sourceTree = "<group>"; };
 		AC845106228DF54E0052BB8F /* ApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiClient.swift; sourceTree = "<group>"; };
 		AC84510822910A0C0052BB8F /* RequestCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestCreator.swift; sourceTree = "<group>"; };
 		AC84EC3626C136F3007FBEF7 /* NotificationContentParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentParser.swift; sourceTree = "<group>"; };
@@ -977,6 +979,7 @@
 				557AE6BE24A56E5E00B57750 /* Auth.swift */,
 				55298B222501A5AB00190BAE /* AuthManager.swift */,
 				AC2C667D20D3111900D46CC9 /* DateProvider.swift */,
+				AC84256126D6167E0066C627 /* AppExtensionHelper.swift */,
 				AC72A0C520CF4CB9004D7997 /* InternalIterableAPI.swift */,
 				AC72A0C420CF4CB8004D7997 /* IterableActionRunner.swift */,
 				AC2C668120D32F2800D46CC9 /* IterableAppIntegrationInternal.swift */,
@@ -1697,6 +1700,7 @@
 				AC219C49225FD7EB00B98631 /* IterableInboxViewController.swift in Sources */,
 				AC3DD9C82142F3650046F886 /* ClassExtensions.swift in Sources */,
 				AC219C50225FEDBD00B98631 /* IterableInboxCell.swift in Sources */,
+				AC84256226D6167E0066C627 /* AppExtensionHelper.swift in Sources */,
 				ACE6888D2228B86C00A95E5E /* InAppInternal.swift in Sources */,
 				AC9355D12589F9F90056C903 /* RequestHandlerProtocol.swift in Sources */,
 				AC1AA1C924EBB3C300F29C6B /* IterableNotifications.swift in Sources */,

--- a/swift-sdk/Internal/AppExtensionHelper.swift
+++ b/swift-sdk/Internal/AppExtensionHelper.swift
@@ -1,0 +1,58 @@
+//
+//  Copyright © 2021 Iterable. All rights reserved.
+//
+
+import Foundation
+
+final class AppExtensionHelper {
+    static var application: UIApplication? {
+        sharedInsance?.appProvider()
+    }
+    
+    static var applicationStateProvider: ApplicationStateProviderProtocol {
+        sharedInsance ?? FallbackApplcationStateProvider()
+    }
+    
+    static func open(url: URL) {
+        sharedInsance?.urlOpener(url)
+    }
+
+    @available(iOSApplicationExtension, unavailable)
+    static func initialize() {
+        let urlOpener: (URL) -> Void = { url in
+            if #available(iOS 10.0, *) {
+                UIApplication.shared.open(url, options: [:]) { success in
+                    if !success {
+                        ITBError("Could not open url: \(url)")
+                    }
+                }
+            } else {
+                _ = UIApplication.shared.openURL(url)
+            }
+
+        }
+        sharedInsance = AppExtensionHelper(appProvider: UIApplication.shared,
+                                           urlOpener: urlOpener)
+    }
+
+    private init(appProvider: @escaping @autoclosure () -> UIApplication,
+                 urlOpener: @escaping (URL) -> Void) {
+        self.appProvider = appProvider
+        self.urlOpener = urlOpener
+    }
+    
+    private let appProvider: () -> UIApplication
+    private let urlOpener: (URL) -> Void
+
+    private static var sharedInsance: AppExtensionHelper?
+    
+    private class FallbackApplcationStateProvider: ApplicationStateProviderProtocol {
+        let applicationState = UIApplication.State.active
+    }
+}
+
+extension AppExtensionHelper: ApplicationStateProviderProtocol {
+    var applicationState: UIApplication.State {
+        appProvider().applicationState
+    }
+}

--- a/swift-sdk/Internal/AppExtensionHelper.swift
+++ b/swift-sdk/Internal/AppExtensionHelper.swift
@@ -7,24 +7,24 @@ import UIKit
 
 final class AppExtensionHelper {
     static var application: UIApplication? {
-        sharedInsance?.appWrapper.provideApp()
+        sharedInstance?.appWrapper.provideApp()
     }
     
     static var applicationStateProvider: ApplicationStateProviderProtocol {
-        sharedInsance?.appWrapper.provideApp() ?? FallbackApplcationStateProvider()
+        sharedInstance?.appWrapper.provideApp() ?? FallbackApplcationStateProvider()
     }
     
     static func open(url: URL) {
-        sharedInsance?.appWrapper.openUrl(url: url)
+        sharedInstance?.appWrapper.openUrl(url: url)
     }
 
     @available(iOSApplicationExtension, unavailable)
     static func initialize() {
-        sharedInsance = AppExtensionHelper(appWrapper: AppWrapper())
+        sharedInstance = AppExtensionHelper(appWrapper: AppWrapper())
     }
 
     static func initialize(appWrapper: AppWrapperProtocol) {
-        sharedInsance = AppExtensionHelper(appWrapper: appWrapper)
+        sharedInstance = AppExtensionHelper(appWrapper: appWrapper)
     }
 
     private init(appWrapper: AppWrapperProtocol) {
@@ -32,7 +32,7 @@ final class AppExtensionHelper {
     }
     
     private let appWrapper: AppWrapperProtocol
-    private static var sharedInsance: AppExtensionHelper?
+    private static var sharedInstance: AppExtensionHelper?
     
     private class FallbackApplcationStateProvider: ApplicationStateProviderProtocol {
         let applicationState = UIApplication.State.active

--- a/swift-sdk/Internal/DependencyContainer.swift
+++ b/swift-sdk/Internal/DependencyContainer.swift
@@ -151,7 +151,7 @@ struct DependencyContainer: DependencyContainerProtocol {
     let inAppDisplayer: InAppDisplayerProtocol = InAppDisplayer()
     let inAppPersister: InAppPersistenceProtocol = InAppFilePersister()
     let urlOpener: UrlOpenerProtocol = AppUrlOpener()
-    let applicationStateProvider: ApplicationStateProviderProtocol = UIApplication.shared
+    let applicationStateProvider: ApplicationStateProviderProtocol = AppExtensionHelper.applicationStateProvider
     let notificationCenter: NotificationCenterProtocol = NotificationCenter.default
     let apnsTypeChecker: APNSTypeCheckerProtocol = APNSTypeChecker()
 }

--- a/swift-sdk/Internal/IterableActionRunner.swift
+++ b/swift-sdk/Internal/IterableActionRunner.swift
@@ -10,20 +10,13 @@ import UIKit
     @objc func open(url: URL)
 }
 
+
 /// Default app opener. Defers to UIApplication open
 class AppUrlOpener: UrlOpenerProtocol {
     public init() {}
-    
+
     public func open(url: URL) {
-        if #available(iOS 10.0, *) {
-            UIApplication.shared.open(url, options: [:]) { success in
-                if !success {
-                    ITBError("Could not open url: \(url)")
-                }
-            }
-        } else {
-            UIApplication.shared.openURL(url)
-        }
+        AppExtensionHelper.open(url: url)
     }
 }
 

--- a/swift-sdk/Internal/IterableAppIntegrationInternal.swift
+++ b/swift-sdk/Internal/IterableAppIntegrationInternal.swift
@@ -31,7 +31,7 @@ struct SystemNotificationStateProvider: NotificationStateProviderProtocol {
             return authorizationStatus == .authorized
         } else {
             // Fallback on earlier versions
-            if let currentSettings = UIApplication.shared.currentUserNotificationSettings, currentSettings.types != [] {
+            if let currentSettings = AppExtensionHelper.application?.currentUserNotificationSettings, currentSettings.types != [] {
                 return true
             } else {
                 return false
@@ -41,7 +41,7 @@ struct SystemNotificationStateProvider: NotificationStateProviderProtocol {
     
     func registerForRemoteNotifications() {
         DispatchQueue.main.async {
-            UIApplication.shared.registerForRemoteNotifications()
+            AppExtensionHelper.application?.registerForRemoteNotifications()
         }
     }
 }

--- a/swift-sdk/Internal/IterableUtil.swift
+++ b/swift-sdk/Internal/IterableUtil.swift
@@ -8,10 +8,10 @@ import UIKit
 
 @objc final class IterableUtil: NSObject {
     static var rootViewController: UIViewController? {
-        if let rootViewController = UIApplication.shared.delegate?.window??.rootViewController {
+        if let rootViewController = AppExtensionHelper.application?.delegate?.window??.rootViewController {
             return rootViewController
         } else {
-            return UIApplication.shared.windows.first?.rootViewController
+            return AppExtensionHelper.application?.windows.first?.rootViewController
         }
     }
     

--- a/swift-sdk/IterableAPI.swift
+++ b/swift-sdk/IterableAPI.swift
@@ -50,6 +50,7 @@ public final class IterableAPI: NSObject {
     ///     - apiKey: The Iterable Mobile API key to be used with the SDK
     ///
     /// - SeeAlso: IterableConfig
+    @available(iOSApplicationExtension, unavailable)
     public static func initialize(apiKey: String) {
         initialize(apiKey: apiKey, launchOptions: nil)
     }
@@ -62,6 +63,7 @@ public final class IterableAPI: NSObject {
     ///     - config: The `IterableConfig` object with the settings to be used
     ///
     /// - SeeAlso: IterableConfig
+    @available(iOSApplicationExtension, unavailable)
     public static func initialize(apiKey: String,
                                   config: IterableConfig) {
         initialize(apiKey: apiKey, launchOptions: nil, config: config)
@@ -75,6 +77,7 @@ public final class IterableAPI: NSObject {
     ///    - launchOptions: The `launchOptions` coming from `application(_:didFinishLaunchingWithOptions:)`
     ///
     /// - SeeAlso: IterableConfig
+    @available(iOSApplicationExtension, unavailable)
     public static func initialize(apiKey: String,
                                   launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
         initialize(apiKey: apiKey, launchOptions: launchOptions, config: IterableConfig())
@@ -89,6 +92,7 @@ public final class IterableAPI: NSObject {
     ///    - config: The `IterableConfig` object with the settings to be used
     ///
     /// - SeeAlso: IterableConfig
+    @available(iOSApplicationExtension, unavailable)
     public static func initialize(apiKey: String,
                                   launchOptions: [UIApplication.LaunchOptionsKey: Any]?,
                                   config: IterableConfig = IterableConfig()) {
@@ -99,11 +103,13 @@ public final class IterableAPI: NSObject {
 
     /// DO NOT USE THIS.
     /// This method is used internally to connect to staging and test environments.
+    @available(iOSApplicationExtension, unavailable)
     public static func initialize2(apiKey: String,
                                    launchOptions: [UIApplication.LaunchOptionsKey: Any]?,
                                    config: IterableConfig = IterableConfig(),
                                    apiEndPointOverride: String? = nil,
                                    callback: ((Bool) -> Void)? = nil) {
+        AppExtensionHelper.initialize()
         internalImplementation = InternalIterableAPI(apiKey: apiKey,
                                                      launchOptions: launchOptions,
                                                      config: config,

--- a/swift-sdk/IterableInboxViewController.swift
+++ b/swift-sdk/IterableInboxViewController.swift
@@ -408,7 +408,7 @@ extension IterableInboxViewController: InboxViewControllerViewModelView {
         let topMargin = CGFloat(10.0)
         let bottomMargin = CGFloat(10.0)
         let frame = tableView.frame
-        let statusHeight = UIApplication.shared.statusBarFrame.height
+        let statusHeight = AppExtensionHelper.application?.statusBarFrame.height ?? 0
         let navHeight = navigationController?.navigationBar.frame.height ?? 0
         let topHeightToSubtract = statusHeight + navHeight - topMargin // subtract topMargin
         

--- a/tests/common/CommonExtensions.swift
+++ b/tests/common/CommonExtensions.swift
@@ -157,6 +157,7 @@ extension IterableAPI {
                                      maxTasks: Int = 1000,
                                      apnsTypeChecker: APNSTypeCheckerProtocol = APNSTypeChecker(),
                                      persistenceContextProvider: IterablePersistenceContextProvider? = nil) {
+        AppExtensionHelper.initialize()
         let mockDependencyContainer = MockDependencyContainer(dateProvider: dateProvider,
                                                               networkSession: networkSession,
                                                               notificationStateProvider: notificationStateProvider,
@@ -200,6 +201,7 @@ extension InternalIterableAPI {
                                                         maxTasks: Int = 1000,
                                                         apnsTypeChecker: APNSTypeCheckerProtocol = APNSTypeChecker(),
                                                         persistenceContextProvider: IterablePersistenceContextProvider? = nil) -> InternalIterableAPI {
+        AppExtensionHelper.initialize()
         let mockDependencyContainer = MockDependencyContainer(dateProvider: dateProvider,
                                                               networkSession: networkSession,
                                                               notificationStateProvider: notificationStateProvider,

--- a/tests/endpoint-tests/E2EDependencyContainer.swift
+++ b/tests/endpoint-tests/E2EDependencyContainer.swift
@@ -49,6 +49,7 @@ extension InternalIterableAPI {
                                                     launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil,
                                                     config: IterableConfig = IterableConfig(),
                                                     localStorage: LocalStorageProtocol = MockLocalStorage()) -> InternalIterableAPI {
+        AppExtensionHelper.initialize()
         let e2eDependencyContainer = E2EDependencyContainer()
         let internalImplementation = InternalIterableAPI(apiKey: apiKey,
                                                          launchOptions: launchOptions,


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-3277](https://iterable.atlassian.net/browse/MOB-3277)

## ✏️ Description

> UIApplication.shared and url opening is not app extension safe. They should not be called from app extensions.
This PR is related to Github issue https://github.com/Iterable/swift-sdk/issues/488.
