### PR TITLE
[MOB-3835] - Fix archive issue SwiftUI doesn't build for  armv7

### DIFF
--- a/swift-sdk/swiftui/InboxViewRepresentable.swift
+++ b/swift-sdk/swiftui/InboxViewRepresentable.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2021 Iterable. All rights reserved.
 //
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && !arch(arm)
 
 import Foundation
 import SwiftUI

--- a/swift-sdk/swiftui/IterableInboxView.swift
+++ b/swift-sdk/swiftui/IterableInboxView.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2021 Iterable. All rights reserved.
 //
 
-#if canImport(SwiftUI)
+#if canImport(SwiftUI) && !arch(arm)
 
 import Foundation
 import SwiftUI


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-3835](https://iterable.atlassian.net/browse/MOB-3835)

## ✏️ Description

> Archiving is failing because SwiftUI does not work for Armv7. Exclude it.
