### PR TITLE
[MOB-3973] add initializer for inboxsessionmanager

### DIFF
--- a/swift-sdk/Internal/InboxSessionManager.swift
+++ b/swift-sdk/Internal/InboxSessionManager.swift
@@ -29,6 +29,11 @@ public class InboxSessionManager {
         self.inboxState = inboxState
     }
     
+    // used for the RN SDK iOS side binding
+    public init() {
+        self.inboxState = InboxState()
+    }
+    
     public func updateVisibleRows(visibleRows: [InboxImpressionTracker.RowInfo]) {
         guard let impressionTracker = impressionTracker else {
             ITBError("Expecting impressionTracker here.")


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-3973](https://iterable.atlassian.net/browse/MOB-3973)

## ✏️ Description

* adds back an initializer of `InboxSessionManager` that the RN SDK was relying on
