### PR TITLE
[MOB-4000] - Rename IterableAppIntegrationInternal => InternalIterableAppIntegration

### DIFF
--- a/swift-sdk.xcodeproj/project.pbxproj
+++ b/swift-sdk.xcodeproj/project.pbxproj
@@ -69,7 +69,7 @@
 		AC2B79F721E6A38900A59080 /* NotificationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2B79F621E6A38900A59080 /* NotificationHelper.swift */; };
 		AC2C667E20D3111900D46CC9 /* DateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2C667D20D3111900D46CC9 /* DateProvider.swift */; };
 		AC2C668020D31B1F00D46CC9 /* IterableNotificationResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2C667F20D31B1F00D46CC9 /* IterableNotificationResponseTests.swift */; };
-		AC2C668220D32F2800D46CC9 /* IterableAppIntegrationInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2C668120D32F2800D46CC9 /* IterableAppIntegrationInternal.swift */; };
+		AC2C668220D32F2800D46CC9 /* InternalIterableAppIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2C668120D32F2800D46CC9 /* InternalIterableAppIntegration.swift */; };
 		AC2C668420D3370600D46CC9 /* Mocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2C668320D3370600D46CC9 /* Mocks.swift */; };
 		AC2C668720D3435700D46CC9 /* IterableActionRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2C668620D3435700D46CC9 /* IterableActionRunnerTests.swift */; };
 		AC31B040232AB42100BE25EB /* InboxSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC31B03F232AB42100BE25EB /* InboxSessionManager.swift */; };
@@ -434,7 +434,7 @@
 		AC2B79F621E6A38900A59080 /* NotificationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHelper.swift; sourceTree = "<group>"; };
 		AC2C667D20D3111900D46CC9 /* DateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateProvider.swift; sourceTree = "<group>"; };
 		AC2C667F20D31B1F00D46CC9 /* IterableNotificationResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterableNotificationResponseTests.swift; sourceTree = "<group>"; };
-		AC2C668120D32F2800D46CC9 /* IterableAppIntegrationInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterableAppIntegrationInternal.swift; sourceTree = "<group>"; };
+		AC2C668120D32F2800D46CC9 /* InternalIterableAppIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalIterableAppIntegration.swift; sourceTree = "<group>"; };
 		AC2C668320D3370600D46CC9 /* Mocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
 		AC2C668620D3435700D46CC9 /* IterableActionRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterableActionRunnerTests.swift; sourceTree = "<group>"; };
 		AC31B03F232AB42100BE25EB /* InboxSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxSessionManager.swift; sourceTree = "<group>"; };
@@ -1031,7 +1031,7 @@
 				AC84256126D6167E0066C627 /* AppExtensionHelper.swift */,
 				AC72A0C520CF4CB9004D7997 /* InternalIterableAPI.swift */,
 				AC72A0C420CF4CB8004D7997 /* IterableActionRunner.swift */,
-				AC2C668120D32F2800D46CC9 /* IterableAppIntegrationInternal.swift */,
+				AC2C668120D32F2800D46CC9 /* InternalIterableAppIntegration.swift */,
 				AC72A0BD20CF4C98004D7997 /* IterableDeepLinkManager.swift */,
 				AC2B79F621E6A38900A59080 /* NotificationHelper.swift */,
 				ACEDF41C2183C2EC000B9BFE /* Pending.swift */,
@@ -1797,7 +1797,7 @@
 				ACF560E820E55A6B000AAC23 /* IterableActionContext.swift in Sources */,
 				AC5812F824F3AE8D007E6D36 /* RequestHandler.swift in Sources */,
 				55DD2015269E5A4200773CC7 /* IterableInboxViewControllerViewDelegate.swift in Sources */,
-				AC2C668220D32F2800D46CC9 /* IterableAppIntegrationInternal.swift in Sources */,
+				AC2C668220D32F2800D46CC9 /* InternalIterableAppIntegration.swift in Sources */,
 				ACD2B83D25B0A74A005D7A90 /* Models.swift in Sources */,
 				55DD2027269E5EA300773CC7 /* InboxViewControllerViewModelView.swift in Sources */,
 				AC1BED9523F1D4C700FDD75F /* MiscInboxClasses.swift in Sources */,

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -547,7 +547,7 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
             notificationStateProvider.registerForRemoteNotifications()
         }
         
-        IterableAppIntegration.implementation = IterableAppIntegrationInternal(tracker: self,
+        IterableAppIntegration.implementation = InternalIterableAppIntegration(tracker: self,
                                                                                urlDelegate: config.urlDelegate,
                                                                                customActionDelegate: config.customActionDelegate,
                                                                                urlOpener: urlOpener,

--- a/swift-sdk/Internal/InternalIterableAppIntegration.swift
+++ b/swift-sdk/Internal/InternalIterableAppIntegration.swift
@@ -110,7 +110,7 @@ extension PushTrackerProtocol {
 
 extension UIApplication: ApplicationStateProviderProtocol {}
 
-struct IterableAppIntegrationInternal {
+struct InternalIterableAppIntegration {
     private weak var tracker: PushTrackerProtocol?
     private let urlDelegate: IterableURLDelegate?
     private let customActionDelegate: IterableCustomActionDelegate?
@@ -178,13 +178,13 @@ struct IterableAppIntegrationInternal {
             return
         }
         
-        guard let itbl = IterableAppIntegrationInternal.itblValue(fromUserInfo: userInfo) else {
+        guard let itbl = InternalIterableAppIntegration.itblValue(fromUserInfo: userInfo) else {
             completionHandler?()
             return
         }
         
-        let dataFields = IterableAppIntegrationInternal.createIterableDataFields(actionIdentifier: response.actionIdentifier, userText: response.userText)
-        let action = IterableAppIntegrationInternal.createIterableAction(actionIdentifier: response.actionIdentifier, userText: response.userText, userInfo: userInfo, iterableElement: itbl)
+        let dataFields = InternalIterableAppIntegration.createIterableDataFields(actionIdentifier: response.actionIdentifier, userText: response.userText)
+        let action = InternalIterableAppIntegration.createIterableAction(actionIdentifier: response.actionIdentifier, userText: response.userText, userInfo: userInfo, iterableElement: itbl)
         
         // Track push open
         if let _ = dataFields[JsonKey.actionIdentifier] { // i.e., if action is not dismiss
@@ -233,7 +233,7 @@ struct IterableAppIntegrationInternal {
         if let defaultActionConfig = itbl[JsonKey.Payload.defaultAction] as? [AnyHashable: Any] {
             return IterableAction.action(fromDictionary: defaultActionConfig)
         } else {
-            return IterableAppIntegrationInternal.legacyDefaultActionFromPayload(userInfo: userInfo)
+            return InternalIterableAppIntegration.legacyDefaultActionFromPayload(userInfo: userInfo)
         }
     }
     
@@ -281,12 +281,12 @@ struct IterableAppIntegrationInternal {
         let dataFields = [JsonKey.actionIdentifier: JsonValue.ActionIdentifier.pushOpenDefault]
         tracker?.trackPushOpen(userInfo, dataFields: dataFields)
         
-        guard let itbl = IterableAppIntegrationInternal.itblValue(fromUserInfo: userInfo) else {
+        guard let itbl = InternalIterableAppIntegration.itblValue(fromUserInfo: userInfo) else {
             return
         }
         
         // Execute the action
-        if let action = IterableAppIntegrationInternal.createDefaultAction(userInfo: userInfo, iterableElement: itbl) {
+        if let action = InternalIterableAppIntegration.createDefaultAction(userInfo: userInfo, iterableElement: itbl) {
             let context = IterableActionContext(action: action, source: .push)
             
             IterableActionRunner.execute(action: action,

--- a/swift-sdk/IterableAppIntegration.swift
+++ b/swift-sdk/IterableAppIntegration.swift
@@ -54,5 +54,5 @@ import UserNotifications
         super.init()
     }
     
-    static var implementation: IterableAppIntegrationInternal?
+    static var implementation: InternalIterableAppIntegration?
 }

--- a/tests/unit-tests/InAppTests.swift
+++ b/tests/unit-tests/InAppTests.swift
@@ -1013,7 +1013,7 @@ class InAppTests: XCTestCase {
             inAppFetcher: mockInAppFetcher
         )
         
-        let appIntegration = IterableAppIntegrationInternal(tracker: internalApi,
+        let appIntegration = InternalIterableAppIntegration(tracker: internalApi,
                                                             urlDelegate: config.urlDelegate,
                                                             customActionDelegate: config.customActionDelegate,
                                                             urlOpener: MockUrlOpener(),
@@ -1053,7 +1053,7 @@ class InAppTests: XCTestCase {
         
         let mockInAppManager = MockInAppManager(expectation: expectation1)
         
-        let appIntegration = IterableAppIntegrationInternal(tracker: MockPushTracker(), inAppNotifiable: mockInAppManager)
+        let appIntegration = InternalIterableAppIntegration(tracker: MockPushTracker(), inAppNotifiable: mockInAppManager)
         appIntegration.application(MockApplicationStateProvider(applicationState: .background), didReceiveRemoteNotification: notification, fetchCompletionHandler: nil)
         
         wait(for: [expectation1], timeout: testExpectationTimeout)
@@ -1095,7 +1095,7 @@ class InAppTests: XCTestCase {
         let config = IterableConfig()
         let internalApi = InternalIterableAPI.initializeForTesting(config: config, notificationCenter: mockNotificationCenter)
         
-        let appIntegrationInternal = IterableAppIntegrationInternal(tracker: internalApi,
+        let appIntegrationInternal = InternalIterableAppIntegration(tracker: internalApi,
                                                                     urlDelegate: config.urlDelegate,
                                                                     customActionDelegate: config.customActionDelegate,
                                                                     urlOpener: MockUrlOpener(),

--- a/tests/unit-tests/IterableNotificationResponseTests.swift
+++ b/tests/unit-tests/IterableNotificationResponseTests.swift
@@ -43,7 +43,7 @@ class IterableNotificationResponseTests: XCTestCase {
             expection.fulfill()
         }
         
-        let appIntegration = IterableAppIntegrationInternal(tracker: pushTracker,
+        let appIntegration = InternalIterableAppIntegration(tracker: pushTracker,
                                                             customActionDelegate: customActionDelegate,
                                                             urlOpener: MockUrlOpener(),
                                                             inAppNotifiable: EmptyInAppManager())
@@ -87,7 +87,7 @@ class IterableNotificationResponseTests: XCTestCase {
             expection.fulfill()
         }
         
-        let appIntegration = IterableAppIntegrationInternal(tracker: pushTracker,
+        let appIntegration = InternalIterableAppIntegration(tracker: pushTracker,
                                                             customActionDelegate: customActionDelegate,
                                                             urlOpener: MockUrlOpener(),
                                                             inAppNotifiable: EmptyInAppManager())
@@ -190,7 +190,7 @@ class IterableNotificationResponseTests: XCTestCase {
         let response = MockNotificationResponse(userInfo: userInfo, actionIdentifier: UNNotificationDefaultActionIdentifier)
         let urlOpener = MockUrlOpener()
         let pushTracker = MockPushTracker()
-        let appIntegration = IterableAppIntegrationInternal(tracker: pushTracker,
+        let appIntegration = InternalIterableAppIntegration(tracker: pushTracker,
                                                             urlOpener: urlOpener,
                                                             inAppNotifiable: EmptyInAppManager())
         appIntegration.userNotificationCenter(nil, didReceive: response, withCompletionHandler: nil)


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-4000](https://iterable.atlassian.net/browse/MOB-XXXX)

## ✏️ Description

> Refactor => Rename

The last part (right most part) of naming should be what the class is. And progressively each part from right to left should give more specific detail. Internal is a detail and not what the class is.

