### PR TITLE
[MOB-4287] Removes the extra api-key argument from the request creator.

### DIFF
--- a/swift-sdk/Internal/ApiClient.swift
+++ b/swift-sdk/Internal/ApiClient.swift
@@ -82,7 +82,7 @@ class ApiClient {
             return .failure(IterableError.general(description: "authProvider is missing"))
         }
         
-        return .success(RequestCreator(apiKey: apiKey, auth: authProvider.auth, deviceMetadata: deviceMetadata))
+        return .success(RequestCreator(auth: authProvider.auth, deviceMetadata: deviceMetadata))
     }
     
     private let apiKey: String

--- a/swift-sdk/Internal/OfflineRequestProcessor.swift
+++ b/swift-sdk/Internal/OfflineRequestProcessor.swift
@@ -246,7 +246,7 @@ struct OfflineRequestProcessor: RequestProcessorProtocol {
     private let taskRunner: IterableTaskRunner
     
     private func createRequestCreator(authProvider: AuthProvider) -> RequestCreator {
-        return RequestCreator(apiKey: apiKey, auth: authProvider.auth, deviceMetadata: deviceMetadata)
+        return RequestCreator(auth: authProvider.auth, deviceMetadata: deviceMetadata)
     }
     
     private func sendIterableRequest(requestGenerator: (RequestCreator) -> Result<IterableRequest, IterableError>,

--- a/swift-sdk/Internal/RequestCreator.swift
+++ b/swift-sdk/Internal/RequestCreator.swift
@@ -449,7 +449,7 @@ struct RequestCreator {
     
     private func createPostRequest(path: String, body: [AnyHashable: Any]? = nil) -> PostRequest {
         PostRequest(path: path,
-                    args: [JsonKey.Header.apiKey: apiKey],
+                    args: nil,
                     body: body)
     }
     

--- a/swift-sdk/Internal/RequestCreator.swift
+++ b/swift-sdk/Internal/RequestCreator.swift
@@ -9,7 +9,6 @@ import UIKit
 /// This will create IterableRequest
 /// The API Endpoint and request endpoint is not defined yet
 struct RequestCreator {
-    let apiKey: String
     let auth: Auth
     let deviceMetadata: DeviceMetadata
     

--- a/tests/offline-events-tests/TaskProcessorTests.swift
+++ b/tests/offline-events-tests/TaskProcessorTests.swift
@@ -19,8 +19,7 @@ class TaskProcessorTests: XCTestCase {
         let networkSession = MockNetworkSession()
         let internalAPI = InternalIterableAPI.initializeForTesting(apiKey: apiKey, config: config, networkSession: networkSession)
         
-        let requestCreator = RequestCreator(apiKey: apiKey,
-                                            auth: auth,
+        let requestCreator = RequestCreator(auth: auth,
                                             deviceMetadata: internalAPI.deviceMetadata)
         guard case let Result.success(trackEventRequest) = requestCreator.createTrackEventRequest(eventName, dataFields: dataFields) else {
             XCTFail("Could not create trackEvent request")
@@ -223,8 +222,7 @@ class TaskProcessorTests: XCTestCase {
         let dataFields = ["var1": "val1", "var2": "val2"]
         
         let auth = Auth(userId: nil, email: email, authToken: nil)
-        let requestCreator = RequestCreator(apiKey: apiKey,
-                                            auth: auth,
+        let requestCreator = RequestCreator(auth: auth,
                                             deviceMetadata: deviceMetadata)
         guard case let Result.success(trackEventRequest) = requestCreator.createTrackEventRequest(eventName, dataFields: dataFields) else {
             XCTFail("Could not create trackEvent request")

--- a/tests/offline-events-tests/TaskRunnerTests.swift
+++ b/tests/offline-events-tests/TaskRunnerTests.swift
@@ -329,7 +329,7 @@ class TaskRunnerTests: XCTestCase {
         let eventName = "CustomEvent1"
         let dataFields = ["var1": "val1", "var2": "val2"]
         
-        let requestCreator = RequestCreator(apiKey: apiKey, auth: auth, deviceMetadata: deviceMetadata)
+        let requestCreator = RequestCreator(auth: auth, deviceMetadata: deviceMetadata)
         guard case let Result.success(trackEventRequest) = requestCreator.createTrackEventRequest(eventName, dataFields: dataFields) else {
             throw IterableError.general(description: "Could not create trackEvent request")
         }

--- a/tests/offline-events-tests/TaskSchedulerTests.swift
+++ b/tests/offline-events-tests/TaskSchedulerTests.swift
@@ -31,7 +31,7 @@ class TaskSchedulerTests: XCTestCase {
             expectation1.fulfill()
         }
         XCTAssertNotNil(reference)
-        let requestCreator = RequestCreator(apiKey: apiKey, auth: auth, deviceMetadata: deviceMetadata)
+        let requestCreator = RequestCreator(auth: auth, deviceMetadata: deviceMetadata)
         guard case let Result.success(trackEventRequest) = requestCreator.createTrackEventRequest(eventName, dataFields: dataFields) else {
             throw IterableError.general(description: "Could not create trackEvent request")
         }

--- a/tests/unit-tests/RequestCreatorTests.swift
+++ b/tests/unit-tests/RequestCreatorTests.swift
@@ -247,8 +247,7 @@ class RequestCreatorTests: XCTestCase {
     }
     
     func testUserlessUpdateUserRequest() {
-        let userlessRequestCreator = RequestCreator(apiKey: apiKey,
-                                                    auth: userlessAuth,
+        let userlessRequestCreator = RequestCreator(auth: userlessAuth,
                                                     deviceMetadata: deviceMetadata)
         
         let result = userlessRequestCreator.createUpdateUserRequest(dataFields: [:], mergeNestedObjects: false)
@@ -262,8 +261,7 @@ class RequestCreatorTests: XCTestCase {
     }
     
     func testUserlessUpdateSubscriptionsRequest() {
-        let userlessRequestCreator = RequestCreator(apiKey: apiKey,
-                                                    auth: userlessAuth,
+        let userlessRequestCreator = RequestCreator(auth: userlessAuth,
                                                     deviceMetadata: deviceMetadata)
         
         let result = userlessRequestCreator.createUpdateSubscriptionsRequest()
@@ -277,8 +275,7 @@ class RequestCreatorTests: XCTestCase {
     }
     
     func testUserlessTrackInboxSessionRequest() {
-        let userlessRequestCreator = RequestCreator(apiKey: apiKey,
-                                                    auth: userlessAuth,
+        let userlessRequestCreator = RequestCreator(auth: userlessAuth,
                                                     deviceMetadata: deviceMetadata)
         
         let result = userlessRequestCreator.createTrackInboxSessionRequest(inboxSession: IterableInboxSession())
@@ -323,8 +320,7 @@ class RequestCreatorTests: XCTestCase {
     }
     
     func testRegisterTokenRequestPrefersUserId() {
-        let userIdRequestCreator = RequestCreator(apiKey: apiKey,
-                                                  auth: userIdAuth,
+        let userIdRequestCreator = RequestCreator(auth: userIdAuth,
                                                   deviceMetadata: deviceMetadata)
         
         let registerTokenInfo = RegisterTokenInfo(hexToken: "hex-token",

--- a/tests/unit-tests/RequestCreatorTests.swift
+++ b/tests/unit-tests/RequestCreatorTests.swift
@@ -149,7 +149,7 @@ class RequestCreatorTests: XCTestCase {
     
     func testGetInAppMessagesRequestFailure() {
         let auth = Auth(userId: nil, email: nil, authToken: nil)
-        let requestCreator = RequestCreator(apiKey: apiKey, auth: auth, deviceMetadata: deviceMetadata)
+        let requestCreator = RequestCreator(auth: auth, deviceMetadata: deviceMetadata)
         
         let failingRequest = requestCreator.createGetInAppMessagesRequest(1)
         
@@ -412,7 +412,7 @@ class RequestCreatorTests: XCTestCase {
     }
     
     private func createRequestCreator() -> RequestCreator {
-        RequestCreator(apiKey: apiKey, auth: auth, deviceMetadata: deviceMetadata)
+        RequestCreator(auth: auth, deviceMetadata: deviceMetadata)
     }
     
     private func createApiClient(networkSession: NetworkSessionProtocol) -> ApiClient {


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-4287](https://iterable.atlassian.net/browse/MOB-4287)

## ✏️ Description

> Removes the api-key argument from the url and only passes it in the header of the request to ensure security.
