### PR TITLE
[AuthManager] clear token refresh timer

### DIFF
--- a/swift-sdk/Internal/AuthManager.swift
+++ b/swift-sdk/Internal/AuthManager.swift
@@ -113,6 +113,7 @@ class AuthManager: IterableAuthManagerProtocol {
         
         let timeIntervalToRefresh = TimeInterval(expirationDate) - dateProvider.currentDate.timeIntervalSince1970 - expirationRefreshPeriod
         
+        clearRefreshTimer()
         expirationRefreshTimer = Timer.scheduledTimer(withTimeInterval: timeIntervalToRefresh, repeats: false) { [weak self] _ in
             self?.requestNewAuthToken(hasFailedPriorAuth: false)
         }


### PR DESCRIPTION
## ✏️ Description
Before creating a new expirationRefreshTimer clear any previous timers

If you call setUserId multiple times from the react-native-sdk timer it will register a timer for refreshing them and call the authHandler multiple times. This prevents any possible duplicate timer situations. 