### PR TITLE
[MOB-5766] remove consume check and match android SDK's check

### DIFF
--- a/swift-sdk/Internal/InAppManager.swift
+++ b/swift-sdk/Internal/InAppManager.swift
@@ -466,12 +466,14 @@ class InAppManager: NSObject, IterableInternalInAppManagerProtocol {
         ITBInfo()
         
         updateMessage(message, didProcessTrigger: true, consumed: true)
+        
         requestHandler?.inAppConsume(message: message,
                                      location: location,
                                      source: source,
                                      inboxSessionId: inboxSessionId,
                                      onSuccess: nil,
                                      onFailure: nil)
+        
         callbackQueue.async { [weak self] in
             self?.notificationCenter.post(name: .iterableInboxChanged, object: self, userInfo: nil)
         }
@@ -486,7 +488,7 @@ class InAppManager: NSObject, IterableInternalInAppManagerProtocol {
     }
     
     fileprivate static func isValid(message: IterableInAppMessage, currentDate: Date) -> Bool {
-        return !isExpired(message: message, currentDate: currentDate)
+        return !message.consumed && !isExpired(message: message, currentDate: currentDate)
     }
     
     fileprivate static func getAppIsReady(applicationStateProvider: ApplicationStateProviderProtocol,

--- a/swift-sdk/Internal/InAppManager.swift
+++ b/swift-sdk/Internal/InAppManager.swift
@@ -482,11 +482,11 @@ class InAppManager: NSObject, IterableInternalInAppManagerProtocol {
             return false
         }
         
-        return currentDate >= expiresAt
+        return currentDate > expiresAt
     }
     
     fileprivate static func isValid(message: IterableInAppMessage, currentDate: Date) -> Bool {
-        message.consumed == false && isExpired(message: message, currentDate: currentDate) == false
+        return !isExpired(message: message, currentDate: currentDate)
     }
     
     fileprivate static func getAppIsReady(applicationStateProvider: ApplicationStateProviderProtocol,

--- a/tests/unit-tests/InboxTests.swift
+++ b/tests/unit-tests/InboxTests.swift
@@ -196,6 +196,7 @@ class InboxTests: XCTestCase {
             XCTAssertEqual(messages.count, 2)
             
             internalAPI.inAppManager.remove(message: messages[0], location: .inbox, source: .inboxSwipe)
+            
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 let newMessages = internalAPI.inAppManager.getInboxMessages()
                 XCTAssertEqual(newMessages.count, 1)


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-5766](https://iterable.atlassian.net/browse/MOB-5766)

## ✏️ Description

* removes consume check from `getMessages` (main source of bug)
* matches the android SDK's date validation condition


[MOB-5766]: https://iterable.atlassian.net/browse/MOB-5766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ