### PR TITLE
[MOB-5970] create and use blank API client

### DIFF
--- a/swift-sdk.xcodeproj/project.pbxproj
+++ b/swift-sdk.xcodeproj/project.pbxproj
@@ -139,6 +139,8 @@
 		5588DFF328C046FF000697D7 /* MockMessageViewControllerEventTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5588DFED28C046FF000697D7 /* MockMessageViewControllerEventTracker.swift */; };
 		5588DFF428C046FF000697D7 /* MockMessageViewControllerEventTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5588DFED28C046FF000697D7 /* MockMessageViewControllerEventTracker.swift */; };
 		55AEA95925F05B7D00B38CED /* InAppMessageProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AEA95825F05B7D00B38CED /* InAppMessageProcessorTests.swift */; };
+		55B06F3729D5102800C3B1BC /* BlankApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B06F3629D5102800C3B1BC /* BlankApiClient.swift */; };
+		55B06F3829D5102800C3B1BC /* BlankApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B06F3629D5102800C3B1BC /* BlankApiClient.swift */; };
 		55B3119B251015CF0056E4FC /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55298B222501A5AB00190BAE /* AuthManager.swift */; };
 		55B37FC1229620D20042F13A /* CommerceItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B37FC0229620D20042F13A /* CommerceItemTests.swift */; };
 		55B37FC42297135F0042F13A /* NotificationMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B37FC32297135F0042F13A /* NotificationMetadataTests.swift */; };
@@ -539,6 +541,7 @@
 		5588DFE528C046D7000697D7 /* MockInboxState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInboxState.swift; sourceTree = "<group>"; };
 		5588DFED28C046FF000697D7 /* MockMessageViewControllerEventTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMessageViewControllerEventTracker.swift; sourceTree = "<group>"; };
 		55AEA95825F05B7D00B38CED /* InAppMessageProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessageProcessorTests.swift; sourceTree = "<group>"; };
+		55B06F3629D5102800C3B1BC /* BlankApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlankApiClient.swift; sourceTree = "<group>"; };
 		55B37FC0229620D20042F13A /* CommerceItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommerceItemTests.swift; sourceTree = "<group>"; };
 		55B37FC32297135F0042F13A /* NotificationMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationMetadataTests.swift; sourceTree = "<group>"; };
 		55B37FC5229752DD0042F13A /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
@@ -1283,9 +1286,10 @@
 		AC87172421A4E3FF00FEA369 /* Helper Classes */ = {
 			isa = PBXGroup;
 			children = (
+				55B06F3629D5102800C3B1BC /* BlankApiClient.swift */,
 				AC2C668320D3370600D46CC9 /* Mocks.swift */,
-				00CB31B4210960C4004ACDEC /* TestUtils.swift */,
 				AC87172521A4E47E00FEA369 /* TestInAppPayloadGenerator.swift */,
+				00CB31B4210960C4004ACDEC /* TestUtils.swift */,
 			);
 			name = "Helper Classes";
 			sourceTree = "<group>";
@@ -2104,6 +2108,7 @@
 				5588DF8128C04494000697D7 /* MockUrlDelegate.swift in Sources */,
 				5585DF8F22A73390000A32B9 /* IterableInboxViewControllerTests.swift in Sources */,
 				55B9F15124B3D33700E8198A /* AuthTests.swift in Sources */,
+				55B06F3829D5102800C3B1BC /* BlankApiClient.swift in Sources */,
 				5588DFE928C046D7000697D7 /* MockInboxState.swift in Sources */,
 				ACED4C01213F50B30055A497 /* LoggingTests.swift in Sources */,
 				AC52C5B8272A8B32000DCDCF /* KeychainWrapperTests.swift in Sources */,
@@ -2210,6 +2215,7 @@
 				AC738CE82315A5B600B96B2D /* CommonExtensions.swift in Sources */,
 				5588DF8828C044BE000697D7 /* MockCustomActionDelegate.swift in Sources */,
 				5588DF8028C04494000697D7 /* MockUrlDelegate.swift in Sources */,
+				55B06F3729D5102800C3B1BC /* BlankApiClient.swift in Sources */,
 				AC738CE72315A54100B96B2D /* CommonMocks.swift in Sources */,
 				5588DFE028C046B7000697D7 /* MockLocalStorage.swift in Sources */,
 				5588DFA028C04570000697D7 /* MockApplicationStateProvider.swift in Sources */,

--- a/tests/unit-tests/BlankApiClient.swift
+++ b/tests/unit-tests/BlankApiClient.swift
@@ -1,0 +1,81 @@
+//
+//  Copyright © 2023 Iterable. All rights reserved.
+//
+
+import Foundation
+
+@testable import IterableSDK
+
+class BlankApiClient: ApiClientProtocol {
+    func register(registerTokenInfo: IterableSDK.RegisterTokenInfo, notificationsEnabled: Bool) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func updateUser(_ dataFields: [AnyHashable : Any], mergeNestedObjects: Bool) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func updateEmail(newEmail: String) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func updateCart(items: [IterableSDK.CommerceItem]) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func track(purchase total: NSNumber, items: [IterableSDK.CommerceItem], dataFields: [AnyHashable : Any]?, campaignId: NSNumber?, templateId: NSNumber?) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func track(pushOpen campaignId: NSNumber, templateId: NSNumber?, messageId: String, appAlreadyRunning: Bool, dataFields: [AnyHashable : Any]?) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func track(event eventName: String, dataFields: [AnyHashable : Any]?) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func updateSubscriptions(_ emailListIds: [NSNumber]?, unsubscribedChannelIds: [NSNumber]?, unsubscribedMessageTypeIds: [NSNumber]?, subscribedMessageTypeIds: [NSNumber]?, campaignId: NSNumber?, templateId: NSNumber?) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func getInAppMessages(_ count: NSNumber) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func track(inAppOpen inAppMessageContext: IterableSDK.InAppMessageContext) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func track(inAppClick inAppMessageContext: IterableSDK.InAppMessageContext, clickedUrl: String) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func track(inAppClose inAppMessageContext: IterableSDK.InAppMessageContext, source: IterableSDK.InAppCloseSource?, clickedUrl: String?) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func track(inAppDelivery inAppMessageContext: IterableSDK.InAppMessageContext) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func inAppConsume(messageId: String) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func inAppConsume(inAppMessageContext: IterableSDK.InAppMessageContext, source: IterableSDK.InAppDeleteSource?) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func track(inboxSession: IterableSDK.IterableInboxSession) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func disableDevice(forAllUsers allUsers: Bool, hexToken: String) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+        Pending()
+    }
+    
+    func getRemoteConfiguration() -> IterableSDK.Pending<IterableSDK.RemoteConfiguration, IterableSDK.SendRequestError> {
+        Pending()
+    }
+}

--- a/tests/unit-tests/InAppHelperTests.swift
+++ b/tests/unit-tests/InAppHelperTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 class InAppHelperTests: XCTestCase {
     func testGetInAppMessagesWithNoError() {
-        class MyApiClient: MockApiClient {
+        class MyApiClient: BlankApiClient {
             override func getInAppMessages(_: NSNumber) -> Pending<SendRequestValue, SendRequestError> {
                 let payload = TestInAppPayloadGenerator.createPayloadWithUrl(numMessages: 3)
                 return Fulfill<SendRequestValue, SendRequestError>(value: payload)
@@ -28,7 +28,7 @@ class InAppHelperTests: XCTestCase {
         // the second message should be consumed because it has a message id
         let expectation1 = expectation(description: "in app consume is called for message with error")
         
-        class MyApiClient: MockApiClient {
+        class MyApiClient: BlankApiClient {
             let expectation: XCTestExpectation
             
             init(expectation: XCTestExpectation) {
@@ -90,89 +90,6 @@ class InAppHelperTests: XCTestCase {
             XCTAssertEqual(urlWithUnsupportedScheme, url)
         } else {
             XCTFail("expected regular url")
-        }
-    }
-    
-    private class MockApiClient: ApiClientProtocol {
-        func register(registerTokenInfo _: RegisterTokenInfo,
-                      notificationsEnabled _: Bool) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func updateUser(_: [AnyHashable: Any], mergeNestedObjects _: Bool) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func updateEmail(newEmail _: String) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func updateCart(items: [CommerceItem]) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func track(purchase _: NSNumber, items _: [CommerceItem], dataFields _: [AnyHashable: Any]?, campaignId _: NSNumber?, templateId _: NSNumber?) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func track(pushOpen _: NSNumber, templateId _: NSNumber?, messageId _: String, appAlreadyRunning _: Bool, dataFields _: [AnyHashable: Any]?) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func track(event _: String, dataFields _: [AnyHashable: Any]?) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func updateSubscriptions(_: [NSNumber]?, unsubscribedChannelIds _: [NSNumber]?, unsubscribedMessageTypeIds _: [NSNumber]?, subscribedMessageTypeIds _: [NSNumber]?, campaignId _: NSNumber?, templateId _: NSNumber?) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func getInAppMessages(_: NSNumber) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func track(inAppOpen _: String) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func track(inAppOpen _: InAppMessageContext) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func track(inAppClick _: String, clickedUrl _: String) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func track(inAppClick _: InAppMessageContext, clickedUrl _: String) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func track(inAppClose _: InAppMessageContext, source _: InAppCloseSource?, clickedUrl _: String?) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func track(inAppDelivery _: InAppMessageContext) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func inAppConsume(messageId _: String) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func inAppConsume(inAppMessageContext _: InAppMessageContext, source _: InAppDeleteSource?) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func track(inboxSession _: IterableInboxSession) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func disableDevice(forAllUsers _: Bool, hexToken _: String) -> Pending<SendRequestValue, SendRequestError> {
-            fatalError()
-        }
-        
-        func getRemoteConfiguration() -> Pending<RemoteConfiguration, SendRequestError> {
-            fatalError()
         }
     }
 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-5970](https://iterable.atlassian.net/browse/MOB-5970)

## ✏️ Description

* creates a "blank" API client for unit test overriding (where we want to test only a subset of API client functions)


[MOB-5970]: https://iterable.atlassian.net/browse/MOB-5970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ