### PR TITLE
[MOB - 6106] - Use Application Directory

### DIFF
--- a/swift-sdk/Internal/InAppPersistence.swift
+++ b/swift-sdk/Internal/InAppPersistence.swift
@@ -411,7 +411,7 @@ class InAppFilePersister: InAppPersistenceProtocol {
 
 struct FileHelper {
     static func getUrl(filename: String, ext: String) -> URL? {
-        guard let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+        guard let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             return nil
         }
         


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-6106](https://iterable.atlassian.net/browse/MOB-6106)

## ✏️ Description

> Use Application Support Directory instead of Default document directory to store files required by SDK so that the files is not visible to user in Files App.

File is stored by the SDK in document directory provided by FileManager [as shown here](https://github.com/Iterable/swift-sdk/blob/fd55d0ae5e182430f79f98430e85bb44d29bc7f7/swift-sdk/Internal/InAppPersistence.swift#L414). 

Looks like (References [#](https://www.hackingwithswift.com/books/ios-swiftui/writing-data-to-the-documents-directory), [#](https://stackoverflow.com/a/57333725) and [#](https://developer.apple.com/documentation/foundation/filemanager/searchpathdirectory/applicationsupportdirectory)) :  
Some apps can have their default Filemanager access the directory which can be visible to FIles App. Hence using applicationSupportDirectory so the file stays under Library/Application Support directory which is hidden from users.

[MOB-6106]: https://iterable.atlassian.net/browse/MOB-6106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ