### PR TITLE
[MOB-6038] Use Iterable events for click and delivery instead of track api

### DIFF
--- a/swift-sdk/Internal/ApiClient.swift
+++ b/swift-sdk/Internal/ApiClient.swift
@@ -224,11 +224,13 @@ extension ApiClient: ApiClientProtocol {
         return send(iterableRequestResult: result)
     }
     
+    @discardableResult
     func track(embeddedMessageReceived message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError> {
         let result = createRequestCreator().flatMap { $0.createEmbeddedMessageReceivedRequest(message) }
         return send(iterableRequestResult: result)
     }
     
+    @discardableResult
     func track(embeddedMessageClick message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError> {
         let result = createRequestCreator().flatMap { $0.createEmbeddedMessageClickRequest(message) }
         return send(iterableRequestResult: result)

--- a/swift-sdk/Internal/ApiClientProtocol.swift
+++ b/swift-sdk/Internal/ApiClientProtocol.swift
@@ -48,9 +48,9 @@ protocol ApiClientProtocol: AnyObject {
     
     func getEmbeddedMessages() -> Pending<EmbeddedMessagesPayload, SendRequestError>
     
-    func track(embeddedMessageReceived message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError>
+    @discardableResult func track(embeddedMessageReceived message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError>
     
-    func track(embeddedMessageClick message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError>
+    @discardableResult func track(embeddedMessageClick message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError>
     
     func track(embeddedMessageDismiss message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError>
     

--- a/swift-sdk/Internal/EmbeddedMessagingManager.swift
+++ b/swift-sdk/Internal/EmbeddedMessagingManager.swift
@@ -43,9 +43,9 @@ class EmbeddedMessagingManager: NSObject, IterableEmbeddedMessagingManagerProtoc
     }
     
     public func track(click message: IterableEmbeddedMessage) {
-//        apiClient.track(embeddedMessageClick: message)
-        IterableAPI.track(event: "embedded-messaging", dataFields: ["name": "click",
-                                                                    "messageId": message.metadata.id])
+        apiClient.track(embeddedMessageClick: message)
+//        IterableAPI.track(event: "embedded-messaging", dataFields: ["name": "click",
+//                                                                    "messageId": message.metadata.id])
     }
     
 //    public func track(dismiss message: IterableEmbeddedMessage) {
@@ -150,11 +150,11 @@ class EmbeddedMessagingManager: NSObject, IterableEmbeddedMessagingManagerProtoc
     
     private func trackNewlyRetrieved(_ processor: EmbeddedMessagingProcessor) {
         for message in processor.newlyRetrievedMessages() {
-//            apiClient.track(embeddedMessagingReceived: message)
-            IterableAPI.track(event: "embedded-messaging",
-                              dataFields: ["name": "received",
-                                           "messageId": message.metadata.id]
-            )
+            apiClient.track(embeddedMessageReceived: message)
+//            IterableAPI.track(event: "embedded-messaging",
+//                              dataFields: ["name": "received",
+//                                           "messageId": message.metadata.id]
+//            )
         }
     }
     

--- a/swift-sdk/Internal/EmptyEmbeddedMessagingManager.swift
+++ b/swift-sdk/Internal/EmptyEmbeddedMessagingManager.swift
@@ -24,4 +24,12 @@ class EmptyEmbeddedMessagingManager: IterableEmbeddedMessagingManagerProtocol {
     func stop() {
         
     }
+    
+    func track(click message: IterableEmbeddedMessage) {
+            
+    }
+    
+    func track(impression message: IterableEmbeddedMessage) {
+        
+    }
 }

--- a/swift-sdk/Internal/RequestCreator.swift
+++ b/swift-sdk/Internal/RequestCreator.swift
@@ -457,8 +457,7 @@ struct RequestCreator {
         
         addUserKey(intoDict: &body)
         
-        // TODO: find/create proper key for the value of the embedded message ID
-        body.setValue(for: JsonKey.messageId, value: message.metadata.id)
+        body.setValue(for: JsonKey.messageId, value: String(message.metadata.id))
         
         return .success(.post(createPostRequest(path: Const.Path.embeddedMessageReceived, body: body as! [String: String])))
     }
@@ -479,7 +478,7 @@ struct RequestCreator {
         
         addUserKey(intoDict: &body)
         
-        // TODO: find/create proper key for the value of the embedded message ID
+        body.setValue(for: JsonKey.messageId, value: String(message.metadata.id))
         
         return .success(.post(createPostRequest(path: Const.Path.embeddedMessageClick, body: body as! [String: String])))
     }

--- a/swift-sdk/IterableEmbeddedMessagingManagerProtocol.swift
+++ b/swift-sdk/IterableEmbeddedMessagingManagerProtocol.swift
@@ -12,4 +12,8 @@ import Foundation
     
     func addUpdateListener(_ listener: IterableEmbeddedMessagingUpdateDelegate)
     func removeUpdateListener(_ listener: IterableEmbeddedMessagingUpdateDelegate)
+    
+    func track(click message: IterableEmbeddedMessage)
+    func track(impression message: IterableEmbeddedMessage)
+
 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-6038](https://iterable.atlassian.net/browse/MOB-6038)

## ✏️ Description

> Please provide a brief description of what this pull request does.
This PR makes the Iterable SDK use Iterable events for click and delivery events on embedded messages instead of the track api

[MOB-6038]: https://iterable.atlassian.net/browse/MOB-6038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ