### PR TITLE
Fix custom payload decoding

### DIFF
--- a/swift-sdk/Internal/EmbeddedMessagingManager.swift
+++ b/swift-sdk/Internal/EmbeddedMessagingManager.swift
@@ -45,7 +45,7 @@ class EmbeddedMessagingManager: NSObject, IterableEmbeddedMessagingManagerProtoc
     public func track(click message: IterableEmbeddedMessage) {
         apiClient.track(embeddedMessageClick: message)
 //        IterableAPI.track(event: "embedded-messaging", dataFields: ["name": "click",
-//                                                                    "messageId": message.metadata.id])
+//                                                                    "messageId": message.metadata.messageId])
     }
     
 //    public func track(dismiss message: IterableEmbeddedMessage) {
@@ -55,7 +55,7 @@ class EmbeddedMessagingManager: NSObject, IterableEmbeddedMessagingManagerProtoc
     public func track(impression message: IterableEmbeddedMessage) {
 //        apiClient.track(embeddedMessageImpression: message)
         IterableAPI.track(event: "embedded-messaging", dataFields: ["name": "impression",
-                                                                    "messageId": message.metadata.id])
+                                                                    "messageId": message.metadata.messageId])
     }
     
     public func track(embeddedSession: IterableEmbeddedSession) {
@@ -157,7 +157,7 @@ class EmbeddedMessagingManager: NSObject, IterableEmbeddedMessagingManagerProtoc
             apiClient.track(embeddedMessageReceived: message)
 //            IterableAPI.track(event: "embedded-messaging",
 //                              dataFields: ["name": "received",
-//                                           "messageId": message.metadata.id]
+//                                           "messageId": message.metadata.messageId]
 //            )
         }
     }

--- a/swift-sdk/Internal/EmbeddedMessagingProcessor.swift
+++ b/swift-sdk/Internal/EmbeddedMessagingProcessor.swift
@@ -37,19 +37,19 @@ struct EmbeddedMessagingProcessor {
     private let fetchedMessages: [IterableEmbeddedMessage]
     
     private func getNewMessages() -> [IterableEmbeddedMessage] {
-        let currentMessageIds = currentMessages.map { $0.metadata.id }
+        let currentMessageIds = currentMessages.map { $0.metadata.messageId }
         
         return fetchedMessages
             .filter { message in
-                !currentMessageIds.contains(where: { $0 == message.metadata.id })
+                !currentMessageIds.contains(where: { $0 == message.metadata.messageId })
             }
     }
     
     private func getCurrentMessageIds() -> [Int] {
-        return currentMessages.map { $0.metadata.id }
+        return currentMessages.map { $0.metadata.messageId }
     }
     
     private func getFetchedMessageIds() -> [Int] {
-        return fetchedMessages.map { $0.metadata.id }
+        return fetchedMessages.map { $0.metadata.messageId }
     }
 }

--- a/swift-sdk/Internal/EmbeddedMessagingSerialization.swift
+++ b/swift-sdk/Internal/EmbeddedMessagingSerialization.swift
@@ -95,7 +95,7 @@ extension IterableEmbeddedMessage: Codable {
         guard let container = try? decoder.container(keyedBy: CodingKeys.self) else {
             ITBError("unable to decode embedded messages payload")
             
-            self.init(id: 0)
+            self.init(messageId: 0)
             
             return
         }
@@ -113,7 +113,7 @@ extension IterableEmbeddedMessage: Codable {
         
         guard let metadata = metadata else {
             ITBError("unable to decode metadata section of embedded messages payload")
-            self.init(id: 0)
+            self.init(messageId: 0)
             
             return
         }

--- a/swift-sdk/Internal/EmbeddedMessagingSerialization.swift
+++ b/swift-sdk/Internal/EmbeddedMessagingSerialization.swift
@@ -4,6 +4,38 @@
 
 import Foundation
 
+struct AnyDecodable: Decodable {
+    let value: Any
+
+    // the current implementation decodes the following value types: null, int, string, bool, double, array, and dictionary
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            value = NSNull()
+        }
+        else if let intVal = try? container.decode(Int.self) {
+            value = intVal
+        } else if let stringVal = try? container.decode(String.self) {
+            value = stringVal
+        } else if let boolVal = try? container.decode(Bool.self) {
+            value = boolVal
+        } else if let doubleVal = try? container.decode(Double.self) {
+            value = doubleVal
+        } else if let arrayVal = try? container.decode([AnyDecodable].self) {
+            value = arrayVal.map { $0.value }
+        } else if let dictionaryVal = try? container.decode([String: AnyDecodable].self) {
+            var dictionary: [String: Any] = [:]
+            for (key, val) in dictionaryVal {
+                dictionary[key] = val.value
+            }
+            value = dictionary
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Container contains an unexpected type")
+        }
+    }
+}
+
+
 struct EmbeddedMessagingSerialization {
     static func encode(messages: [IterableEmbeddedMessage]) -> Data {
         guard let encoded = try? JSONEncoder().encode(EmbeddedMessagesPayload(embeddedMessages: messages)) else {
@@ -70,7 +102,14 @@ extension IterableEmbeddedMessage: Codable {
         
         let metadata = (try? container.decode(EmbeddedMessageMetadata.self, forKey: .metadata))
         let elements = (try? container.decode(EmbeddedMessageElements.self, forKey: .elements))
-        let payload = EmbeddedMessagingSerialization.decode(payload: try? container.decode(Data.self, forKey: .payload))
+        var payload: [String: Any]? = nil
+        
+        do {
+            let anyDecodable = try container.decodeIfPresent(AnyDecodable.self, forKey: .payload)
+            payload = anyDecodable?.value as? [String: Any]
+        } catch {
+            ITBError("Error decoding payload data: \(error)")
+        }
         
         guard let metadata = metadata else {
             ITBError("unable to decode metadata section of embedded messages payload")

--- a/swift-sdk/Internal/EmbeddedSessionManager.swift
+++ b/swift-sdk/Internal/EmbeddedSessionManager.swift
@@ -30,7 +30,7 @@ public class EmbeddedSessionManager {
         }
         session.embeddedSessionEnd = Date()
         updateDisplayDurations()
-//        let _ = IterableAPI.embeddedMessagingManager.track(embeddedSession: session)
+        let _ = IterableAPI.embeddedMessagingManager.track(embeddedSession: session)
     }
     
     public func pauseImpression(impressionId: String) {

--- a/swift-sdk/Internal/EmbeddedSessionManager.swift
+++ b/swift-sdk/Internal/EmbeddedSessionManager.swift
@@ -13,11 +13,13 @@ public class EmbeddedSessionManager {
     var currentlyTrackingImpressions: [String: (totalDisplayDuration: TimeInterval, startTime: Date, tracking: Bool)] = [:]
 
     public func startSession() {
+        print("starting session...")
         let startTime = Date()
         session = IterableEmbeddedSession(embeddedSessionId: UUID().uuidString, embeddedSessionStart: startTime, impressions: [])
     }
 
     public func endSession() {
+        print("ending session...")
         guard let session = session else {
             ITBError("No current session.")
             return
@@ -28,7 +30,7 @@ public class EmbeddedSessionManager {
         }
         session.embeddedSessionEnd = Date()
         updateDisplayDurations()
-        let _ = IterableAPI.embeddedMessagingManager.track(embeddedSession: session)
+//        let _ = IterableAPI.embeddedMessagingManager.track(embeddedSession: session)
     }
     
     public func pauseImpression(impressionId: String) {

--- a/swift-sdk/Internal/RequestCreator.swift
+++ b/swift-sdk/Internal/RequestCreator.swift
@@ -457,7 +457,7 @@ struct RequestCreator {
         
         addUserKey(intoDict: &body)
         
-        body.setValue(for: JsonKey.messageId, value: String(message.metadata.id))
+        body.setValue(for: JsonKey.messageId, value: String(message.metadata.messageId))
         
         return .success(.post(createPostRequest(path: Const.Path.embeddedMessageReceived, body: body as! [String: String])))
     }
@@ -478,7 +478,7 @@ struct RequestCreator {
         
         addUserKey(intoDict: &body)
         
-        body.setValue(for: JsonKey.messageId, value: String(message.metadata.id))
+        body.setValue(for: JsonKey.messageId, value: String(message.metadata.messageId))
         
         return .success(.post(createPostRequest(path: Const.Path.embeddedMessageClick, body: body as! [String: String])))
     }

--- a/swift-sdk/IterableEmbeddedMessage.swift
+++ b/swift-sdk/IterableEmbeddedMessage.swift
@@ -18,8 +18,8 @@ public final class IterableEmbeddedMessage: NSObject {
         self.payload = payload
     }
     
-    convenience init(id: Int, campaignId: String? = nil, isProof: Bool? = nil) {
-        let metadata = EmbeddedMessageMetadata(id: id, campaignId: campaignId, isProof: isProof)
+    convenience init(messageId: Int, campaignId: String? = nil, isProof: Bool? = nil) {
+        let metadata = EmbeddedMessageMetadata(messageId: messageId, campaignId: campaignId, isProof: isProof)
         
         self.init(metadata: metadata)
     }
@@ -27,7 +27,7 @@ public final class IterableEmbeddedMessage: NSObject {
 
 extension IterableEmbeddedMessage {
     public struct EmbeddedMessageMetadata: Codable {
-        public let id: Int
+        public let messageId: Int
         public let campaignId: String?
         public let isProof: Bool?
     }
@@ -40,6 +40,7 @@ extension IterableEmbeddedMessage {
         public let buttons: [EmbeddedMessageElementsButton]?
         public let images: [EmbeddedMessageElementsImage]?
         public let text: [EmbeddedMessageElementsText]?
+        public let defaultAction: EmbeddedMessageElementsDefaultAction?
         
         public struct EmbeddedMessageElementsButton: Codable {
             public let id: String
@@ -58,6 +59,11 @@ extension IterableEmbeddedMessage {
         }
 
         public struct EmbeddedMessageElementsButtonAction: Codable {
+            public let type: String
+            public let data: String?
+        }
+        
+        public struct EmbeddedMessageElementsDefaultAction: Codable {
             public let type: String
             public let data: String?
         }

--- a/tests/embedded-messaging-tests/EmbeddedMessagingProcessorTests.swift
+++ b/tests/embedded-messaging-tests/EmbeddedMessagingProcessorTests.swift
@@ -14,7 +14,7 @@ final class EmbeddedMessagingProcessorTests: XCTestCase {
         let processor = EmbeddedMessagingProcessor(currentMessages: currentMessages,
                                                    fetchedMessages: fetchedMessages)
         
-        XCTAssertEqual(processor.processedMessagesList().map { $0.metadata.id },
+        XCTAssertEqual(processor.processedMessagesList().map { $0.metadata.messageId },
                        [1, 3, 4, 5])
     }
     
@@ -35,7 +35,7 @@ final class EmbeddedMessagingProcessorTests: XCTestCase {
         let processor = EmbeddedMessagingProcessor(currentMessages: currentMessages,
                                                    fetchedMessages: fetchedMessages)
         
-        XCTAssertEqual(processor.newlyRetrievedMessages().map { $0.metadata.id }, [4])
+        XCTAssertEqual(processor.newlyRetrievedMessages().map { $0.metadata.messageId }, [4])
     }
     
 //    func testPlacementIdsToNotify() {


### PR DESCRIPTION
This PR fixes the custom payload decoding in embedded messages. Should work on most standard JSON structures. Tested with the following payload:
```
{
  "test": null,
  "testObj": [
    {
      "testObjKey1": 1,
      "testObjKey2": "two"
    },
    {
      "testObj2Key1": {
        "Obj2NestedKey1": 1,
        "obj2NestedKey2": "two"
      },
      "testObj2key2": "2"
    }
  ],
  "messageImportance": "low"
}
```