### PR TITLE
[MOB-6317] make data region enum accessible

### DIFF
--- a/swift-sdk/Constants.swift
+++ b/swift-sdk/Constants.swift
@@ -270,9 +270,9 @@ enum JsonValue {
     }
 }
 
-enum IterableDataRegion {
-    static let US = "https://api.iterable.com/api/"
-    static let EU = "https://api.eu.iterable.com/api/"
+public enum IterableDataRegion {
+    public static let US = "https://api.iterable.com/api/"
+    public static let EU = "https://api.eu.iterable.com/api/"
 }
 
 public protocol JsonValueRepresentable {


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-6317](https://iterable.atlassian.net/browse/MOB-6317)

## ✏️ Description

> Fixes the enum to make it publicly available to RN SDK 


[MOB-6317]: https://iterable.atlassian.net/browse/MOB-6317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ