### PR TITLE
[MOB-6356] Use email or uid when making requests to api

### DIFF
--- a/swift-sdk/Internal/RequestCreator.swift
+++ b/swift-sdk/Internal/RequestCreator.swift
@@ -436,7 +436,7 @@ struct RequestCreator {
             args[JsonKey.Embedded.packageName] = packageName
         }
         
-        addUserKey(intoDict: &args)
+        setCurrentUser(inDict: &args)
         
         return .success(.get(createGetRequest(forPath: Const.Path.getEmbeddedMessages, withArgs: args as! [String: String])))
     }
@@ -455,7 +455,7 @@ struct RequestCreator {
             body[JsonKey.Embedded.packageName] = packageName
         }
         
-        addUserKey(intoDict: &body)
+        setCurrentUser(inDict: &body)
         
         body.setValue(for: JsonKey.messageId, value: String(message.metadata.messageId))
         
@@ -476,7 +476,7 @@ struct RequestCreator {
             body[JsonKey.Embedded.packageName] = packageName
         }
         
-        addUserKey(intoDict: &body)
+        setCurrentUser(inDict: &body)
         
         body.setValue(for: JsonKey.messageId, value: String(message.metadata.messageId))
         
@@ -497,7 +497,7 @@ struct RequestCreator {
             body[JsonKey.Embedded.packageName] = packageName
         }
         
-        addUserKey(intoDict: &body)
+        setCurrentUser(inDict: &body)
         
         // TODO: find/create proper key for the value of the embedded message ID
         
@@ -518,7 +518,7 @@ struct RequestCreator {
             body[JsonKey.Embedded.packageName] = packageName
         }
         
-        addUserKey(intoDict: &body)
+        setCurrentUser(inDict: &body)
         
         // TODO: find/create proper key for the value of the embedded message ID
         
@@ -546,7 +546,7 @@ struct RequestCreator {
 
         var body = [AnyHashable: Any]()
         
-        addUserKey(intoDict: &body)
+        setCurrentUser(inDict: &body)
 
         body.setValue(for: JsonKey.embeddedSessionId, value: [
             "id": embeddedSessionId,


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-6356](https://iterable.atlassian.net/browse/MOB-6356)

## ✏️ Description

This PR enables UID in embedded message requests. If the user is signed in via email, it will use email. If the user is signed in via uid, it will use uid when making requests to the API.

[MOB-6356]: https://iterable.atlassian.net/browse/MOB-6356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ