### PR TITLE
Fix click tracking and metadata

### DIFF
--- a/swift-sdk/Constants.swift
+++ b/swift-sdk/Constants.swift
@@ -180,6 +180,8 @@ enum JsonKey {
     static let placementId = "placementId"
     static let embeddedSessionStart = "embeddedSessionStart"
     static let embeddedSessionEnd = "embeddedSessionEnd"
+    static let embeddedButtonId = "buttonIdentifier"
+    static let embeddedTargetUrl = "targetUrl"
     
     
     enum ActionButton {

--- a/swift-sdk/Internal/ApiClient.swift
+++ b/swift-sdk/Internal/ApiClient.swift
@@ -231,8 +231,8 @@ extension ApiClient: ApiClientProtocol {
     }
     
     @discardableResult
-    func track(embeddedMessageClick message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError> {
-        let result = createRequestCreator().flatMap { $0.createEmbeddedMessageClickRequest(message) }
+    func track(embeddedMessageClick message: IterableEmbeddedMessage, clickType: String) -> Pending<SendRequestValue, SendRequestError> {
+        let result = createRequestCreator().flatMap { $0.createEmbeddedMessageClickRequest(message, clickType) }
         return send(iterableRequestResult: result)
     }
     

--- a/swift-sdk/Internal/ApiClientProtocol.swift
+++ b/swift-sdk/Internal/ApiClientProtocol.swift
@@ -50,7 +50,7 @@ protocol ApiClientProtocol: AnyObject {
     
     @discardableResult func track(embeddedMessageReceived message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError>
     
-    @discardableResult func track(embeddedMessageClick message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError>
+    @discardableResult func track(embeddedMessageClick message: IterableEmbeddedMessage, clickType: String) -> Pending<SendRequestValue, SendRequestError>
     
     func track(embeddedMessageDismiss message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError>
     

--- a/swift-sdk/Internal/EmbeddedMessagingManager.swift
+++ b/swift-sdk/Internal/EmbeddedMessagingManager.swift
@@ -42,8 +42,8 @@ class EmbeddedMessagingManager: NSObject, IterableEmbeddedMessagingManagerProtoc
         retrieveEmbeddedMessages()
     }
     
-    public func track(click message: IterableEmbeddedMessage) {
-        apiClient.track(embeddedMessageClick: message)
+    public func track(click message: IterableEmbeddedMessage, clickType: String) {
+        apiClient.track(embeddedMessageClick: message, clickType: clickType)
 //        IterableAPI.track(event: "embedded-messaging", dataFields: ["name": "click",
 //                                                                    "messageId": message.metadata.messageId])
     }

--- a/swift-sdk/Internal/EmbeddedSessionManager.swift
+++ b/swift-sdk/Internal/EmbeddedSessionManager.swift
@@ -15,6 +15,7 @@ public class EmbeddedSessionManager {
     public func startSession() {
         print("starting session...")
         let startTime = Date()
+        currentlyTrackingImpressions = [:]
         session = IterableEmbeddedSession(embeddedSessionId: UUID().uuidString, embeddedSessionStart: startTime, impressions: [])
     }
 

--- a/swift-sdk/Internal/EmptyEmbeddedMessagingManager.swift
+++ b/swift-sdk/Internal/EmptyEmbeddedMessagingManager.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 class EmptyEmbeddedMessagingManager: IterableEmbeddedMessagingManagerProtocol {
+    
     func addUpdateListener(_ listener: IterableEmbeddedMessagingUpdateDelegate) {
         
     }
@@ -25,7 +26,11 @@ class EmptyEmbeddedMessagingManager: IterableEmbeddedMessagingManagerProtocol {
         
     }
     
-    func track(click message: IterableEmbeddedMessage) {
+    func temp_manualOverrideRefresh() {
+        
+    }
+    
+    func track(click message: IterableEmbeddedMessage, clickType: String) {
             
     }
     

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -424,9 +424,11 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
     
     @discardableResult
     func track(embeddedMessageClick message: IterableEmbeddedMessage,
+               clickType: String,
                onSuccess: OnSuccessHandler? = nil,
                onFailure: OnFailureHandler? = nil) -> Pending<SendRequestValue, SendRequestError> {
         requestHandler.track(embeddedMessageClick: message,
+                             clickType: clickType,
                              onSuccess: onSuccess,
                              onFailure: onFailure)
     }

--- a/swift-sdk/Internal/OfflineRequestProcessor.swift
+++ b/swift-sdk/Internal/OfflineRequestProcessor.swift
@@ -246,11 +246,11 @@ struct OfflineRequestProcessor: RequestProcessorProtocol {
     }
     
     @discardableResult
-    func track(embeddedMessageClick message: IterableEmbeddedMessage,
+    func track(embeddedMessageClick message: IterableEmbeddedMessage, clickType: String,
                onSuccess: OnSuccessHandler? = nil,
                onFailure: OnFailureHandler? = nil) -> Pending<SendRequestValue, SendRequestError> {
         let requestGenerator = { (requestCreator: RequestCreator) in
-            requestCreator.createEmbeddedMessageClickRequest(message)
+            requestCreator.createEmbeddedMessageClickRequest(message, clickType)
         }
         
         return sendIterableRequest(requestGenerator: requestGenerator,

--- a/swift-sdk/Internal/OnlineRequestProcessor.swift
+++ b/swift-sdk/Internal/OnlineRequestProcessor.swift
@@ -244,10 +244,10 @@ struct OnlineRequestProcessor: RequestProcessorProtocol {
     }
     
     @discardableResult
-    func track(embeddedMessageClick message: IterableEmbeddedMessage,
+    func track(embeddedMessageClick message: IterableEmbeddedMessage, clickType: String,
                onSuccess: OnSuccessHandler? = nil,
                onFailure: OnFailureHandler? = nil) -> Pending<SendRequestValue, SendRequestError> {
-        sendRequest(requestProvider: { apiClient.track(embeddedMessageClick: message) },
+        sendRequest(requestProvider: { apiClient.track(embeddedMessageClick: message, clickType: clickType) },
                     successHandler: onSuccess,
                     failureHandler: onFailure,
                     requestIdentifier: "trackEmbeddedMessageClick")

--- a/swift-sdk/Internal/RequestCreator.swift
+++ b/swift-sdk/Internal/RequestCreator.swift
@@ -457,7 +457,7 @@ struct RequestCreator {
         return .success(.post(createPostRequest(path: Const.Path.embeddedMessageReceived, body: body)))
     }
     
-    func createEmbeddedMessageClickRequest(_ message: IterableEmbeddedMessage) -> Result<IterableRequest, IterableError> {
+    func createEmbeddedMessageClickRequest(_ message: IterableEmbeddedMessage, _ clickType: String) -> Result<IterableRequest, IterableError> {
         if case .none = auth.emailOrUserId {
             ITBError(Self.authMissingMessage)
             return .failure(IterableError.general(description: Self.authMissingMessage))
@@ -467,7 +467,34 @@ struct RequestCreator {
         
         setCurrentUser(inDict: &body)
         
+        switch clickType {
+            case "primaryEmbeddedMessageButton":
+                if let buttonData = message.elements?.buttons?.first {
+                    if !buttonData.id.isEmpty {
+                        body.setValue(for: JsonKey.embeddedButtonId, value: buttonData.id)
+                    }
+                    if let actionData = buttonData.action?.data, !actionData.isEmpty {
+                        body.setValue(for: JsonKey.embeddedTargetUrl, value: actionData)
+                    }
+                }
+            case "secondaryEmbeddedMessageButton":
+                if let buttonData = message.elements?.buttons?.dropFirst().first {
+                    if !buttonData.id.isEmpty {
+                        body.setValue(for: JsonKey.embeddedButtonId, value: buttonData.id)
+                    }
+                    if let actionData = buttonData.action?.data, !actionData.isEmpty {
+                        body.setValue(for: JsonKey.embeddedTargetUrl, value: actionData)
+                    }
+                }
+            case "embeddedMessage":
+                if let defaultActionData = message.elements?.defaultAction?.data, !defaultActionData.isEmpty {
+                    body.setValue(for: JsonKey.embeddedTargetUrl, value: defaultActionData)
+                }
+            default:
+                return .failure(IterableError.general(description: "Invalid click type"))
+        }
         body.setValue(for: JsonKey.messageId, value: message.metadata.messageId)
+
         body.setValue(for: JsonKey.deviceInfo, value: deviceMetadata.asDictionary())
         
         return .success(.post(createPostRequest(path: Const.Path.embeddedMessageClick, body: body)))

--- a/swift-sdk/Internal/RequestCreator.swift
+++ b/swift-sdk/Internal/RequestCreator.swift
@@ -447,19 +447,14 @@ struct RequestCreator {
             return .failure(IterableError.general(description: Self.authMissingMessage))
         }
         
-        var body: [AnyHashable: Any] = [JsonKey.platform: JsonValue.iOS,
-                                        JsonKey.systemVersion: UIDevice.current.systemVersion,
-                                        JsonKey.Embedded.sdkVersion: IterableAPI.sdkVersion]
-        
-        if let packageName = Bundle.main.appPackageName {
-            body[JsonKey.Embedded.packageName] = packageName
-        }
+        var body = [AnyHashable: Any]()
         
         setCurrentUser(inDict: &body)
         
         body.setValue(for: JsonKey.messageId, value: message.metadata.messageId)
+        body.setValue(for: JsonKey.deviceInfo, value: deviceMetadata.asDictionary())
         
-        return .success(.post(createPostRequest(path: Const.Path.embeddedMessageReceived, body: body as! [String: String])))
+        return .success(.post(createPostRequest(path: Const.Path.embeddedMessageReceived, body: body)))
     }
     
     func createEmbeddedMessageClickRequest(_ message: IterableEmbeddedMessage) -> Result<IterableRequest, IterableError> {
@@ -468,19 +463,14 @@ struct RequestCreator {
             return .failure(IterableError.general(description: Self.authMissingMessage))
         }
         
-        var body: [AnyHashable: Any] = [JsonKey.platform: JsonValue.iOS,
-                                        JsonKey.systemVersion: UIDevice.current.systemVersion,
-                                        JsonKey.Embedded.sdkVersion: IterableAPI.sdkVersion]
-        
-        if let packageName = Bundle.main.appPackageName {
-            body[JsonKey.Embedded.packageName] = packageName
-        }
+        var body = [AnyHashable: Any]()
         
         setCurrentUser(inDict: &body)
         
         body.setValue(for: JsonKey.messageId, value: message.metadata.messageId)
+        body.setValue(for: JsonKey.deviceInfo, value: deviceMetadata.asDictionary())
         
-        return .success(.post(createPostRequest(path: Const.Path.embeddedMessageClick, body: body as! [String: String])))
+        return .success(.post(createPostRequest(path: Const.Path.embeddedMessageClick, body: body)))
     }
     
     func createEmbeddedMessageDismissRequest(_ message: IterableEmbeddedMessage) -> Result<IterableRequest, IterableError> {
@@ -509,20 +499,16 @@ struct RequestCreator {
             ITBError(Self.authMissingMessage)
             return .failure(IterableError.general(description: Self.authMissingMessage))
         }
+
         
-        var body: [AnyHashable: Any] = [JsonKey.platform: JsonValue.iOS,
-                                        JsonKey.systemVersion: UIDevice.current.systemVersion,
-                                        JsonKey.Embedded.sdkVersion: IterableAPI.sdkVersion]
-        
-        if let packageName = Bundle.main.appPackageName {
-            body[JsonKey.Embedded.packageName] = packageName
-        }
+        var body = [AnyHashable: Any]()
         
         setCurrentUser(inDict: &body)
         
-        // TODO: find/create proper key for the value of the embedded message ID
+        body.setValue(for: JsonKey.messageId, value: message.metadata.messageId)
+        body.setValue(for: JsonKey.deviceInfo, value: deviceMetadata.asDictionary())
         
-        return .success(.post(createPostRequest(path: Const.Path.embeddedMessageImpression, body: body as! [String: String])))
+        return .success(.post(createPostRequest(path: Const.Path.embeddedMessageImpression, body: body)))
     }
     
     func createTrackEmbeddedSessionRequest(embeddedSession: IterableEmbeddedSession) -> Result<IterableRequest, IterableError> {

--- a/swift-sdk/Internal/RequestHandler.swift
+++ b/swift-sdk/Internal/RequestHandler.swift
@@ -269,11 +269,12 @@ class RequestHandler: RequestHandlerProtocol {
     }
     
     @discardableResult
-    func track(embeddedMessageClick message: IterableEmbeddedMessage,
+    func track(embeddedMessageClick message: IterableEmbeddedMessage, clickType: String,
                onSuccess: OnSuccessHandler?,
                onFailure: OnFailureHandler?) -> Pending<SendRequestValue, SendRequestError> {
         sendUsingRequestProcessor { processor in
             processor.track(embeddedMessageClick: message,
+                            clickType: clickType,
                             onSuccess: onSuccess,
                             onFailure: onFailure)
         }

--- a/swift-sdk/Internal/RequestHandlerProtocol.swift
+++ b/swift-sdk/Internal/RequestHandlerProtocol.swift
@@ -125,6 +125,7 @@ protocol RequestHandlerProtocol: AnyObject {
     
     @discardableResult
     func track(embeddedMessageClick message: IterableEmbeddedMessage,
+               clickType: String,
                onSuccess: OnSuccessHandler?,
                onFailure: OnFailureHandler?) -> Pending<SendRequestValue, SendRequestError>
     

--- a/swift-sdk/Internal/RequestProcessorProtocol.swift
+++ b/swift-sdk/Internal/RequestProcessorProtocol.swift
@@ -106,7 +106,7 @@ protocol RequestProcessorProtocol {
                onFailure: OnFailureHandler?) -> Pending<SendRequestValue, SendRequestError>
     
     @discardableResult
-    func track(embeddedMessageClick message: IterableEmbeddedMessage,
+    func track(embeddedMessageClick message: IterableEmbeddedMessage, clickType: String,
                onSuccess: OnSuccessHandler?,
                onFailure: OnFailureHandler?) -> Pending<SendRequestValue, SendRequestError>
     

--- a/swift-sdk/IterableEmbeddedMessagingManagerProtocol.swift
+++ b/swift-sdk/IterableEmbeddedMessagingManagerProtocol.swift
@@ -13,7 +13,9 @@ import Foundation
     func addUpdateListener(_ listener: IterableEmbeddedMessagingUpdateDelegate)
     func removeUpdateListener(_ listener: IterableEmbeddedMessagingUpdateDelegate)
     
-    func track(click message: IterableEmbeddedMessage)
+    func temp_manualOverrideRefresh()
+    
+    func track(click message: IterableEmbeddedMessage, clickType: String)
     func track(impression message: IterableEmbeddedMessage)
     func track(embeddedSession: IterableEmbeddedSession)
 

--- a/tests/unit-tests/BlankApiClient.swift
+++ b/tests/unit-tests/BlankApiClient.swift
@@ -87,7 +87,7 @@ class BlankApiClient: ApiClientProtocol {
         Pending()
     }
     
-    func track(embeddedMessageClick message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError> {
+    func track(embeddedMessageClick message: IterableEmbeddedMessage, clickType: String) -> Pending<SendRequestValue, SendRequestError> {
         Pending()
     }
     


### PR DESCRIPTION
General bug fixes in advance prior to bug bash.

- Fix click tracking to pass on click event type string along with message and then obtain appropriate click data in request creator.
- Enable temp_manualOverrideRefresh() to manually refresh SDK messages
- Fix embedded tracking metadata