### PR TITLE
fix integration tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Build and test
       env: 
         api_key: ${{secrets.E2E_API_KEY}}
+        server_api_key: ${{secrets.E2E_SERVER_API_KEY}}
         push_campaign_id: ${{secrets.E2E_PUSH_CAMPAIGN_ID}}
         push_template_id: ${{secrets.E2E_PUSH_TEMPLATE_ID}}
         in_app_campaign_id: ${{secrets.E2E_IN_APP_CAMPAIGN_ID}}

--- a/tests/endpoint-tests/CI.swift.template
+++ b/tests/endpoint-tests/CI.swift.template
@@ -8,6 +8,7 @@ import Foundation
 /// Actual values will be injected by build step
 struct CI {
     static let apiKey = "{api_key}"
+    static let serverApiKey = "{server_api_key}"
     static let pushCampaignId = NSNumber(0)
     static let pushTemplateId = NSNumber(0)
     static let inAppCampaignId = NSNumber(0)

--- a/tests/endpoint-tests/EndpointTests.swift
+++ b/tests/endpoint-tests/EndpointTests.swift
@@ -215,10 +215,13 @@ class EndpointTests: XCTestCase {
         ensureInAppMessages(api: api, email: email)
         
         api.inAppManager.scheduleSync().wait()
-        let count = api.inAppManager.getMessages().count
-        XCTAssert(count > 0)
-        
-        let message = api.inAppManager.getMessages()[0]
+        let messages = api.inAppManager.getMessages()
+        XCTAssert(messages.count > 0)
+
+        guard let message = messages.first else {
+            XCTFail("No messages available")
+            return
+        }
         let startTime = Date()
         let endTime = startTime.addingTimeInterval(10.0)
         
@@ -274,6 +277,7 @@ class EndpointTests: XCTestCase {
     }
     
     private static let apiKey = Environment.apiKey!
+    private static let serverApiKey = Environment.serverApiKey!
     private static let pushCampaignId = Environment.pushCampaignId!
     private static let pushTemplateId = Environment.pushTemplateId!
     private static let inAppCampaignId = Environment.inAppCampaignId!
@@ -288,7 +292,7 @@ class EndpointTests: XCTestCase {
         }
         
         let expectation1 = expectation(for: predicate, evaluatedWith: nil, handler: nil)
-        wait(for: [expectation1], timeout: 60)
+        wait(for: [expectation1], timeout: 120)
     }
     
     private func clearAllInAppMessages(api: InternalIterableAPI) {

--- a/tests/endpoint-tests/Environment.swift
+++ b/tests/endpoint-tests/Environment.swift
@@ -10,6 +10,7 @@ import Foundation
 struct Environment {
     enum Key: String {
         case apiKey = "api_key"
+        case serverApiKey = "server_api_key"
         case pushCampaignId = "push_campaign_id"
         case pushTemplateId = "push_template_id"
         case inAppCampaignId = "in_app_campaign_id"
@@ -18,6 +19,10 @@ struct Environment {
     
     static var apiKey: String? {
         getFromEnv(key: .apiKey) ?? CI.apiKey
+    }
+
+    static var serverApiKey: String? {
+        getFromEnv(key: .serverApiKey) ?? CI.serverApiKey
     }
     
     static var pushCampaignId: NSNumber? {

--- a/tests/endpoint-tests/IterableAPISupport.swift
+++ b/tests/endpoint-tests/IterableAPISupport.swift
@@ -12,7 +12,7 @@ struct IterableAPISupport {
         }
         
         var urlRequest = URLRequest(url: url)
-        urlRequest.setValue(apiKey, forHTTPHeaderField: JsonKey.Header.apiKey)
+        urlRequest.setValue(serverApiKey, forHTTPHeaderField: JsonKey.Header.apiKey)
         
         return RequestSender.sendRequest(urlRequest, usingSession: urlSession)
     }
@@ -44,6 +44,7 @@ struct IterableAPISupport {
     }
     
     private static let apiKey = Environment.apiKey!
+    private static let serverApiKey = Environment.serverApiKey!
     
     private static func createPostRequest(iterablePostRequest: PostRequest) -> URLRequest? {
         IterableRequestUtil.createPostRequest(forApiEndPoint: Path.apiEndpoint,
@@ -57,7 +58,7 @@ struct IterableAPISupport {
         [JsonKey.contentType: JsonValue.applicationJson,
          JsonKey.Header.sdkPlatform: JsonValue.iOS,
          JsonKey.Header.sdkVersion: IterableAPI.sdkVersion,
-         JsonKey.Header.apiKey: apiKey]
+         JsonKey.Header.apiKey: serverApiKey]
     }
     
     private static var urlSession: URLSession = {

--- a/tests/endpoint-tests/scripts/env_vars.sh.sample
+++ b/tests/endpoint-tests/scripts/env_vars.sh.sample
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export api_key=the_api_key
+export server_api_key=the_server_api_key
 export push_campaign_id=0
 export push_template_id=0
 export in_app_campaign_id=0

--- a/tests/endpoint-tests/scripts/run_test.sh
+++ b/tests/endpoint-tests/scripts/run_test.sh
@@ -14,6 +14,7 @@ fi
 
 echo Generating CI.swift
 sed -e "s/\(apiKey = \).*$/\1\"$api_key\"/" \
+-e "s/\(serverApiKey = \).*$/\1\"$server_api_key\"/" \
 -e "s/\(pushCampaignId = \).*$/\1\NSNumber($push_campaign_id)/" \
 -e "s/\(pushTemplateId = \).*$/\1\NSNumber($push_template_id)/" \
 -e "s/\(inAppCampaignId = \).*$/\1\NSNumber($in_app_campaign_id)/" \


### PR DESCRIPTION
This PR fixes integration test failures related to:

1. No proper server key for sending in app messages (e.g. /inApp/target) via IterableAPISupport
2. The mobile SDK test project caching is broken somehow so that calling getMessages yields a set of messages each with the same data, including messageIds, none of which correspond to the actual messageIds for a user's non-consumed messages. This means we cannot consume those messages via our integration test, causing the tests to fail.
