### PR TITLE
Fix Start Embedded Impression duplicates

### DIFF
--- a/swift-sdk/Internal/EmbeddedSessionManager.swift
+++ b/swift-sdk/Internal/EmbeddedSessionManager.swift
@@ -63,6 +63,9 @@ public class EmbeddedSessionManager {
     }
 
     public func startImpression(messageId: String) {
+        if let trackingImpression = currentlyTrackingImpressions[messageId], trackingImpression.tracking {
+            return
+        }
         if let _ = currentlyTrackingImpressions[messageId] {
             if let index = session?.impressions.firstIndex(where: { $0.messageId == messageId }) {
                 session?.impressions[index].displayCount += 1


### PR DESCRIPTION


## ✏️ Description

Fixes a bug where embedded impressions count could increase when reforegrounding the app. startImpression(messageId:) will simply return if the message (associated by the messageId) is already being tracked.