### PR TITLE
Add `onLogoutPreviousUserFailed` delegate to the `IterableAuthDelegate`

### DIFF
--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -506,7 +506,9 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         }
         
         if config.autoPushRegistration {
-            disableDeviceForCurrentUser()
+            disableDeviceForCurrentUser(onFailure:  { [weak self] reason, data in
+                self?.config.authDelegate?.onLogoutPreviousUserFailed(reason)
+            })
         }
         
         _email = nil

--- a/swift-sdk/IterableConfig.swift
+++ b/swift-sdk/IterableConfig.swift
@@ -56,6 +56,7 @@ import Foundation
 @objc public protocol IterableAuthDelegate: AnyObject {
     @objc func onAuthTokenRequested(completion: @escaping AuthTokenRetrievalHandler)
     @objc func onTokenRegistrationFailed(_ reason: String?)
+    @objc func onLogoutPreviousUserFailed(_ reason: String?)
 }
 
 /// Iterable Configuration Object. Use this when initializing the API.


### PR DESCRIPTION
## 🔹 Jira Ticket(s)
I can not make Jira ticket for this because I don't have permission to access Jira.

## ✏️ Description
I am a iOS software engineer at PrestoLabs and was asked by Daryl Greaves to make a PR what I requested specifications.
I requested the specifications below but I only made this PR for 3rd one.

1. Can I use disableDeviceForAllUsers when I set autoPushRegistration as true? 
- I got a response that I can use disableDeviceForAllUsers.
2. Could you make a patch that retry register api when it failed by network error?
- I found a onFailure callback when register api was failed.
- IterableAPI.register(token: Data, , onSuccess: OnSuccessHandler? = nil, onFailure: OnFailureHandler? = nil)
3. Could you make a patch that notify when unregister device failed by 401 error?


