### PR TITLE
Fixed MOB-7031

### DIFF
--- a/swift-sdk/Internal/IterableTaskRunner.swift
+++ b/swift-sdk/Internal/IterableTaskRunner.swift
@@ -52,6 +52,7 @@ class IterableTaskRunner: NSObject {
         ITBInfo()
         persistenceContext.perform { [weak self] in
             self?.paused = true
+            self?.running = false
             self?.connectivityManager.stop()
         }
     }


### PR DESCRIPTION
Fixed TaskRunner pause

## 🔹 Jira Ticket(s)

* [MOB-7031](https://iterable.atlassian.net/browse/MOB-7031)

## ✏️ Description

Fixes TaskRunner pause state; running flag never being set to false


[MOB-7031]: https://iterable.atlassian.net/browse/MOB-7031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ