### PR TITLE
[MOB-7153] Implement JWT retry logic

### DIFF
--- a/swift-sdk/Internal/RequestProcessorUtil.swift
+++ b/swift-sdk/Internal/RequestProcessorUtil.swift
@@ -18,7 +18,7 @@ struct RequestProcessorUtil {
         .onError { error in
             if error.httpStatusCode == 401, error.iterableCode == JsonValue.Code.invalidJwtPayload {
                 ITBError("invalid JWT token, trying again: \(error.reason ?? "")")
-                authManager?.requestNewAuthToken(hasFailedPriorAuth: true) { _ in
+                authManager?.requestNewAuthToken(hasFailedPriorAuth: false) { _ in
                     requestProvider().onSuccess { json in
                         reportSuccess(result: result, value: json, successHandler: onSuccess, identifier: identifier)
                     }.onError { error in

--- a/tests/common/MockAuthManager.swift
+++ b/tests/common/MockAuthManager.swift
@@ -1,0 +1,44 @@
+//
+//  MockAuthManager.swift
+//  swift-sdk
+//
+//  Created by HARDIK MASHRU on 08/11/23.
+//  Copyright © 2023 Iterable. All rights reserved.
+//
+
+import Foundation
+@testable import IterableSDK
+
+class MockAuthManager: IterableAuthManagerProtocol {
+    var shouldRetry = true
+    var retryWasRequested = false
+    
+    func getAuthToken() -> String? {
+        return "AuthToken"
+    }
+    
+    func resetFailedAuthCount() {
+        
+    }
+    
+    func requestNewAuthToken(hasFailedPriorAuth: Bool, onSuccess: ((String?) -> Void)?) {
+        if shouldRetry {
+            // Simulate the authManager obtaining a new token
+            retryWasRequested = true
+            shouldRetry = false
+            onSuccess?("newAuthToken")
+        } else {
+            // Simulate failing to obtain a new token
+            retryWasRequested = false
+            onSuccess?(nil)
+        }
+    }
+    
+    func setNewToken(_ newToken: String) {
+        
+    }
+    
+    func logoutUser() {
+        
+    }
+}

--- a/tests/unit-tests/IterableAPIResponseTests.swift
+++ b/tests/unit-tests/IterableAPIResponseTests.swift
@@ -100,6 +100,54 @@ class IterableAPIResponseTests: XCTestCase {
         wait(for: [xpectation], timeout: testExpectationTimeout)
     }
     
+    func testRetryOnInvalidJwtPayload() {
+        let xpectation = expectation(description: "retry on 401 with invalidJWTPayload")
+        
+        // Mock the dependencies and requestProvider for your test
+        let authManager = MockAuthManager()
+        
+        let networkErrorSession = MockNetworkSession() { _ in
+            MockNetworkSession.MockResponse(statusCode: 401,
+                                            data: ["code":"InvalidJwtPayload"].toJsonData(),
+                                            delay: 1)
+        }
+        
+        let networkSuccessSession = MockNetworkSession() { _ in
+            MockNetworkSession.MockResponse(statusCode: 200,
+                                            data: ["msg": "success"].toJsonData(),
+                                            delay: 1)
+        }
+        
+        let urlErrorRequest = createApiClient(networkSession: networkErrorSession).convertToURLRequest(iterableRequest: IterableRequest.post(PostRequest(path: "", args: nil, body: [:])))!
+        
+        
+        let urlSuccessRequest = createApiClient(networkSession: networkSuccessSession).convertToURLRequest(iterableRequest: IterableRequest.post(PostRequest(path: "", args: nil, body: [:])))!
+
+        let requestProvider: () -> Pending<SendRequestValue, SendRequestError> = {
+            if authManager.retryWasRequested {
+                return RequestSender.sendRequest(urlSuccessRequest, usingSession: networkSuccessSession)
+            }
+            return RequestSender.sendRequest(urlErrorRequest, usingSession: networkErrorSession)
+        }
+
+        let result = RequestProcessorUtil.sendRequest(
+            requestProvider: requestProvider,
+            authManager: authManager,
+            requestIdentifier: "TestIdentifier"
+        )
+        
+        result.onSuccess { value in
+            xpectation.fulfill()
+            XCTAssert(true)
+        }.onError { error in
+            if authManager.retryWasRequested {
+                xpectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: testExpectationTimeout)
+    }
+    
     func testResponseCode401() { // 401 = unauthorized
         let xpectation = expectation(description: "401")
         let iterableRequest = IterableRequest.post(PostRequest(path: "", args: nil, body: [:]))


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-7153](https://iterable.atlassian.net/browse/MOB-7153)

## ✏️ Description

> Provides a mechanism for retrieving a new JWT token when a request fails.
Credit: Omni-CG

[MOB-7153]: https://iterable.atlassian.net/browse/MOB-7153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ