### PR TITLE
[MOB-7021] Implement retry mechanism to the iOS SDK for failed network requests

### DIFF
--- a/swift-sdk/Internal/NetworkHelper.swift
+++ b/swift-sdk/Internal/NetworkHelper.swift
@@ -77,7 +77,7 @@ struct NetworkHelper {
         
         let fulfill = Fulfill<T, NetworkError>()
             
-        func sendRequestWithRetries(request: URLRequest, retriesLeft: Int) {
+        func sendRequestWithRetries(request: URLRequest, requestId: String, retriesLeft: Int) {
             networkSession.makeRequest(request) { data, response, error in
                 let result = createResultFromNetworkResponse(data: data,
                                                              converter: converter,
@@ -129,11 +129,11 @@ struct NetworkHelper {
             }
             
             DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
-                sendRequestWithRetries(request: request, retriesLeft: retriesLeft - 1)
+                sendRequestWithRetries(request: request, requestId: requestId, retriesLeft: retriesLeft - 1)
             }
         }
         
-        sendRequestWithRetries(request: request, retriesLeft: maxRetryCount)
+        sendRequestWithRetries(request: request, requestId: requestId, retriesLeft: maxRetryCount)
         
         return fulfill
     }

--- a/swift-sdk/Internal/NetworkHelper.swift
+++ b/swift-sdk/Internal/NetworkHelper.swift
@@ -92,6 +92,7 @@ struct NetworkHelper {
                         fulfill.resolve(with: value)
                     case let .failure(error):
                         if error.httpStatusCode ?? 0 >= 500 && retriesLeft > 0 {
+                            print("url::sendRequestWithRetries: \(request.url)::\(retriesLeft)")
                             #if NETWORK_DEBUG
                             print("retry attempt: \(maxRetryCount-retriesLeft+1) for url: \(request.url?.absoluteString ?? "")")
                             print(error)

--- a/swift-sdk/Internal/NetworkHelper.swift
+++ b/swift-sdk/Internal/NetworkHelper.swift
@@ -85,32 +85,51 @@ struct NetworkHelper {
                                                              error: error)
                 switch result {
                     case let .success(value):
-                        #if NETWORK_DEBUG
-                        print("request with id: \(requestId) successfully sent, response:")
-                        print(value)
-                        #endif
-                        fulfill.resolve(with: value)
+                        handleSuccess(requestId: requestId, value: value)
                     case let .failure(error):
-                        if error.httpStatusCode ?? 0 >= 500 && retriesLeft > 0 {
-                            #if NETWORK_DEBUG
-                            print("retry attempt: \(maxRetryCount-retriesLeft+1) for url: \(request.url?.absoluteString ?? "")")
-                            print(error)
-                            #endif
-                            var delay: DispatchTimeInterval = .seconds(0)
-                            if retriesLeft <= 3 {
-                                delay = .seconds(retryDelaySeconds)
-                            }
-                            DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
-                                sendRequestWithRetries(request: request, retriesLeft: retriesLeft - 1)
-                            }
-                        } else {
-                            #if NETWORK_DEBUG
-                            print("request with id: \(requestId) errored")
-                            print(error)
-                            #endif
-                            fulfill.reject(with: error)
-                        }
+                        handleFailure(requestId: requestId, request: request, error: error, retriesLeft: retriesLeft)
                 }
+            }
+        }
+        
+        func handleSuccess(requestId: String, value: T) {
+            #if NETWORK_DEBUG
+            print("request with id: \(requestId) successfully sent, response:")
+            print(value)
+            #endif
+            fulfill.resolve(with: value)
+        }
+        
+        func handleFailure(requestId: String, request: URLRequest, error: NetworkError, retriesLeft: Int) {
+            if shouldRetry(error: error, retriesLeft: retriesLeft) {
+                retryRequest(requestId: requestId, request: request, error: error, retriesLeft: retriesLeft)
+            } else {
+                #if NETWORK_DEBUG
+                print("request with id: \(requestId) errored")
+                print(error)
+                #endif
+                fulfill.reject(with: error)
+            }
+            
+        }
+        
+        func shouldRetry(error: NetworkError, retriesLeft: Int) -> Bool {
+            return error.httpStatusCode ?? 0 >= 500 && retriesLeft > 0
+        }
+        
+        func retryRequest(requestId: String, request: URLRequest, error: NetworkError, retriesLeft: Int) {
+            #if NETWORK_DEBUG
+            print("retry attempt: \(maxRetryCount-retriesLeft+1) for url: \(request.url?.absoluteString ?? "")")
+            print(error)
+            #endif
+            
+            var delay: DispatchTimeInterval = .seconds(0)
+            if retriesLeft <= 3 {
+                delay = .seconds(retryDelaySeconds)
+            }
+            
+            DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+                sendRequestWithRetries(request: request, retriesLeft: retriesLeft - 1)
             }
         }
         

--- a/swift-sdk/Internal/NetworkHelper.swift
+++ b/swift-sdk/Internal/NetworkHelper.swift
@@ -92,13 +92,12 @@ struct NetworkHelper {
                         fulfill.resolve(with: value)
                     case let .failure(error):
                         if error.httpStatusCode ?? 0 >= 500 && retriesLeft > 0 {
-                            print("url::sendRequestWithRetries: \(request.url)::\(retriesLeft)")
                             #if NETWORK_DEBUG
                             print("retry attempt: \(maxRetryCount-retriesLeft+1) for url: \(request.url?.absoluteString ?? "")")
                             print(error)
                             #endif
                             var delay: DispatchTimeInterval = .seconds(0)
-                            if (retriesLeft <= 3) {
+                            if retriesLeft <= 3 {
                                 delay = .seconds(retryDelaySeconds)
                             }
                             DispatchQueue.global().asyncAfter(deadline: .now() + delay) {

--- a/swift-sdk/Internal/NetworkHelper.swift
+++ b/swift-sdk/Internal/NetworkHelper.swift
@@ -55,8 +55,9 @@ struct NetworkHelper {
     static func sendRequest<T>(_ request: URLRequest,
                                converter: @escaping (Data) throws -> T?,
                                usingSession networkSession: NetworkSessionProtocol) -> Pending<T, NetworkError> {
-        #if NETWORK_DEBUG
+        
         let requestId = IterableUtil.generateUUID()
+        #if NETWORK_DEBUG
         print()
         print("====================================================>")
         print("sending request: \(request)")


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-7021](https://iterable.atlassian.net/browse/MOB-7021)

## ✏️ Description

> This pull request implements retry mechanism for failed network requests along with associated tests. Credit: omni-cg.


[MOB-7021]: https://iterable.atlassian.net/browse/MOB-7021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ