### PR TITLE
[MOB-7313] prepare 6.5.0-beta1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 6.5.0-beta1
+
 ## 6.4.16
 ### Added
 - `sendRequestWithRetries` function added as part of the `NetworkHelperclass`

--- a/Iterable-iOS-AppExtensions.podspec
+++ b/Iterable-iOS-AppExtensions.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "Iterable-iOS-AppExtensions"
   s.module_name  = "IterableAppExtensions"
-  s.version      = "6.4.16"
+  s.version      = "6.5.0-beta1"
   s.summary      = "App Extensions for Iterable SDK"
 
   s.description  = <<-DESC

--- a/Iterable-iOS-SDK.podspec
+++ b/Iterable-iOS-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "Iterable-iOS-SDK"
   s.module_name  = "IterableSDK"
-  s.version      = "6.4.16"
+  s.version      = "6.5.0-beta1"
   s.summary      = "Iterable's official SDK for iOS"
 
   s.description  = <<-DESC

--- a/swift-sdk/IterableAPI.swift
+++ b/swift-sdk/IterableAPI.swift
@@ -7,7 +7,7 @@ import UIKit
 
 @objcMembers public final class IterableAPI: NSObject {
     /// The current SDK version
-    public static let sdkVersion = "6.4.16"
+    public static let sdkVersion = "6.5.0-beta1"
     
     /// The email of the logged in user that this IterableAPI is using
     public static var email: String? {


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-7313](https://iterable.atlassian.net/browse/MOB-7313)

## ✏️ Description

> This pull request prepares for the 6.5.0-beta1 release.


[MOB-7313]: https://iterable.atlassian.net/browse/MOB-7313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ