### PR TITLE
[QAE-1038] set pods to correct version - 6.4.16

### DIFF
--- a/Iterable-iOS-AppExtensions.podspec
+++ b/Iterable-iOS-AppExtensions.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "Iterable-iOS-AppExtensions"
   s.module_name  = "IterableAppExtensions"
-  s.version      = "6.9.0-testing"
+  s.version      = "6.4.16"
   s.summary      = "App Extensions for Iterable SDK"
 
   s.description  = <<-DESC

--- a/Iterable-iOS-SDK.podspec
+++ b/Iterable-iOS-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "Iterable-iOS-SDK"
   s.module_name  = "IterableSDK"
-  s.version      = "6.9.0-testing"
+  s.version      = "6.4.16"
   s.summary      = "Iterable's official SDK for iOS"
 
   s.description  = <<-DESC


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [QAE-1038](https://iterable.atlassian.net/browse/QAE-1038)

## ✏️ Description

During testing of automated release in Github Actions, master branch was unintentionally updated with a testing version number for `.podspec` files. This PR will reset to correct version.

To prevent this in the future, Github Actions should not be run on master but a branch.

[QAE-1038]: https://iterable.atlassian.net/browse/QAE-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ