### PR TITLE
[MOB-7488] changelog and bump IterableAPI to v6.4.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.4.17]
+
+### Changed
+
+- IterableTaskRunner’s stop function now to set `running` variable as `false`
+
 ## [6.4.16]
 
 ### Added

--- a/swift-sdk/IterableAPI.swift
+++ b/swift-sdk/IterableAPI.swift
@@ -7,7 +7,7 @@ import UIKit
 
 @objcMembers public final class IterableAPI: NSObject {
     /// The current SDK version
-    public static let sdkVersion = "6.4.16"
+    public static let sdkVersion = "6.4.17"
     
     /// The email of the logged in user that this IterableAPI is using
     public static var email: String? {


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-7488](https://iterable.atlassian.net/browse/MOB-7488)

## ✏️ Description

[6.4.17]
Changed
IterableTaskRunner’s stop function now to set running variable as false

[MOB-7488]: https://iterable.atlassian.net/browse/MOB-7488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ