### PR TITLE
[MOB-7565] use bundle.module when loading IterableEmbeddedView

### DIFF
--- a/swift-sdk/uicomponents/IterableEmbeddedView.swift
+++ b/swift-sdk/uicomponents/IterableEmbeddedView.swift
@@ -188,8 +188,9 @@ public class IterableEmbeddedView:UIView {
     }
 
     func loadViewFromNib() -> UIView? {
-        let bundle = Bundle(for: type(of: self))
-        let nib = UINib(nibName: "IterableEmbeddedView", bundle: bundle)
+//        let bundle = Bundle(for: type(of: self))
+//        let nib = UINib(nibName: "IterableEmbeddedView", bundle: bundle)
+        let nib = UINib(nibName: "IterableEmbeddedView", bundle: Bundle.module)
         let view = nib.instantiate(withOwner: self, options: nil).first as? UIView
         view?.backgroundColor = UIColor.clear
         self.clipsToBounds = false

--- a/swift-sdk/uicomponents/IterableEmbeddedView.swift
+++ b/swift-sdk/uicomponents/IterableEmbeddedView.swift
@@ -188,8 +188,6 @@ public class IterableEmbeddedView:UIView {
     }
 
     func loadViewFromNib() -> UIView? {
-//        let bundle = Bundle(for: type(of: self))
-//        let nib = UINib(nibName: "IterableEmbeddedView", bundle: bundle)
         let nib = UINib(nibName: "IterableEmbeddedView", bundle: Bundle.module)
         let view = nib.instantiate(withOwner: self, options: nil).first as? UIView
         view?.backgroundColor = UIColor.clear


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-7565](https://iterable.atlassian.net/browse/MOB-7565)

## ✏️ Description

> Updates the way the nib for IterableEmbeddedView is instatiated per the slack thread [here](https://iterable.slack.com/archives/C03V4A5F3LP/p1704240697853559).


[MOB-7565]: https://iterable.atlassian.net/browse/MOB-7565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ