### PR TITLE
[MOB-7595] iOS SDK Release automation refactor

### DIFF
--- a/.github/workflows/ios-sdk-release.yml
+++ b/.github/workflows/ios-sdk-release.yml
@@ -48,6 +48,9 @@ jobs:
       - name: create xcframeworks and zip
         run: bundle exec fastlane ios build_xcframework output_dir:./output_dir
 
+      - name: create and push git tag
+        run: bundle exec fastlane ios create_git_tag version:$VERSION
+
       - name: create github release and upload assets
         run: |
           bundle exec fastlane ios create_release version:$VERSION branch:$BRANCH changelog_section:$CHANGELOG_SECTION output_dir:$OUTPUT_DIR github_token:$GITHUB_TOKEN set_prerelease:$SET_PRERELEASE

--- a/.github/workflows/ios-sdk-release.yml
+++ b/.github/workflows/ios-sdk-release.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Install Cocoapods
         run: gem install cocoapods
 
-      - name: set version number and push podspecs to git
-        run: bundle exec fastlane ios bump_release_version version:$VERSION
-
       - name: clean cocaopods cache and lint
         run: bundle exec fastlane ios clean_and_lint
 
@@ -52,7 +49,6 @@ jobs:
         run: bundle exec fastlane ios build_xcframework output_dir:./output_dir
 
       - name: create github release and upload assets
-
         run: |
           bundle exec fastlane ios create_release version:$VERSION branch:$BRANCH changelog_section:$CHANGELOG_SECTION output_dir:$OUTPUT_DIR github_token:$GITHUB_TOKEN set_prerelease:$SET_PRERELEASE
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,6 +14,7 @@ platform :ios do
     bump_release_version(version:set_version)
     clean_and_lint
     build_xcframework(output_dir:set_output_dir)
+    create_git_tag(version:set_version)
     create_release(version:set_version, output_dir:set_output_dir, changelog_section:set_changelog_section, github_token:set_github_token)
     pod_trunk_push
   end 
@@ -77,6 +78,14 @@ platform :ios do
     )
   end
 
+  desc "create git tag and push tag"
+  lane :create_git_tag do |options|
+    version = options[:version]
+
+    add_git_tag(tag: "#{version}")
+    push_git_tags
+  end
+
   desc "create github release and upload assets"
   lane :create_release do |options|
     version = options[:version]
@@ -85,8 +94,6 @@ platform :ios do
     output_dir = options[:output_dir]
     github_token = options[:github_token]
     set_prerelease = options[:set_prerelease]
-
-    add_git_tag(tag: "#{version}") 
 
     version_changelog = read_changelog(
       changelog_path: 'CHANGELOG.md',


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-7595](https://iterable.atlassian.net/browse/MOB-7595)

## ✏️ Description

Updating the iOS SDK automation release by separating the bump version step of podspecs from the rest of the process. This ensures a cleaner solution as bump version requires a code merge, whereas the rest of the release steps do not.

Please see the updated [slab doc](https://iterable.slab.com/posts/automated-i-os-sdk-release-es6hjhxs)


[MOB-7595]: https://iterable.atlassian.net/browse/MOB-7595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ