### PR TITLE
[MOB-7733] doesn't fetch embedded messages by default, adds a config option

### DIFF
--- a/swift-sdk/Internal/DependencyContainerProtocol.swift
+++ b/swift-sdk/Internal/DependencyContainerProtocol.swift
@@ -62,7 +62,8 @@ extension DependencyContainerProtocol {
                                 urlDelegate: config.urlDelegate,
                                 customActionDelegate: config.customActionDelegate,
                                 urlOpener: urlOpener,
-                                allowedProtocols: config.allowedProtocols)
+                                allowedProtocols: config.allowedProtocols,
+                                enableEmbeddedMessaging: config.enableEmbeddedMessaging)
     }
     
     func createRequestHandler(apiKey: String,

--- a/swift-sdk/Internal/IterableEmbeddedManager.swift
+++ b/swift-sdk/Internal/IterableEmbeddedManager.swift
@@ -14,7 +14,8 @@ class IterableEmbeddedManager: NSObject, IterableInternalEmbeddedManagerProtocol
          urlDelegate: IterableURLDelegate?,
          customActionDelegate: IterableCustomActionDelegate?,
          urlOpener: UrlOpenerProtocol,
-         allowedProtocols: [String]) {
+         allowedProtocols: [String],
+         enableEmbeddedMessaging: Bool) {
          ITBInfo()
         
         self.apiClient = apiClient
@@ -22,6 +23,7 @@ class IterableEmbeddedManager: NSObject, IterableInternalEmbeddedManagerProtocol
         self.customActionDelegate = customActionDelegate
         self.urlOpener = urlOpener
         self.allowedProtocols = allowedProtocols
+        self.enableEmbeddedMessaging = enableEmbeddedMessaging
         
         super.init()
         addForegroundObservers()
@@ -130,6 +132,7 @@ class IterableEmbeddedManager: NSObject, IterableInternalEmbeddedManagerProtocol
     private var messages: [Int: [IterableEmbeddedMessage]] = [:]
     private var listeners: NSHashTable<IterableEmbeddedUpdateDelegate> = NSHashTable(options: [.weakMemory])
     private var trackedMessageIds: Set<String> = Set()
+    private var enableEmbeddedMessaging: Bool
     
     private func addForegroundObservers() {
         NotificationCenter.default.addObserver(self,
@@ -224,6 +227,8 @@ class IterableEmbeddedManager: NSObject, IterableInternalEmbeddedManagerProtocol
 
 extension IterableEmbeddedManager: EmbeddedNotifiable {
     public func syncMessages(completion: @escaping () -> Void) {
-        retrieveEmbeddedMessages(completion: completion)
+        if (enableEmbeddedMessaging) {
+            retrieveEmbeddedMessages(completion: completion)
+        }
     }
 }

--- a/swift-sdk/IterableConfig.swift
+++ b/swift-sdk/IterableConfig.swift
@@ -127,4 +127,7 @@ public class IterableConfig: NSObject {
     
     /// Sets data region which determines data center and endpoints used by the SDK
     public var dataRegion: String = IterableDataRegion.US
+    
+    /// Allows for fetching embedded messages.
+    public var enableEmbeddedMessaging = false
 }

--- a/tests/unit-tests/EmbeddedManagerTests.swift
+++ b/tests/unit-tests/EmbeddedManagerTests.swift
@@ -18,7 +18,8 @@ final class EmbeddedManagerTests: XCTestCase {
                                                   urlDelegate: nil,
                                                   customActionDelegate: nil,
                                                   urlOpener: MockUrlOpener(),
-                                                  allowedProtocols: [])
+                                                  allowedProtocols: [],
+                                                  enableEmbeddedMessaging: true)
             
             let view1 = ViewWithUpdateDelegate(
                 onMessagesUpdatedCallback: {
@@ -42,7 +43,8 @@ final class EmbeddedManagerTests: XCTestCase {
                                               urlDelegate: nil,
                                               customActionDelegate: nil,
                                               urlOpener: MockUrlOpener(),
-                                              allowedProtocols: [])
+                                              allowedProtocols: [],
+                                              enableEmbeddedMessaging: true)
         XCTAssertEqual(manager.getMessages().count, 0)
     }
     func testGetMessagesForPlacement() {
@@ -57,7 +59,8 @@ final class EmbeddedManagerTests: XCTestCase {
                                               urlDelegate: nil,
                                               customActionDelegate: nil,
                                               urlOpener: MockUrlOpener(),
-                                              allowedProtocols: [])
+                                              allowedProtocols: [],
+                                              enableEmbeddedMessaging: true)
         
         manager.syncMessages { }
         
@@ -85,7 +88,8 @@ final class EmbeddedManagerTests: XCTestCase {
                                               urlDelegate: nil,
                                               customActionDelegate: nil,
                                               urlOpener: MockUrlOpener(),
-                                              allowedProtocols: [])
+                                              allowedProtocols: [],
+                                              enableEmbeddedMessaging: true)
         
         let view = ViewWithUpdateDelegate(
             onMessagesUpdatedCallback: {
@@ -117,7 +121,8 @@ final class EmbeddedManagerTests: XCTestCase {
                                               urlDelegate: nil,
                                               customActionDelegate: nil,
                                               urlOpener: MockUrlOpener(),
-                                              allowedProtocols: [])
+                                              allowedProtocols: [],
+                                              enableEmbeddedMessaging: true)
         
         manager.syncMessages {
             syncMessagesExpectation.fulfill()
@@ -139,7 +144,8 @@ final class EmbeddedManagerTests: XCTestCase {
                                               urlDelegate: nil,
                                               customActionDelegate: nil,
                                               urlOpener: MockUrlOpener(),
-                                              allowedProtocols: [])
+                                              allowedProtocols: [],
+                                              enableEmbeddedMessaging: true)
         
         let view = ViewWithUpdateDelegate(
             onMessagesUpdatedCallback: nil,
@@ -162,7 +168,8 @@ final class EmbeddedManagerTests: XCTestCase {
                                               urlDelegate: nil,
                                               customActionDelegate: nil,
                                               urlOpener: MockUrlOpener(),
-                                              allowedProtocols: [])
+                                              allowedProtocols: [],
+                                              enableEmbeddedMessaging: true)
 
         var delegate1Called = false
         var delegate2Called = false
@@ -195,7 +202,8 @@ final class EmbeddedManagerTests: XCTestCase {
                                               urlDelegate: nil,
                                               customActionDelegate: nil,
                                               urlOpener: MockUrlOpener(),
-                                              allowedProtocols: [])
+                                              allowedProtocols: [],
+                                              enableEmbeddedMessaging: true)
 
         var delegateCalled = false
 
@@ -243,7 +251,8 @@ final class EmbeddedManagerTests: XCTestCase {
                                               urlDelegate: nil,
                                               customActionDelegate: nil,
                                               urlOpener: MockUrlOpener(),
-                                              allowedProtocols: [])
+                                              allowedProtocols: [],
+                                              enableEmbeddedMessaging: true)
 
         let updateDelegate = ViewWithUpdateDelegate(
             onMessagesUpdatedCallback: {
@@ -270,7 +279,8 @@ final class EmbeddedManagerTests: XCTestCase {
                                                                         urlDelegate: nil,
                                                                         customActionDelegate: nil,
                                                                         urlOpener: MockUrlOpener(),
-                                                                        allowedProtocols: [])
+                                                                        allowedProtocols: [],
+                                                                        enableEmbeddedMessaging: true)
         manager?.onDeinit = {
             deinitExpectation.fulfill()
         }
@@ -289,7 +299,8 @@ final class EmbeddedManagerTests: XCTestCase {
                                               urlDelegate: nil,
                                               customActionDelegate: nil,
                                               urlOpener: MockUrlOpener(),
-                                              allowedProtocols: [])
+                                              allowedProtocols: [],
+                                              enableEmbeddedMessaging: true)
         
         let mockDelegate = ViewWithUpdateDelegate(
             onMessagesUpdatedCallback: {


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-7733](https://iterable.atlassian.net/browse/MOB-7733)

## ✏️ Description

Disables fetching embedded messages by default and adds a config to turn it on.


[MOB-7733]: https://iterable.atlassian.net/browse/MOB-7733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ