### PR TITLE
[MOB-?] Fix InAppMessage not being displayed due to correct KeyWindow not being retrieved on app that uses multiple windows

### DIFF
--- a/swift-sdk/Internal/IterableUtil.swift
+++ b/swift-sdk/Internal/IterableUtil.swift
@@ -11,7 +11,7 @@ import UIKit
         if let rootViewController = AppExtensionHelper.application?.delegate?.window??.rootViewController {
             return rootViewController
         } else {
-            return AppExtensionHelper.application?.windows.first?.rootViewController
+            return AppExtensionHelper.application?.windows.filter {$0.isKeyWindow}.first?.rootViewController
         }
     }
     

--- a/swift-sdk/Internal/IterableUtil.swift
+++ b/swift-sdk/Internal/IterableUtil.swift
@@ -11,7 +11,11 @@ import UIKit
         if let rootViewController = AppExtensionHelper.application?.delegate?.window??.rootViewController {
             return rootViewController
         } else {
-            return AppExtensionHelper.application?.windows.filter {$0.isKeyWindow}.first?.rootViewController
+            if #available(iOS 15.0, *) {
+                return AppExtensionHelper.application?.connectedScenes.compactMap { ($0 as? UIWindowScene)?.keyWindow }.last?.rootViewController
+            } else {
+                return UIApplication.shared.windows.filter {$0.isKeyWindow}.first?.rootViewController
+            }
         }
     }
     

--- a/swift-sdk/Internal/IterableUtil.swift
+++ b/swift-sdk/Internal/IterableUtil.swift
@@ -14,7 +14,7 @@ import UIKit
             if #available(iOS 15.0, *) {
                 return AppExtensionHelper.application?.connectedScenes.compactMap { ($0 as? UIWindowScene)?.keyWindow }.last?.rootViewController
             } else {
-                return UIApplication.shared.windows.filter {$0.isKeyWindow}.first?.rootViewController
+                return AppExtensionHelper.application?.windows.filter {$0.isKeyWindow}.first?.rootViewController
             }
         }
     }


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-XXXX](https://iterable.atlassian.net/browse/MOB-XXXX)

## ✏️ Description

If a project makes use of multiple Windows, then the IterableSDK can fail to retrieve the correct one, resulting in the InAppMessage failing and never being displayed.

This fix allows the currently displayed Window to be retrieved (the true keyWindow), so the InAppMessage can be displayed on the very top view controller.

It also accounts for the iOS 15 changes to windows.

