### PR TITLE
[MOB-9021] - Remove protocol method

### DIFF
--- a/swift-sdk/Internal/WebViewProtocol.swift
+++ b/swift-sdk/Internal/WebViewProtocol.swift
@@ -17,7 +17,6 @@ protocol WebViewProtocol {
     @discardableResult func loadHTMLString(_ string: String, baseURL: URL?) -> WKNavigation?
     func set(position: ViewPosition)
     func set(navigationDelegate: WKNavigationDelegate?)
-    func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any?, Error?) -> Void)?)
     func layoutSubviews()
     func calculateHeight() -> Pending<CGFloat, IterableError>
 }

--- a/tests/common/MockWebView.swift
+++ b/tests/common/MockWebView.swift
@@ -23,10 +23,6 @@ class MockWebView: WebViewProtocol {
     
     func set(navigationDelegate _: WKNavigationDelegate?) {}
     
-    func evaluateJavaScript(_: String, completionHandler: ((Any?, Error?) -> Void)?) {
-        completionHandler?(height, nil)
-    }
-    
     func layoutSubviews() {}
     
     func calculateHeight() -> Pending<CGFloat, IterableError> {


### PR DESCRIPTION
Removing the protocol method as SDK uses the default WKWebview method

## 🔹 Jira Ticket(s)

* [MOB-9021](https://iterable.atlassian.net/browse/MOB-9021)

## ✏️ Description

> Remove protocol method


[MOB-9021]: https://iterable.atlassian.net/browse/MOB-9021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ