### PR TITLE
[MOB-8823] separates SDK initialization check

### DIFF
--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -275,6 +275,10 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
                     mergeNestedObjects: Bool,
                     onSuccess: OnSuccessHandler? = nil,
                     onFailure: OnFailureHandler? = nil) -> Pending<SendRequestValue, SendRequestError> {
+        if !isEitherUserIdOrEmailSet() {
+            return rejectWithInitializationError(onFailure: onFailure)
+        }
+        
         if !isEitherUserIdOrEmailSet() && localStorage.userIdAnnon == nil {
             if config.enableAnonTracking {
                 anonymousUserManager.trackAnonUpdateUser(dataFields)
@@ -306,6 +310,10 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
     func updateCart(items: [CommerceItem],
                     onSuccess: OnSuccessHandler? = nil,
                     onFailure: OnFailureHandler? = nil) -> Pending<SendRequestValue, SendRequestError> {
+        if !isEitherUserIdOrEmailSet() {
+            return rejectWithInitializationError(onFailure: onFailure)
+        }
+        
         if !isEitherUserIdOrEmailSet() && localStorage.userIdAnnon == nil {
             if config.enableAnonTracking {
                 anonymousUserManager.trackAnonUpdateCart(items: items)
@@ -338,6 +346,10 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
                        templateId: NSNumber? = nil,
                        onSuccess: OnSuccessHandler? = nil,
                        onFailure: OnFailureHandler? = nil) -> Pending<SendRequestValue, SendRequestError> {
+        if !isEitherUserIdOrEmailSet() {
+            return rejectWithInitializationError(onFailure: onFailure)
+        }
+        
         if !isEitherUserIdOrEmailSet() && localStorage.userIdAnnon == nil {
             if config.enableAnonTracking {
                 anonymousUserManager.trackAnonPurchaseEvent(total: total, items: items, dataFields: dataFields)
@@ -411,6 +423,10 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
                dataFields: [AnyHashable: Any]? = nil,
                onSuccess: OnSuccessHandler? = nil,
                onFailure: OnFailureHandler? = nil) -> Pending<SendRequestValue, SendRequestError> {
+        if !isEitherUserIdOrEmailSet() {
+            return rejectWithInitializationError(onFailure: onFailure)
+        }
+        
         if !isEitherUserIdOrEmailSet() && localStorage.userIdAnnon == nil {
             if config.enableAnonTracking {
                 anonymousUserManager.trackAnonEvent(name: eventName, dataFields: dataFields)


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-8823](https://iterable.atlassian.net/browse/MOB-8823)

## ✏️ Description

> This pull request separates SDK initialization check from anonymous user tracking check so that if anonymous user tracking is disabled then track request are not made when SDK is not initialized.


[MOB-8823]: https://iterable.atlassian.net/browse/MOB-8823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ