### PR TITLE
[MOB-9109] adds anonymous user id stored check

### DIFF
--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -130,11 +130,11 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         _payloadData = data
     }
     
-    func setEmail(_ email: String?, authToken: String? = nil, merge: Bool? = nil, successHandler: OnSuccessHandler? = nil, failureHandler: OnFailureHandler? = nil) {
+    func setEmail(_ email: String?, authToken: String? = nil, merge: Bool = true, successHandler: OnSuccessHandler? = nil, failureHandler: OnFailureHandler? = nil) {
         
         ITBInfo()
 
-        let shouldMerge = (merge ?? true) && localStorage.userIdAnnon != nil
+        let shouldMerge = merge && localStorage.userIdAnnon != nil
         let (sourceUserId, sourceEmail) = getSourceUserIdOrEmail();
         
         anonymousUserMerge.tryMergeUser(sourceUserId: sourceUserId, sourceEmail: sourceEmail, destinationUserIdOrEmail: email, isEmail: true, merge: shouldMerge) { mergeResult, error in
@@ -155,9 +155,6 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
                 
                 if (shouldMerge) {
                     self.anonymousUserManager.syncNonSyncedEvents()
-                } else {
-                    self.localStorage.anonymousUserEvents = nil
-                    self.localStorage.anonymousSessions = nil
                 }
                 self._successCallback = successHandler
                 self._failureCallback = failureHandler
@@ -184,10 +181,10 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         
     }
     
-    func setUserId(_ userId: String?, authToken: String? = nil, merge: Bool? = nil, successHandler: OnSuccessHandler? = nil, failureHandler: OnFailureHandler? = nil, isAnon: Bool = false) {
+    func setUserId(_ userId: String?, authToken: String? = nil, merge: Bool = true, successHandler: OnSuccessHandler? = nil, failureHandler: OnFailureHandler? = nil, isAnon: Bool = false) {
         ITBInfo()
         
-        let shouldMerge = (merge ?? true) && localStorage.userIdAnnon != nil
+        let shouldMerge = merge && localStorage.userIdAnnon != nil
         let (sourceUserId, sourceEmail) = getSourceUserIdOrEmail();
    
         anonymousUserMerge.tryMergeUser(sourceUserId: sourceUserId, sourceEmail: sourceEmail, destinationUserIdOrEmail: userId, isEmail: false, merge: shouldMerge) { mergeResult, error in
@@ -212,9 +209,6 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
                     
                 if (shouldMerge) {
                     self.anonymousUserManager.syncNonSyncedEvents()
-                } else {
-                    self.localStorage.anonymousUserEvents = nil
-                    self.localStorage.anonymousSessions = nil
                 }
                 self._successCallback = successHandler
                 self._failureCallback = failureHandler

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -155,6 +155,9 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
                 
                 if (shouldMerge) {
                     self.anonymousUserManager.syncNonSyncedEvents()
+                } else {
+                    self.localStorage.anonymousUserEvents = nil
+                    self.localStorage.anonymousSessions = nil
                 }
                 self._successCallback = successHandler
                 self._failureCallback = failureHandler
@@ -209,6 +212,9 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
                     
                 if (shouldMerge) {
                     self.anonymousUserManager.syncNonSyncedEvents()
+                } else {
+                    self.localStorage.anonymousUserEvents = nil
+                    self.localStorage.anonymousSessions = nil
                 }
                 self._successCallback = successHandler
                 self._failureCallback = failureHandler

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -134,7 +134,7 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         
         ITBInfo()
 
-        let shouldMerge = (merge ?? true)
+        let shouldMerge = (merge ?? true) && localStorage.userIdAnnon != nil
         let (sourceUserId, sourceEmail) = getSourceUserIdOrEmail();
         
         anonymousUserMerge.tryMergeUser(sourceUserId: sourceUserId, sourceEmail: sourceEmail, destinationUserIdOrEmail: email, isEmail: true, merge: shouldMerge) { mergeResult, error in
@@ -184,7 +184,7 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
     func setUserId(_ userId: String?, authToken: String? = nil, merge: Bool? = nil, successHandler: OnSuccessHandler? = nil, failureHandler: OnFailureHandler? = nil, isAnon: Bool = false) {
         ITBInfo()
         
-        let shouldMerge = (merge ?? true) 
+        let shouldMerge = (merge ?? true) && localStorage.userIdAnnon != nil
         let (sourceUserId, sourceEmail) = getSourceUserIdOrEmail();
    
         anonymousUserMerge.tryMergeUser(sourceUserId: sourceUserId, sourceEmail: sourceEmail, destinationUserIdOrEmail: userId, isEmail: false, merge: shouldMerge) { mergeResult, error in

--- a/swift-sdk/IterableAPI.swift
+++ b/swift-sdk/IterableAPI.swift
@@ -147,11 +147,11 @@ import UIKit
         implementation?.setUserId(userId, authToken: authToken, successHandler: successHandler, failureHandler: failureHandler)
     }
     
-    public static func setEmail(_ email: String?, _ authToken: String? = nil, merge: Bool? = nil, _ successHandler: OnSuccessHandler? = nil, _ failureHandler: OnFailureHandler? = nil) {
+    public static func setEmail(_ email: String?, _ authToken: String? = nil, merge: Bool = true, _ successHandler: OnSuccessHandler? = nil, _ failureHandler: OnFailureHandler? = nil) {
         implementation?.setEmail(email, authToken: authToken, merge: merge, successHandler: successHandler, failureHandler: failureHandler)
     }
     
-    public static func setUserId(_ userId: String?, _ authToken: String? = nil, merge: Bool? = nil, _ successHandler: OnSuccessHandler? = nil, _ failureHandler: OnFailureHandler? = nil, _ isAnon: Bool = false) {
+    public static func setUserId(_ userId: String?, _ authToken: String? = nil, merge: Bool = true, _ successHandler: OnSuccessHandler? = nil, _ failureHandler: OnFailureHandler? = nil, _ isAnon: Bool = false) {
         implementation?.setUserId(userId, authToken: authToken, merge: merge,successHandler: successHandler, failureHandler: failureHandler, isAnon: isAnon)
     }
     

--- a/tests/unit-tests/UserMergeScenariosTests.swift
+++ b/tests/unit-tests/UserMergeScenariosTests.swift
@@ -108,9 +108,9 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
                }
         
         if let events = localStorage.anonymousUserEvents {
-                    XCTAssertFalse(events.isEmpty, "Expected events to not be synced")
+                    XCTFail("Expected events should not be found")
                } else {
-                   XCTFail("Expected events but found nil")
+                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
                }
  
         // Verify "merge user" API call is not made
@@ -499,9 +499,9 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
                }
         
         if let events = localStorage.anonymousUserEvents {
-                    XCTAssertFalse(events.isEmpty, "Expected events to not be synced")
+                    XCTFail("Expected events should not be found")
                } else {
-                   XCTFail("Expected events but found nil")
+                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
                }
  
         // Verify "merge user" API call is not made

--- a/tests/unit-tests/UserMergeScenariosTests.swift
+++ b/tests/unit-tests/UserMergeScenariosTests.swift
@@ -153,7 +153,7 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
         waitForDuration(seconds: 5)
 
         if let events = localStorage.anonymousUserEvents {
-                XCTFail("Expected events should not be found")
+                XCTAssertFalse(events.isEmpty, "Expected events to be logged")
             } else {
                 XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
             }
@@ -198,7 +198,7 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
         waitForDuration(seconds: 5)
 
         if let events = localStorage.anonymousUserEvents {
-                XCTFail("Expected events should not be found")
+                XCTAssertFalse(events.isEmpty, "Expected events to be logged")
             } else {
                 XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
             }
@@ -407,14 +407,14 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
                    XCTFail("Expected userId but found nil")
                }
  
-        // Verify "merge user" API call is made
+        // Verify "merge user" API call is not made
            let apiCallExpectation = self.expectation(description: "API call is made to merge user")
            DispatchQueue.main.async {
                if let _ = self.mockSession.getRequest(withEndPoint: Const.Path.mergeUser) {
                    // Pass the test if the API call was made
-                   apiCallExpectation.fulfill()
+                   XCTFail("Expected merge user API call was made")
                } else {
-                   XCTFail("Expected merge user API call was not made")
+                   apiCallExpectation.fulfill()
                }
            }
            
@@ -544,7 +544,7 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
         waitForDuration(seconds: 5)
 
         if let events = localStorage.anonymousUserEvents {
-                XCTFail("Expected events nil but found")
+            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
             } else {
                 XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
             }
@@ -589,7 +589,7 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
         waitForDuration(seconds: 5)
 
         if let events = localStorage.anonymousUserEvents {
-                XCTFail("Expected events should not be found")
+            XCTAssertFalse(events.isEmpty, "Expected events to be logged")
             } else {
                 XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
             }

--- a/tests/unit-tests/UserMergeScenariosTests.swift
+++ b/tests/unit-tests/UserMergeScenariosTests.swift
@@ -108,9 +108,9 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
                }
         
         if let events = localStorage.anonymousUserEvents {
-                    XCTFail("Expected events should not be found")
+                    XCTAssertFalse(events.isEmpty, "Expected events to be logged")
                } else {
-                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
+                   XCTFail("Expected events to be logged but found nil")
                }
  
         // Verify "merge user" API call is not made
@@ -499,9 +499,9 @@ class UserMergeScenariosTests: XCTestCase, AuthProvider {
                }
         
         if let events = localStorage.anonymousUserEvents {
-                    XCTFail("Expected events should not be found")
+                    XCTAssertFalse(events.isEmpty, "Expected events to be logged")
                } else {
-                   XCTAssertNil(localStorage.anonymousUserEvents, "Expected events to be nil")
+                   XCTFail("Expected events to be logged but found nil")
                }
  
         // Verify "merge user" API call is not made


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-9109](https://iterable.atlassian.net/browse/MOB-9109)

## ✏️ Description

> This pull request adds a check for the anonymous user id in local storage. Merging should only occur when there is an anonymous user logged in.


[MOB-9109]: https://iterable.atlassian.net/browse/MOB-9109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ