### PR TITLE
Mob 9192 JWT error Mapping

### DIFF
--- a/swift-sdk/Internal/NetworkHelper.swift
+++ b/swift-sdk/Internal/NetworkHelper.swift
@@ -156,6 +156,12 @@ struct NetworkHelper {
         if httpStatusCode >= 500 {
             return .failure(NetworkError(reason: "Internal Server Error", data: data, httpStatusCode: httpStatusCode))
         } else if httpStatusCode >= 400 {
+            
+            if let data = data, 
+                let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                let msg = json["msg"] as? String {
+                return .failure(NetworkError(reason: msg, data: data, httpStatusCode: httpStatusCode))
+            }
             return .failure(NetworkError(reason: "Invalid Request", data: data, httpStatusCode: httpStatusCode))
         } else if httpStatusCode == 200 {
             if let data = data, data.count > 0 {

--- a/swift-sdk/Internal/RequestSender.swift
+++ b/swift-sdk/Internal/RequestSender.swift
@@ -57,7 +57,7 @@ struct SendRequestError: Error {
                 iterableCode = jsonDict[JsonKey.Response.iterableCode] as? String
             }
             
-            return SendRequestError(reason: "Invalid API Key",
+            return SendRequestError(reason: networkError.reason,
                                     data: networkError.data,
                                     httpStatusCode: httpStatusCode,
                                     iterableCode: iterableCode,

--- a/tests/unit-tests/IterableAPIResponseTests.swift
+++ b/tests/unit-tests/IterableAPIResponseTests.swift
@@ -156,7 +156,7 @@ class IterableAPIResponseTests: XCTestCase {
         createApiClient(networkSession: MockNetworkSession(statusCode: 401))
             .send(iterableRequest: iterableRequest).onError { sendError in
                 xpectation.fulfill()
-                XCTAssert(sendError.reason!.lowercased().contains("invalid api key"))
+                XCTAssert(sendError.reason!.lowercased().contains("invalid request"))
             }
         
         wait(for: [xpectation], timeout: testExpectationTimeout)


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-9192](https://iterable.atlassian.net/browse/MOB-9192)

## ✏️ Description

> Removing the generic error mapping at Request Handling layer. This is what gets read further and appropriate AuthFailure reasons will be passed to the app.

[MOB-9192]: https://iterable.atlassian.net/browse/MOB-9192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ