### PR TITLE
[MOB-9247] - Bug fix for no push on APNS SANDBOX

### DIFF
--- a/swift-sdk/Internal/APNSTypeChecker.swift
+++ b/swift-sdk/Internal/APNSTypeChecker.swift
@@ -66,6 +66,7 @@ struct APNSTypeChecker: APNSTypeCheckerProtocol {
 
         let encodings: [String.Encoding] = [
             .ascii,
+            .isoLatin1,
             .utf8,
             .utf16,
             .utf16BigEndian,
@@ -73,29 +74,21 @@ struct APNSTypeChecker: APNSTypeCheckerProtocol {
             .utf32,
             .utf32BigEndian,
             .utf32LittleEndian,
-            .isoLatin1,
             .macOSRoman
         ]
         
-        var asciiString: String?
+        var plistString: String?
         
         for encoding in encodings {
-            if let string = String(data: data, encoding: encoding) {
-                asciiString = string
+            if let string = String(data: data, encoding: encoding),
+            let propertyListString = scan(string: string, begin: "<plist", end: "</plist>") {
+                plistString = propertyListString
                 break
             }
         }
         
-        guard let finalString = asciiString else {
-            ITBError("Failed to detect APNS type from provisioning file. Defaulting to type - Production. Please use IterableConfig.pushPlatform to manually set APNS platform type")
-            return [:]
-        }
-        
-        guard let propertyListString = scan(string: finalString, begin: "<plist", end: "</plist>") else {
-            return [:]
-        }
-        
-        guard let propertyListData = propertyListString.data(using: .utf8) else {
+        guard let propertyListData = plistString?.data(using: .utf8) else {
+            ITBDebug("Failed to detect APNS type from provisioning file. Defaulting to type - Production. Please use IterableConfig.pushPlatform to manually set APNS platform type")
             return [:]
         }
         


### PR DESCRIPTION

## 🔹 Jira Ticket(s)

* [MOB-9247](https://iterable.atlassian.net/browse/MOB-9247)

## ✏️ Description

### Logic explanation
SDK checks if the target is a simulator
if so > APNS SANDBOX
if not > read the file 'embedded.provision'
Check if certain value exist to mark it as APNSSANDBOX If not, default it to PRODUCTION APNS.

Using Xcode 16 beta with iOS 18 beta, we discovered that file reading was failing with normal ASCII encoding.

### Diff explanation -
File was able to type to data easily.
Once the data was available, now we try to read the file with all encoding available to us now. If none of them works, we print ITBLError. The first one to decode the file proceeds with scan operation - finding the right tags and keywords.

- Tested with Xcode GA and Beta and iOS 17 and iOS 18 devices



[MOB-9247]: https://iterable.atlassian.net/browse/MOB-9247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ