### PR TITLE
[MOB-9320] - AuthFailure parity with Android

### DIFF
--- a/swift-sdk/AuthFailureReason.swift
+++ b/swift-sdk/AuthFailureReason.swift
@@ -19,5 +19,4 @@ import Foundation
     case authTokenNull
     case authTokenGenerationError
     case authTokenMissing
-    case authTokenInvalid
 }

--- a/swift-sdk/Internal/RequestProcessorUtil.swift
+++ b/swift-sdk/Internal/RequestProcessorUtil.swift
@@ -99,7 +99,7 @@ struct RequestProcessorUtil {
             case "jwt authorization header is not set":
                 return .authTokenMissing
             default:
-            return .authTokenInvalid
+            return .authTokenGenericError
         }
     }
 


### PR DESCRIPTION
Removing additional reason in iOS SDK

## 🔹 Jira Ticket(s)

* [MOB-9320](https://iterable.atlassian.net/browse/MOB-9320)

## ✏️ Description

> AuthFailure parity with Android

[MOB-9320]: https://iterable.atlassian.net/browse/MOB-9320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ