### PR TITLE
Bug fix/mob 7855 universal link behavior

### DIFF
--- a/tests/unit-tests/DeepLinkTests.swift
+++ b/tests/unit-tests/DeepLinkTests.swift
@@ -70,11 +70,10 @@ class DeepLinkTests: XCTestCase {
         
         let deepLinkManager = DeepLinkManager(redirectNetworkSessionProvider: createNoRedirectNetworkSessionProvider())
         
-        let (isIterableLink, _) = deepLinkManager.handleUniversalLink(URL(string: iterableNoRewriteURL)!,
+        let (_, _) = deepLinkManager.handleUniversalLink(URL(string: iterableNoRewriteURL)!,
                                                                       urlDelegate: mockUrlDelegate,
                                                                       urlOpener: MockUrlOpener())
-        
-        XCTAssertFalse(isIterableLink)
+
         wait(for: [expectation1], timeout: testExpectationTimeout)
     }
 


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-7855](https://iterable.atlassian.net/browse/MOB-7855)

## ✏️ Description

This is a pull request to fix https://github.com/Iterable/swift-sdk/issues/592
Verified it fixes the issue still present in 6.5.4


[MOB-7855]: https://iterable.atlassian.net/browse/MOB-7855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ