### PR TITLE
MOB-9449: update user should not be a separate call

### DIFF
--- a/swift-sdk/Internal/ApiClient.swift
+++ b/swift-sdk/Internal/ApiClient.swift
@@ -288,8 +288,8 @@ extension ApiClient: ApiClientProtocol {
         return send(iterableRequestResult: result)
     }
         
-    func trackAnonSession(createdAt: Int, withUserId userId: String, requestJson: [AnyHashable: Any])  -> Pending<SendRequestValue, SendRequestError> {
-        let result = createRequestCreator().flatMap { $0.createTrackAnonSessionRequest(createdAt: createdAt, withUserId: userId, requestJson: requestJson) }
+    func trackAnonSession(createdAt: Int, withUserId userId: String, dataFields: [AnyHashable: Any]?, requestJson: [AnyHashable: Any])  -> Pending<SendRequestValue, SendRequestError> {
+        let result = createRequestCreator().flatMap { $0.createTrackAnonSessionRequest(createdAt: createdAt, withUserId: userId, dataFields: dataFields, requestJson: requestJson) }
         return send(iterableRequestResult: result)
     }
     // MARK: - Embedded Messaging

--- a/swift-sdk/Internal/ApiClientProtocol.swift
+++ b/swift-sdk/Internal/ApiClientProtocol.swift
@@ -56,7 +56,7 @@ protocol ApiClientProtocol: AnyObject {
     
     func getCriteria() -> Pending<SendRequestValue, SendRequestError>
 
-    func trackAnonSession(createdAt: Int, withUserId userId: String, requestJson: [AnyHashable: Any])  -> Pending<SendRequestValue, SendRequestError>
+    func trackAnonSession(createdAt: Int, withUserId userId: String, dataFields: [AnyHashable: Any]?, requestJson: [AnyHashable: Any])  -> Pending<SendRequestValue, SendRequestError>
     func getEmbeddedMessages() -> Pending<PlacementsPayload, SendRequestError>
     
     @discardableResult func track(embeddedMessageReceived message: IterableEmbeddedMessage) -> Pending<SendRequestValue, SendRequestError>

--- a/swift-sdk/Internal/RequestCreator.swift
+++ b/swift-sdk/Internal/RequestCreator.swift
@@ -682,7 +682,7 @@ struct RequestCreator {
         return .success(.get(createGetRequest(forPath: Const.Path.getCriteria, withArgs: body as! [String: String])))
     }
 
-    func createTrackAnonSessionRequest(createdAt: Int, withUserId userId: String, requestJson: [AnyHashable: Any]) -> Result<IterableRequest, IterableError> {
+    func createTrackAnonSessionRequest(createdAt: Int, withUserId userId: String, dataFields: [AnyHashable: Any]?, requestJson: [AnyHashable: Any]) -> Result<IterableRequest, IterableError> {
         var body = [AnyHashable: Any]()
         
         var userDict = [AnyHashable: Any]()
@@ -690,6 +690,9 @@ struct RequestCreator {
         userDict[JsonKey.preferUserId] = true
         userDict[JsonKey.mergeNestedObjects] = true
         userDict[JsonKey.createNewFields] = true
+        if let dataFields = dataFields {
+            userDict[JsonKey.dataFields] = dataFields
+        }
 
         body.setValue(for: JsonKey.Commerce.user, value: userDict)
         body.setValue(for: JsonKey.Body.createdAt, value: createdAt)

--- a/tests/unit-tests/BlankApiClient.swift
+++ b/tests/unit-tests/BlankApiClient.swift
@@ -19,12 +19,11 @@ class BlankApiClient: ApiClientProtocol {
     func mergeUser(sourceEmail: String?, sourceUserId: String?, destinationEmail: String?, destinationUserId: String?) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
         Pending()
     }
-    
-    
-    func trackAnonSession(createdAt: Int, withUserId userId: String, requestJson: [AnyHashable : Any]) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
+
+    func trackAnonSession(createdAt: Int, withUserId userId: String, dataFields: [AnyHashable : Any]?, requestJson: [AnyHashable : Any]) -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
         Pending()
     }
-    
+
     func getCriteria() -> IterableSDK.Pending<IterableSDK.SendRequestValue, IterableSDK.SendRequestError> {
         Pending()
     }


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [MOB-9449](https://iterable.atlassian.net/browse/MOB-9449)

## Description
> Update user should not be a separate call

##Test Steps
> Video attached to the ticket, See a JIRA ticket for the video

[MOB-9449]: https://iterable.atlassian.net/browse/MOB-9449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ