### PR TITLE
[SDK-132] Fix Carthage build failure with Xcode 26 / Swift 6.2

### DIFF
--- a/swift-sdk/Internal/Pending.swift
+++ b/swift-sdk/Internal/Pending.swift
@@ -21,7 +21,7 @@ extension IterableError: LocalizedError {
 // either there is a success with result
 // or there is a failure with error
 // There is no way to set value a result in this class.
-class Pending<Value, Failure> where Failure: Error {
+public class Pending<Value, Failure> where Failure: Error {
     fileprivate var successCallbacks = [(Value) -> Void]()
     fileprivate var errorCallbacks = [(Failure) -> Void]()
     
@@ -98,8 +98,8 @@ class Pending<Value, Failure> where Failure: Error {
 }
 
 // need this class for testing failure
-class FailPending<Value, Failure: Error>: Pending<Value, Failure> {
-    init(error: Failure) {
+public class FailPending<Value, Failure: Error>: Pending<Value, Failure> {
+    public init(error: Failure) {
         super.init()
         self.result = .failure(error)
     }
@@ -194,7 +194,7 @@ extension Pending where Failure == Never {
 }
 
 // This class takes the responsibility of setting value for Pending
-class Fulfill<Value, Failure>: Pending<Value, Failure> where Failure: Error {
+public class Fulfill<Value, Failure>: Pending<Value, Failure> where Failure: Error {
     public init(value: Value? = nil) {
         ITBDebug()
         super.init()


### PR DESCRIPTION
## Problem

Carthage builds with `--use-xcframeworks` fail on Xcode 26.0.1 (Swift 6.2) with the error:

```
error: no type named 'Pending' in module 'IterableSDK'
```

This issue was reported by Grammarly's iOS team who rely on Carthage for dependency management.

## Root Cause

When building with Carthage's library evolution mode (`BUILD_LIBRARY_FOR_DISTRIBUTION=YES`), Swift generates `.swiftinterface` files to ensure ABI stability. The issue occurs due to:

1. **`Pending` type visibility**: The `Pending<Value, Failure>` class is defined as `internal` in `swift-sdk/Internal/Pending.swift`
2. **Protocol leakage**: `PushTrackerProtocol` (internal protocol) has methods returning `Pending<SendRequestValue, SendRequestError>`
3. **Public mock implementation**: `MockPushTracker` is a `public` class that implements `PushTrackerProtocol`, compiled into the `host-app` test target
4. **Swift 6.2 interface generation**: With the new `$NonescapableTypes` compiler feature, Swift attempts to export the public API surface of `MockPushTracker` in the generated `.swiftinterface` file
5. **Build failure**: Since `Pending` is internal to IterableSDK, it cannot be referenced in another module's public interface, causing the build to fail

## Solution

Make the `Pending`, `FailPending`, and `Fulfill` classes `public`. These classes were already designed with public methods (`onSuccess`, `onError`, `onCompletion`) and are de facto part of the SDK's API since they're returned by various tracking methods.

## Changes

- Made `Pending<Value, Failure>` class public
- Made `FailPending<Value, Failure>` class and its initializer public  
- Made `Fulfill<Value, Failure>` class public (initializers were already public)

## Impact

- **Minimal API surface change**: These types were already functionally public through their usage in method return types
- **Fixes Carthage compatibility**: Enables proper module interface generation for library evolution builds
- **No breaking changes**: Existing code continues to work as-is
- **Improves API clarity**: The public visibility now accurately reflects the intended usage of these types

## Testing

Verified that the error no longer occurs in Carthage build logs from Grammarly's environment showing the `Pending` type resolution failure.

Closes SDK-132