### PR TITLE
SDK-184 AuthFailure is missing Objc on its properties

### DIFF
--- a/swift-sdk/Core/Utilities/AuthFailure.swift
+++ b/swift-sdk/Core/Utilities/AuthFailure.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-@objc public class AuthFailure: NSObject {
+@objcMembers public class AuthFailure: NSObject {
 
     /// userId or email of the signed-in user
     public let userKey: String?


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [SDK-184](https://iterable.atlassian.net/browse/SDK-184)

## ✏️ Description

- Replaced @objc with @objcMembers on AuthFailure class to ensure properties are accessible from Objective-C

Fixes #959

[SDK-184]: https://iterable.atlassian.net/browse/SDK-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ