### PR TITLE
Sumeru / #1006 - Cache DateFormatter in formatDate() to prevent hangs

### DIFF
--- a/swift-sdk/Internal/Utilities/IterableLogUtil.swift
+++ b/swift-sdk/Internal/Utilities/IterableLogUtil.swift
@@ -49,9 +49,13 @@ struct IterableLogUtil {
         }
     }
     
-    private static func formatDate(date: Date) -> String {
+    private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm:ss.SSSS"
-        return formatter.string(from: date)
+        return formatter
+    }()
+
+    private static func formatDate(date: Date) -> String {
+        return dateFormatter.string(from: date)
     }
 }


### PR DESCRIPTION
## Summary
- Caches the `DateFormatter` instance as a static property in `IterableLogUtil.formatDate()` instead of creating a new one on every call
- `DateFormatter` allocation is expensive and was causing 2-3 second main thread hangs as reported in #1006
- `DateFormatter` is thread-safe on iOS, so a static `let` is safe to use

## Test plan
- [ ] Verify `formatDate()` still produces correct date strings
- [ ] Profile with Instruments to confirm no more DateFormatter allocation overhead
- [ ] Run existing unit tests

Fixes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)