### PR TITLE
Sumeru / #688 - Fix NWPathMonitor crash and memory leak

### DIFF
--- a/swift-sdk/Internal/Network/NetworkConnectivityManager.swift
+++ b/swift-sdk/Internal/Network/NetworkConnectivityManager.swift
@@ -75,8 +75,8 @@ class NetworkConnectivityManager: NSObject {
 
     private func updateStatus() {
         ITBInfo()
-        connectivityChecker.checkConnectivity().onSuccess { connected in
-            self.online = connected
+        connectivityChecker.checkConnectivity().onSuccess { [weak self] connected in
+            self?.online = connected
         }
     }
     

--- a/swift-sdk/Internal/Network/NetworkMonitor.swift
+++ b/swift-sdk/Internal/Network/NetworkMonitor.swift
@@ -31,14 +31,15 @@ class NetworkMonitor: NetworkMonitorProtocol {
 
     func start() {
         ITBInfo()
-        let networkMonitor = NWPathMonitor()
-        networkMonitor.pathUpdateHandler = { path in
+        stop()
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
             ITBInfo("networkMonitor.pathUpdateHandler, path: \(path.debugDescription), status: \(path.status)")
-            self.statusUpdatedCallback?()
+            self?.statusUpdatedCallback?()
         }
 
-        networkMonitor.start(queue: queue)
-        self.networkMonitor = networkMonitor
+        monitor.start(queue: queue)
+        self.networkMonitor = monitor
     }
     
     func stop() {
@@ -47,6 +48,6 @@ class NetworkMonitor: NetworkMonitorProtocol {
         networkMonitor = nil
     }
     
-    private weak var networkMonitor: NWPathMonitor?
+    private var networkMonitor: NWPathMonitor?
     private let queue = DispatchQueue(label: "NetworkMonitor")
 }


### PR DESCRIPTION
## Summary
- Use `[weak self]` in `pathUpdateHandler` closure to break retain cycle (fixes memory leak #867)
- Change `networkMonitor` from `weak` to strong `var` to prevent premature deallocation causing `EXC_BAD_ACCESS` (fixes crash #688)
- Call `stop()` before creating new monitor in `start()` to clean up any existing instance
- Use `[weak self]` in `NetworkConnectivityManager.updateStatus()` to prevent potential retain cycle

Fixes #688, Fixes #867

## Test plan
- [ ] Verify no crash on app launch / foreground transitions
- [ ] Run Instruments Leaks tool and confirm no leak in `NetworkMonitor` path
- [ ] Verify network status change callbacks still fire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)