### PR TITLE
Fix #1006: Cache DateFormatter in IterableLogUtil to prevent app hangs

### DIFF
--- a/swift-sdk/Internal/Utilities/IterableLogUtil.swift
+++ b/swift-sdk/Internal/Utilities/IterableLogUtil.swift
@@ -49,9 +49,13 @@ struct IterableLogUtil {
         }
     }
     
-    private static func formatDate(date: Date) -> String {
+    private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm:ss.SSSS"
-        return formatter.string(from: date)
+        return formatter
+    }()
+
+    private static func formatDate(date: Date) -> String {
+        return dateFormatter.string(from: date)
     }
 }


### PR DESCRIPTION
## Summary
- Cache DateFormatter as a static property instead of creating new instance on every log call
- Prevents 2-3+ second app hangs during rapid successive log calls

## Test plan
- Verify logging still works correctly
- Verify no app hangs during foreground transitions

Generated with Claude Code