### PR TITLE
Fix #821: Add CustomDebugStringConvertible to AuthFailureReason

### DIFF
--- a/swift-sdk/Core/Utilities/AuthFailureReason.swift
+++ b/swift-sdk/Core/Utilities/AuthFailureReason.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-@objc public enum AuthFailureReason: Int {
+@objc public enum AuthFailureReason: Int, CustomDebugStringConvertible {
     case authTokenExpired
     case authTokenGenericError
     case authTokenExpirationInvalid
@@ -19,4 +19,20 @@ import Foundation
     case authTokenNull
     case authTokenGenerationError
     case authTokenMissing
+
+    public var debugDescription: String {
+        switch self {
+        case .authTokenExpired: return "authTokenExpired"
+        case .authTokenGenericError: return "authTokenGenericError"
+        case .authTokenExpirationInvalid: return "authTokenExpirationInvalid"
+        case .authTokenSignatureInvalid: return "authTokenSignatureInvalid"
+        case .authTokenFormatInvalid: return "authTokenFormatInvalid"
+        case .authTokenInvalidated: return "authTokenInvalidated"
+        case .authTokenPayloadInvalid: return "authTokenPayloadInvalid"
+        case .authTokenUserKeyInvalid: return "authTokenUserKeyInvalid"
+        case .authTokenNull: return "authTokenNull"
+        case .authTokenGenerationError: return "authTokenGenerationError"
+        case .authTokenMissing: return "authTokenMissing"
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Make AuthFailureReason enum conform to CustomDebugStringConvertible
- Provides human-readable debug descriptions for all enum cases

## Test plan
- Verify AuthFailureReason prints readable strings in debug output

Generated with Claude Code