### PR TITLE
Fix #794: Fix string length conflation in DeepLinkManager

### DIFF
--- a/swift-sdk/Internal/DeepLinkManager.swift
+++ b/swift-sdk/Internal/DeepLinkManager.swift
@@ -94,7 +94,7 @@ class DeepLinkManager: NSObject {
             return false
         }
         
-        return regex.firstMatch(in: urlString, options: [], range: NSMakeRange(0, urlString.count)) != nil
+        return regex.firstMatch(in: urlString, options: [], range: NSMakeRange(0, (urlString as NSString).length)) != nil
     }
     
     private lazy var redirectUrlSession: NetworkSessionProtocol = {


### PR DESCRIPTION
## Summary
- Use NSString.length instead of String.count when creating NSRange for regex matching
- Fixes potential buffer overrun with unicode characters like emojis in deep link URLs

## Test plan
- Verify deep links with unicode characters work correctly

Generated with Claude Code