### PR TITLE
Fix #867: Fix NetworkMonitor memory leak in IterableTaskRunner

### DIFF
--- a/swift-sdk/Internal/Network/NetworkMonitor.swift
+++ b/swift-sdk/Internal/Network/NetworkMonitor.swift
@@ -32,9 +32,9 @@ class NetworkMonitor: NetworkMonitorProtocol {
     func start() {
         ITBInfo()
         let networkMonitor = NWPathMonitor()
-        networkMonitor.pathUpdateHandler = { path in
+        networkMonitor.pathUpdateHandler = { [weak self] path in
             ITBInfo("networkMonitor.pathUpdateHandler, path: \(path.debugDescription), status: \(path.status)")
-            self.statusUpdatedCallback?()
+            self?.statusUpdatedCallback?()
         }
 
         networkMonitor.start(queue: queue)
@@ -47,6 +47,6 @@ class NetworkMonitor: NetworkMonitorProtocol {
         networkMonitor = nil
     }
     
-    private weak var networkMonitor: NWPathMonitor?
+    private var networkMonitor: NWPathMonitor?
     private let queue = DispatchQueue(label: "NetworkMonitor")
 }


### PR DESCRIPTION
## Summary
- Use [weak self] in NWPathMonitor pathUpdateHandler closure to break retain cycle
- Change networkMonitor from weak to strong to prevent premature deallocation

## Test plan
- Run with Instruments, verify no memory leak at IterableTaskRunner.start()

Generated with Claude Code