### PR TITLE
Fix #1008: Track push open even when campaignId missing from payload

### DIFF
--- a/swift-sdk/Internal/Utilities/NotificationHelper.swift
+++ b/swift-sdk/Internal/Utilities/NotificationHelper.swift
@@ -85,15 +85,13 @@ private extension IterablePushNotificationMetadata {
         guard isValidCampaignId(itblElement[Keys.campaignId.rawValue]) else {
             return nil
         }
-        
-        guard let templateId = itblElement[Keys.templateId.rawValue] as? NSNumber else {
-            return nil
-        }
-        
+
+        let templateId = itblElement[Keys.templateId.rawValue] as? NSNumber ?? NSNumber(value: 0)
+
         guard let messageId = itblElement[Keys.messageId.rawValue] as? String else {
             return nil
         }
-        
+
         let campaignId = itblElement[Keys.campaignId.rawValue] as? NSNumber ?? NSNumber(value: 0)
         
         return IterablePushNotificationMetadata(campaignId: campaignId,


### PR DESCRIPTION
## Summary
- Make templateId non-required in push notification metadata parsing (default to 0)
- Allows push open tracking when campaignId is missing from API-triggered campaigns

## Test plan
- Send push without campaignId, verify trackPushOpen fires
- Verify existing behavior unchanged

Generated with Claude Code