### PR TITLE
Fix #765: Add success/failure callbacks to logoutUser()

### DIFF
--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -247,8 +247,8 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
 
     }
 
-    func logoutUser() {
-        logoutPreviousUser()
+    func logoutUser(withOnSuccess onSuccess: OnSuccessHandler? = nil, onFailure: OnFailureHandler? = nil) {
+        logoutPreviousUser(withOnSuccess: onSuccess, onFailure: onFailure)
     }
     
     func attemptAndProcessMerge(merge: Bool, replay: Bool, destinationUser: String?, isEmail: Bool, failureHandler: OnFailureHandler? = nil) {
@@ -844,13 +844,13 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         IterableUtil.isNotNullOrEmpty(string: localStorage.userIdUnknownUser)
     }
     
-    private func logoutPreviousUser() {
+    private func logoutPreviousUser(withOnSuccess onSuccess: OnSuccessHandler? = nil, onFailure: OnFailureHandler? = nil) {
         ITBInfo()
-        
+
         guard isSDKInitialized() else { return }
-        
+
         if config.autoPushRegistration {
-            disableDeviceForCurrentUser()
+            disableDeviceForCurrentUser(withOnSuccess: onSuccess, onFailure: onFailure)
         }
         
         _email = nil

--- a/swift-sdk/SDK/IterableAPI.swift
+++ b/swift-sdk/SDK/IterableAPI.swift
@@ -211,8 +211,8 @@ import UIKit
     /// - Remark: This will empty out user specific authentication data and reset the in-app manager.
     ///           If `autoPushRegistration` is `true` (which is the default value), this will also
     ///           disable the current push token.
-    public static func logoutUser() {
-        implementation?.logoutUser()
+    public static func logoutUser(withOnSuccess onSuccess: OnSuccessHandler? = nil, onFailure: OnFailureHandler? = nil) {
+        implementation?.logoutUser(withOnSuccess: onSuccess, onFailure: onFailure)
     }
     
     /// The instance that manages getting and showing in-app messages


### PR DESCRIPTION
## Summary
- Add optional OnSuccessHandler and OnFailureHandler to logoutUser()
- Pass callbacks through to disableDeviceForCurrentUser()

## Test plan
- Verify logoutUser with callbacks receives results
- Verify backward compatibility

Generated with Claude Code