### PR TITLE
Fix #757: Rename SPM package to avoid naming conflicts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "IterableSDK",
+    name: "iterable-swift-sdk",
     platforms: [.iOS(.v10)],
     products: [
         // The external product of our package is an importable


### PR DESCRIPTION
## Summary
- Rename package from IterableSDK to iterable-swift-sdk in Package.swift
- Prevents SPM naming conflicts with other packages named swift-sdk

## Test plan
- Verify SPM resolves correctly with new name

Generated with Claude Code