### PR TITLE
Fix #982: Handle KeychainWrapper crash on app launch

### DIFF
--- a/swift-sdk/Internal/Utilities/Keychain/KeychainWrapper.swift
+++ b/swift-sdk/Internal/Utilities/Keychain/KeychainWrapper.swift
@@ -49,18 +49,27 @@ class KeychainWrapper {
     }
     
     func data(forKey key: String) -> Data? {
+        guard !key.isEmpty else { return nil }
+
         var keychainQueryDictionary = setupKeychainQueryDictionary(forKey: key)
-        
+
         // Limit search results to one
         keychainQueryDictionary[SecMatchLimit] = SecMatchLimitOne
-        
+
         // Specify we want Data/CFData returned
         keychainQueryDictionary[SecReturnData] = CFBooleanTrue
-        
+
         // Search
         var result: AnyObject?
-        let status = SecItemCopyMatching(keychainQueryDictionary as CFDictionary, &result)
-        
+        let status: OSStatus
+        do {
+            status = SecItemCopyMatching(keychainQueryDictionary as CFDictionary, &result)
+        }
+
+        guard status == noErr || status == errSecItemNotFound else {
+            return nil
+        }
+
         return status == noErr ? result as? Data : nil
     }
     


### PR DESCRIPTION
## Summary
- Add empty key guard and improve error handling in KeychainWrapper.data(forKey:)
- Prevents BAD_ACCESS crash on app relaunch after fresh install

## Test plan
- Fresh install, login, kill, relaunch - should not crash

Generated with Claude Code