### PR TITLE
Fix #799: Fix IterableAuthDelegate protocol conformance

### DIFF
--- a/swift-sdk/SDK/IterableConfig.swift
+++ b/swift-sdk/SDK/IterableConfig.swift
@@ -90,7 +90,7 @@ public struct IterableAPIMobileFrameworkInfo: Codable {
 /// The delegate for getting the authentication token
 @objc public protocol IterableAuthDelegate: AnyObject {
     @objc func onAuthTokenRequested(completion: @escaping AuthTokenRetrievalHandler)
-    @objc func onAuthFailure(_ authFailure: AuthFailure)
+    @objc optional func onAuthFailure(_ authFailure: AuthFailure)
 }
 
 /// The delegate for getting the UserId once unknown user session tracked


### PR DESCRIPTION
## Summary
- Make onAuthFailure method optional in IterableAuthDelegate protocol
- Allows conformance without implementing onAuthFailure

## Test plan
- Verify classes can conform without onAuthFailure

Generated with Claude Code