### PR TITLE
fix: Skip in-app message fetch when no user identity is set

### DIFF
--- a/swift-sdk/Internal/in-app/InAppManager.swift
+++ b/swift-sdk/Internal/in-app/InAppManager.swift
@@ -241,7 +241,14 @@ class InAppManager: NSObject, IterableInternalInAppManagerProtocol {
     
     private func synchronize(appIsReady: Bool) -> Pending<Bool, Error> {
         ITBInfo()
-        
+
+        // Skip fetching in-app messages when no user identity (email or userId) is set.
+        // Making API calls without a user identity returns empty results and wastes bandwidth.
+        guard IterableAPI.email != nil || IterableAPI.userId != nil else {
+            ITBInfo("Skipping in-app sync: no email or userId set")
+            return Fulfill<Bool, Error>(value: true)
+        }
+
         return fetcher.fetch()
             .map { [weak self] in
                 self?.mergeMessages($0) ?? MergeMessagesResult(inboxChanged: false, messagesMap: [:], deliveredMessages: [])


### PR DESCRIPTION
## Summary
- Guards against unnecessary API calls by checking for user identity (email or userId) before scheduling in-app message sync in `InAppManager.start()`
- Returns a resolved pending with `true` when no user identity exists, avoiding network errors

## Test plan
- [ ] Verify in-app sync is skipped when no email/userId is set
- [ ] Verify in-app sync proceeds normally when user identity exists
- [ ] Run `IterableInAppTests` suite

Closes #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)