### PR TITLE
feat: Add configurable getMessages sync interval

### DIFF
--- a/swift-sdk/Internal/Utilities/DependencyContainerProtocol.swift
+++ b/swift-sdk/Internal/Utilities/DependencyContainerProtocol.swift
@@ -49,7 +49,7 @@ extension DependencyContainerProtocol {
                      applicationStateProvider: applicationStateProvider,
                      notificationCenter: notificationCenter,
                      dateProvider: dateProvider,
-                     moveToForegroundSyncInterval: config.inAppDisplayInterval)
+                     moveToForegroundSyncInterval: config.inAppSyncInterval)
     }
     
     func createAuthManager(config: IterableConfig) -> IterableAuthManagerProtocol {

--- a/swift-sdk/SDK/IterableConfig.swift
+++ b/swift-sdk/SDK/IterableConfig.swift
@@ -162,6 +162,12 @@ public class IterableConfig: NSObject {
     
     /// How many seconds to wait before showing the next in-app, if there are more than one present
     public var inAppDisplayInterval: Double = 30.0
+
+    /// The minimum interval (in seconds) between in-app message sync requests when the app
+    /// returns to the foreground. This prevents excessive network calls if the user rapidly
+    /// switches between apps. Set to 0 to sync on every foreground event.
+    /// Defaults to 60 seconds.
+    public var inAppSyncInterval: Double = 60.0
     
     /// the number of seconds before expiration of the current auth token to get a new auth token
     /// will only apply if token-based authentication is enabled, and the current auth token has


### PR DESCRIPTION
## Summary
- Add `inAppSyncInterval` property to `IterableConfig` (defaults to 60 seconds)
- Controls the minimum interval between in-app message sync requests on foreground
- Prevents excessive network calls when users rapidly switch between apps

## Test plan
- [ ] Set custom interval and verify sync respects it
- [ ] Set to 0 and verify sync on every foreground event
- [ ] Verify default 60s behavior works correctly

Closes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)