### PR TITLE
fix: Prevent NWPathMonitor crash from retain cycle

### DIFF
--- a/swift-sdk/Internal/Network/NetworkMonitor.swift
+++ b/swift-sdk/Internal/Network/NetworkMonitor.swift
@@ -21,32 +21,35 @@ class NetworkMonitor: NetworkMonitorProtocol {
     init() {
         ITBInfo()
     }
-    
+
     deinit {
         ITBInfo()
         stop()
     }
-    
+
     var statusUpdatedCallback: (() -> Void)?
 
     func start() {
         ITBInfo()
         let networkMonitor = NWPathMonitor()
-        networkMonitor.pathUpdateHandler = { path in
+        networkMonitor.pathUpdateHandler = { [weak self] path in
             ITBInfo("networkMonitor.pathUpdateHandler, path: \(path.debugDescription), status: \(path.status)")
-            self.statusUpdatedCallback?()
+            self?.statusUpdatedCallback?()
         }
 
         networkMonitor.start(queue: queue)
         self.networkMonitor = networkMonitor
     }
-    
+
     func stop() {
         ITBInfo()
         networkMonitor?.cancel()
         networkMonitor = nil
     }
-    
-    private weak var networkMonitor: NWPathMonitor?
-    private let queue = DispatchQueue(label: "NetworkMonitor")
+
+    // Use a strong reference so the NWPathMonitor is kept alive while monitoring.
+    // The previous weak reference could cause the monitor to be deallocated prematurely,
+    // leading to crashes when the path update handler fired on a released object.
+    private var networkMonitor: NWPathMonitor?
+    private let queue = DispatchQueue(label: "NetworkMonitor", qos: .utility)
 }


### PR DESCRIPTION
## Summary
- Use `[weak self]` in `pathUpdateHandler` closure to break retain cycle that caused crashes
- Change `networkMonitor` from `weak` to strong reference to prevent premature deallocation
- Use `.utility` QoS for the monitoring dispatch queue

## Test plan
- [ ] Verify network status changes are still detected
- [ ] Profile for memory leaks around NetworkMonitor lifecycle
- [ ] Verify no crash on rapid start/stop cycles

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)