### PR TITLE
Sumeru — #823 Skip in-app fetch when no user identity set

### DIFF
--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -88,7 +88,8 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
                                                     apiClient: self.apiClient,
                                                     requestHandler: self.requestHandler,
                                                     deviceMetadata: deviceMetadata,
-                                                    authManager: self.authManager)
+                                                    authManager: self.authManager,
+                                                    authProvider: self)
     }()
     
     lazy var authManager: IterableAuthManagerProtocol = {

--- a/swift-sdk/Internal/Utilities/DependencyContainer.swift
+++ b/swift-sdk/Internal/Utilities/DependencyContainer.swift
@@ -5,8 +5,8 @@
 import Foundation
 
 struct DependencyContainer: DependencyContainerProtocol {
-    func createInAppFetcher(apiClient: ApiClientProtocol, authManager: IterableAuthManagerProtocol?) -> InAppFetcherProtocol {
-        InAppFetcher(apiClient: apiClient, authManager: authManager)
+    func createInAppFetcher(apiClient: ApiClientProtocol, authManager: IterableAuthManagerProtocol?, authProvider: AuthProvider?) -> InAppFetcherProtocol {
+        InAppFetcher(apiClient: apiClient, authManager: authManager, authProvider: authProvider)
     }
     
     let dateProvider: DateProviderProtocol = SystemDateProvider()

--- a/swift-sdk/Internal/Utilities/DependencyContainerProtocol.swift
+++ b/swift-sdk/Internal/Utilities/DependencyContainerProtocol.swift
@@ -16,7 +16,7 @@ protocol DependencyContainerProtocol: RedirectNetworkSessionProvider {
     var notificationCenter: NotificationCenterProtocol { get }
     var apnsTypeChecker: APNSTypeCheckerProtocol { get }
     
-    func createInAppFetcher(apiClient: ApiClientProtocol, authManager: IterableAuthManagerProtocol?) -> InAppFetcherProtocol
+    func createInAppFetcher(apiClient: ApiClientProtocol, authManager: IterableAuthManagerProtocol?, authProvider: AuthProvider?) -> InAppFetcherProtocol
     func createPersistenceContextProvider() -> IterablePersistenceContextProvider?
     func createRequestHandler(apiKey: String,
                               config: IterableConfig,
@@ -34,10 +34,11 @@ extension DependencyContainerProtocol {
                             apiClient: ApiClientProtocol,
                             requestHandler: RequestHandlerProtocol,
                             deviceMetadata: DeviceMetadata,
-                            authManager: IterableAuthManagerProtocol?) -> IterableInternalInAppManagerProtocol {
+                            authManager: IterableAuthManagerProtocol?,
+                            authProvider: AuthProvider?) -> IterableInternalInAppManagerProtocol {
         InAppManager(requestHandler: requestHandler,
                      deviceMetadata: deviceMetadata,
-                     fetcher: createInAppFetcher(apiClient: apiClient, authManager: authManager),
+                     fetcher: createInAppFetcher(apiClient: apiClient, authManager: authManager, authProvider: authProvider),
                      displayer: inAppDisplayer,
                      persister: inAppPersister,
                      inAppDelegate: config.inAppDelegate,

--- a/swift-sdk/Internal/in-app/InAppInternal.swift
+++ b/swift-sdk/Internal/in-app/InAppInternal.swift
@@ -26,34 +26,41 @@ struct IterableInAppMessageMetadata {
 }
 
 class InAppFetcher: InAppFetcherProtocol {
-    init(apiClient: ApiClientProtocol, authManager: IterableAuthManagerProtocol?) {
+    init(apiClient: ApiClientProtocol, authManager: IterableAuthManagerProtocol?, authProvider: AuthProvider?) {
         ITBInfo()
         self.apiClient = apiClient
         self.authManager = authManager
+        self.authProvider = authProvider
     }
-    
+
     deinit {
         ITBInfo()
     }
-    
+
     func fetch() -> Pending<[IterableInAppMessage], Error> {
         ITBInfo()
-        
+
         guard let apiClient = apiClient else {
             ITBError("Invalid state: expected ApiClient")
             return Fulfill(error: IterableError.general(description: "Invalid state: expected InternalApi"))
         }
-        
+
+        if let authProvider = authProvider, case .none = authProvider.auth.emailOrUserId {
+            ITBInfo("Skipping in-app message fetch — no user identity (email/userId) set")
+            return Fulfill<[IterableInAppMessage], Error>(value: [])
+        }
+
         return InAppHelper.getInAppMessagesFromServer(apiClient: apiClient,
                                                       authManager: authManager,
                                                       number: numMessages).mapFailure { $0 }
     }
-    
+
     // MARK: - Private/Internal
-    
+
     private weak var apiClient: ApiClientProtocol?
     private let authManager: IterableAuthManagerProtocol?
-    
+    private weak var authProvider: AuthProvider?
+
     private let numMessages = 100
 }
 

--- a/tests/common/CommonExtensions.swift
+++ b/tests/common/CommonExtensions.swift
@@ -121,7 +121,7 @@ class MockDependencyContainer: DependencyContainerProtocol {
         ITBInfo()
     }
     
-    func createInAppFetcher(apiClient _: ApiClientProtocol, authManager _: IterableAuthManagerProtocol?) -> InAppFetcherProtocol {
+    func createInAppFetcher(apiClient _: ApiClientProtocol, authManager _: IterableAuthManagerProtocol?, authProvider _: AuthProvider?) -> InAppFetcherProtocol {
         inAppFetcher
     }
     

--- a/tests/endpoint-tests/E2EDependencyContainer.swift
+++ b/tests/endpoint-tests/E2EDependencyContainer.swift
@@ -19,8 +19,8 @@ class E2EDependencyContainer: DependencyContainerProtocol {
     let notificationCenter: NotificationCenterProtocol
     let apnsTypeChecker: APNSTypeCheckerProtocol
 
-    func createInAppFetcher(apiClient: ApiClientProtocol, authManager: IterableAuthManagerProtocol?) -> InAppFetcherProtocol {
-        InAppFetcher(apiClient: apiClient, authManager: authManager)
+    func createInAppFetcher(apiClient: ApiClientProtocol, authManager: IterableAuthManagerProtocol?, authProvider: AuthProvider?) -> InAppFetcherProtocol {
+        InAppFetcher(apiClient: apiClient, authManager: authManager, authProvider: authProvider)
     }
     
     init(dateProvider: DateProviderProtocol = SystemDateProvider(),


### PR DESCRIPTION
## Summary
- Passes `AuthProvider` to `InAppFetcher` so it can check if a user identity (email/userId) exists before making API calls
- When no user identity is set, `fetch()` returns an empty array instead of hitting the API and generating error logs
- Covers both SDK initialization and foreground sync code paths

## Test plan
- [ ] Initialize SDK without setting email/userId — verify no "getMessages error" in logs
- [ ] Set email/userId after init — verify in-app messages are fetched on next foreground
- [ ] Run existing in-app message test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)