### PR TITLE
SDK-382 BCIT JWT Auth Retry: add real Iterable backend mode

### DIFF
--- a/tests/business-critical-integration/README.md
+++ b/tests/business-critical-integration/README.md
@@ -283,8 +283,8 @@ The **JWT Auth Retry** screen (inside the integration tester app) exercises the 
 
 | Mode       | Destination                               | Notes                                                                          |
 |------------|-------------------------------------------|--------------------------------------------------------------------------------|
-| `Normal`   | Real `https://api.iterable.com`           | Proxied with the SDK's real JWT. Use this to validate retry against prod-shape responses. |
-| `401`      | Real `https://api.iterable.com`           | Proxied with the `Authorization` header swapped to an **expired** JWT. Real backend returns a real `401 InvalidJwtPayload`. |
+| `Normal`   | Real `https://api.iterable.com` (direct)  | URLProtocol opts out — the SDK talks to Iterable directly, no proxy. Use this to validate retry against prod-shape responses. |
+| `401`      | Real `https://api.iterable.com` (proxied) | Intercepted and re-issued with the `Authorization` header swapped to an **expired** JWT. Real backend returns a real `401 InvalidJwtPayload`. |
 | `500`      | Local synthesis inside `MockAPIServer`    | No real traffic — you can't force prod to 500.                                 |
 | `Conn Err` | Local synthesis inside `MockAPIServer`    | Emits `NSURLErrorNotConnectedToInternet`. Equivalent to Android's `DEAD_PORT` trick. |
 

--- a/tests/business-critical-integration/README.md
+++ b/tests/business-critical-integration/README.md
@@ -277,6 +277,32 @@ To see everything that's happening:
 | `./scripts/run-tests.sh push --verbose` | Test push with details |
 | `open reports/` | View test reports in Finder |
 
+## 🔐 JWT Auth Retry Screen — Response Modes
+
+The **JWT Auth Retry** screen (inside the integration tester app) exercises the SDK's unified JWT retry logic. Its response-mode radios determine where traffic actually goes — matching the Android network-tester's behavior:
+
+| Mode       | Destination                               | Notes                                                                          |
+|------------|-------------------------------------------|--------------------------------------------------------------------------------|
+| `Normal`   | Real `https://api.iterable.com`           | Proxied with the SDK's real JWT. Use this to validate retry against prod-shape responses. |
+| `401`      | Real `https://api.iterable.com`           | Proxied with the `Authorization` header swapped to an **expired** JWT. Real backend returns a real `401 InvalidJwtPayload`. |
+| `500`      | Local synthesis inside `MockAPIServer`    | No real traffic — you can't force prod to 500.                                 |
+| `Conn Err` | Local synthesis inside `MockAPIServer`    | Emits `NSURLErrorNotConnectedToInternet`. Equivalent to Android's `DEAD_PORT` trick. |
+
+### Configuring a test project
+
+Proxied traffic lands in a real Iterable project. Use a **dedicated test project** to keep prod dashboards clean. The tester reads credentials from `integration-test-app/config/test-config.json`:
+
+```json
+{
+  "jwtApiKey": "<JWT-enabled API key from your test project>",
+  "jwtSecret": "<HMAC secret from the same test project>",
+  "baseUrl": "https://api.iterable.com",
+  "projectId": "<your test project ID>"
+}
+```
+
+The JWT secret rotates on the Iterable project's settings page; if you regenerate it, update `test-config.json` and rebuild.
+
 ## 🎉 What's Next?
 
 Once your local tests are passing:

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/AppDelegate+IntegrationTest.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/AppDelegate+IntegrationTest.swift
@@ -208,8 +208,10 @@ extension AppDelegate {
 
         let apiKey = loadJWTApiKeyFromConfig() ?? loadApiKeyFromConfig()
 
-        // Activate mock server BEFORE init to intercept GET requests (getInAppMessages,
-        // embedded-messaging) so they don't hit the real API with test emails.
+        // Activate mock server BEFORE init so requests route through it. Depending
+        // on `apiResponseMode` the protocol will either proxy to the real Iterable
+        // API (.normal / .jwt401) or synthesize locally (.server500 / .connectionError).
+        MockAPIServer.shared.jwtSecret = jwtSecret
         MockAPIServer.shared.activate()
 
         IterableAPI.initialize(apiKey: apiKey, launchOptions: nil, config: config)

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/MockAPIServer.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/MockAPIServer.swift
@@ -4,6 +4,14 @@ final class MockAPIServer {
     static let shared = MockAPIServer()
 
     // MARK: - API Response Mode (controlled by JWT Auth Retry panel)
+    //
+    // Matches Android MockServer.ResponseMode + the UI-only CONN_ERROR:
+    // - .normal          → proxy to real Iterable API (see MockAPIServerURLProtocol)
+    // - .jwt401          → proxy to real Iterable API with Authorization swapped
+    //                      to an expired JWT; real backend returns real 401
+    // - .server500       → local synthesized 500 (can't force 500 from prod)
+    // - .connectionError → local synthesized connection error (iOS equivalent of
+    //                      Android's DEAD_PORT trick)
 
     enum APIResponseMode: String, CaseIterable {
         case normal = "Normal"
@@ -13,6 +21,10 @@ final class MockAPIServer {
     }
 
     var apiResponseMode: APIResponseMode = .normal
+
+    /// JWT signing secret used by MockAPIServerURLProtocol when forging the
+    /// expired token for `.jwt401`. Populated by AppDelegate during SDK re-init.
+    var jwtSecret: String?
 
     // MARK: - State
 
@@ -79,80 +91,30 @@ final class MockAPIServer {
         return true
     }
 
-    /// Returns a mock response for the given request, or nil to pass through.
-    /// Matches Android behavior: same response mode applies to ALL requests
-    /// (GET and POST) uniformly. Only getRemoteConfiguration is exempt.
+    /// Returns a locally-synthesized mock response for `.server500` / `.connectionError`.
+    /// For `.normal` / `.jwt401` the request is proxied to the real Iterable API by
+    /// MockAPIServerURLProtocol; this method returns nil in those cases.
     func mockResponse(for request: URLRequest) -> MockResponse? {
         guard isActive, let url = request.url else { return nil }
 
-        let path = url.path
-
-        // getRemoteConfiguration handled by ConfigOverrideURLProtocol
-        if path.contains("getRemoteConfiguration") {
-            return nil
-        }
-
-        // Non-Iterable requests pass through
+        if url.path.contains("getRemoteConfiguration") { return nil }
         guard url.host?.contains("iterable.com") == true else { return nil }
 
         requestCount += 1
 
-        let endpoint = path.split(separator: "/").last.map(String.init) ?? path
+        let endpoint = url.path.split(separator: "/").last.map(String.init) ?? url.path
 
-        // Same response mode for GET and POST — matches Android MockServer.serve()
         switch apiResponseMode {
-        case .normal:
-            return successResponse(for: path)
-
-        case .jwt401:
-            return jwt401Response(endpoint: endpoint)
-
+        case .normal, .jwt401:
+            return nil // handled by proxy
         case .server500:
             return server500Response(endpoint: endpoint)
-
         case .connectionError:
             return connectionErrorResponse()
         }
     }
 
-    // MARK: - Response Helpers (matching Android response bodies)
-
-    private func successResponse(for path: String) -> MockResponse {
-        // Return endpoint-specific valid JSON for Decodable types,
-        // generic success for everything else (matching Android).
-        let json: [String: Any]
-        if path.contains("embedded-messaging/messages") {
-            json = ["placements": []]
-        } else if path.contains("getMessages") {
-            json = ["inAppMessages": []]
-        } else {
-            json = ["msg": "Success", "code": "Success", "successCount": 1]
-        }
-        let data = (try? JSONSerialization.data(withJSONObject: json)) ?? Data()
-        let endpoint = path.split(separator: "/").last.map(String.init) ?? path
-        print("[MOCK SERVER] 200 \(endpoint)")
-        LogStore.shared.log("📤 \(endpoint) → 200 ✅")
-        return MockResponse(
-            statusCode: 200,
-            data: data,
-            headers: ["Content-Type": "application/json", "Connection": "close"]
-        )
-    }
-
-    private func jwt401Response(endpoint: String) -> MockResponse {
-        let json: [String: Any] = [
-            "code": "InvalidJwtPayload",
-            "msg": "JWT token is expired"
-        ]
-        let data = (try? JSONSerialization.data(withJSONObject: json)) ?? Data()
-        print("[MOCK SERVER] 401 \(endpoint)")
-        LogStore.shared.log("📤 \(endpoint) → 401 ❌")
-        return MockResponse(
-            statusCode: 401,
-            data: data,
-            headers: ["Content-Type": "application/json", "Connection": "close"]
-        )
-    }
+    // MARK: - Response Helpers
 
     private func server500Response(endpoint: String) -> MockResponse {
         let json: [String: Any] = [
@@ -161,7 +123,7 @@ final class MockAPIServer {
         ]
         let data = (try? JSONSerialization.data(withJSONObject: json)) ?? Data()
         print("[MOCK SERVER] 500 \(endpoint)")
-        LogStore.shared.log("📤 \(endpoint) → 500 ❌")
+        LogStore.shared.log("📤 \(endpoint) → 500 ❌ (mocked)")
         return MockResponse(
             statusCode: 500,
             data: data,

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/MockAPIServer.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/MockAPIServer.swift
@@ -5,10 +5,11 @@ final class MockAPIServer {
 
     // MARK: - API Response Mode (controlled by JWT Auth Retry panel)
     //
-    // Matches Android MockServer.ResponseMode + the UI-only CONN_ERROR:
-    // - .normal          → proxy to real Iterable API (see MockAPIServerURLProtocol)
-    // - .jwt401          → proxy to real Iterable API with Authorization swapped
-    //                      to an expired JWT; real backend returns real 401
+    // - .normal          → NOT intercepted; SDK talks to api.iterable.com directly
+    //                      (MockAPIServerURLProtocol.canInit returns false)
+    // - .jwt401          → intercepted and proxied to api.iterable.com with the
+    //                      Authorization header swapped to an expired JWT; real
+    //                      backend returns a real 401 InvalidJwtPayload
     // - .server500       → local synthesized 500 (can't force 500 from prod)
     // - .connectionError → local synthesized connection error (iOS equivalent of
     //                      Android's DEAD_PORT trick)

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/MockAPIServer.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/MockAPIServer.swift
@@ -93,8 +93,8 @@ final class MockAPIServer {
     }
 
     /// Returns a locally-synthesized mock response for `.server500` / `.connectionError`.
-    /// For `.normal` / `.jwt401` the request is proxied to the real Iterable API by
-    /// MockAPIServerURLProtocol; this method returns nil in those cases.
+    /// `.normal` is not intercepted (URLProtocol.canInit returns false), and `.jwt401`
+    /// is proxied by MockAPIServerURLProtocol, so this method returns nil for both.
     func mockResponse(for request: URLRequest) -> MockResponse? {
         guard isActive, let url = request.url else { return nil }
 

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/MockAPIServerURLProtocol.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/MockAPIServerURLProtocol.swift
@@ -1,29 +1,28 @@
 import Foundation
+import IterableSDK
 
-/// URLProtocol that intercepts Iterable API requests and returns
-/// mock responses from MockAPIServer.
+/// URLProtocol that routes Iterable API requests per MockAPIServer.apiResponseMode:
+/// - .normal          → proxy to real Iterable API with the SDK's JWT
+/// - .jwt401          → proxy to real Iterable API, but with Authorization swapped
+///                      to an expired JWT (real backend returns a real 401
+///                      InvalidJwtPayload)
+/// - .server500       → local synthesized 500
+/// - .connectionError → local synthesized NSURLErrorNotConnectedToInternet
 ///
-/// Registered globally via URLProtocol.registerClass() and also
-/// injected into URLSessionConfiguration via swizzling, so it
-/// intercepts requests from ALL URLSessions including the SDK's
-/// offline task queue.
+/// Registered globally via URLProtocol.registerClass() and injected into
+/// URLSessionConfiguration via swizzling, so it intercepts requests from every
+/// URLSession — including the SDK's offline task queue.
 final class MockAPIServerURLProtocol: URLProtocol {
 
     private static let handledKey = "MockAPIServerURLProtocol.handled"
 
+    private var forwardTask: URLSessionDataTask?
+
     override class func canInit(with request: URLRequest) -> Bool {
-        // Only intercept when mock server is active
         guard MockAPIServer.shared.isActive else { return false }
-
-        // Don't handle if already handled (prevent double-handling)
         guard URLProtocol.property(forKey: handledKey, in: request) == nil else { return false }
-
-        // Only intercept Iterable API requests
         guard let host = request.url?.host, host.contains("iterable.com") else { return false }
-
-        // Only intercept if mock server wants to handle this request
         guard MockAPIServer.shared.shouldIntercept(request: request) else { return false }
-
         return true
     }
 
@@ -32,31 +31,41 @@ final class MockAPIServerURLProtocol: URLProtocol {
     }
 
     override func startLoading() {
-        // Mark as handled
-        let mutableRequest = (request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
-        URLProtocol.setProperty(true, forKey: MockAPIServerURLProtocol.handledKey, in: mutableRequest)
+        switch MockAPIServer.shared.apiResponseMode {
+        case .server500, .connectionError:
+            serveLocal()
+        case .normal:
+            proxyToRealBackend(swapExpiredJwt: false)
+        case .jwt401:
+            proxyToRealBackend(swapExpiredJwt: true)
+        }
+    }
 
+    override func stopLoading() {
+        forwardTask?.cancel()
+        forwardTask = nil
+    }
+
+    // MARK: - Local synthesis (500 / connection error only)
+
+    private func serveLocal() {
         guard let mockResponse = MockAPIServer.shared.mockResponse(for: request),
               let url = request.url else {
             client?.urlProtocol(self, didFailWithError: URLError(.unknown))
             return
         }
 
-        // Connection error — deliver NSError directly
         if let error = mockResponse.error {
             client?.urlProtocol(self, didFailWithError: error)
             return
         }
 
-        // Create HTTP response
-        let httpResponse = HTTPURLResponse(
+        if let response = HTTPURLResponse(
             url: url,
             statusCode: mockResponse.statusCode,
             httpVersion: "HTTP/1.1",
             headerFields: mockResponse.headers
-        )
-
-        if let response = httpResponse {
+        ) {
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         }
 
@@ -64,7 +73,60 @@ final class MockAPIServerURLProtocol: URLProtocol {
         client?.urlProtocolDidFinishLoading(self)
     }
 
-    override func stopLoading() {
-        // Responses are synchronous, nothing to cancel
+    // MARK: - Proxy to real backend (mirrors Android MockServer.proxy())
+
+    private func proxyToRealBackend(swapExpiredJwt: Bool) {
+        guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        // Mark handled so our canInit skips the re-issued request (avoids recursion).
+        URLProtocol.setProperty(true, forKey: MockAPIServerURLProtocol.handledKey, in: mutableRequest)
+
+        if swapExpiredJwt {
+            // Match MockAuthDelegate's email source so the forged expired JWT
+            // identifies the same user the SDK signed for — otherwise Iterable
+            // can return `jwtUserIdentifiersMismatched` instead of
+            // `InvalidJwtPayload`, exercising the wrong retry branch.
+            let email = IterableAPI.email ?? AppDelegate.currentTestEmail ?? ""
+            let secret = MockAPIServer.shared.jwtSecret ?? ""
+            let expired = JwtHelper.generateToken(email: email, secret: secret, expired: true) ?? "expired"
+            mutableRequest.setValue("Bearer \(expired)", forHTTPHeaderField: "Authorization")
+        }
+
+        let endpoint = request.url?.path.split(separator: "/").last.map(String.init)
+            ?? request.url?.path
+            ?? "?"
+
+        let task = URLSession.shared.dataTask(with: mutableRequest as URLRequest) { [weak self] data, response, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                // stopLoading() cancels the forwarded task; URLProtocol contract
+                // forbids further client callbacks after that, so swallow the
+                // cancellation instead of surfacing a false-negative failure.
+                if (error as NSError).code == NSURLErrorCancelled { return }
+
+                LogStore.shared.log("📤 \(endpoint) → error: \(error.localizedDescription)")
+                self.client?.urlProtocol(self, didFailWithError: error)
+                return
+            }
+
+            if let httpResponse = response as? HTTPURLResponse {
+                let emoji = (200..<300).contains(httpResponse.statusCode) ? "✅" : "❌"
+                let tag = swapExpiredJwt ? " (expired JWT)" : ""
+                LogStore.shared.log("📤 \(endpoint) → \(httpResponse.statusCode) \(emoji)\(tag)")
+                self.client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+            }
+
+            if let data = data {
+                self.client?.urlProtocol(self, didLoad: data)
+            }
+
+            self.client?.urlProtocolDidFinishLoading(self)
+        }
+        self.forwardTask = task
+        task.resume()
     }
 }

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/MockAPIServerURLProtocol.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/MockAPIServerURLProtocol.swift
@@ -2,16 +2,16 @@ import Foundation
 import IterableSDK
 
 /// URLProtocol that routes Iterable API requests per MockAPIServer.apiResponseMode:
-/// - .normal          → proxy to real Iterable API with the SDK's JWT
-/// - .jwt401          → proxy to real Iterable API, but with Authorization swapped
-///                      to an expired JWT (real backend returns a real 401
-///                      InvalidJwtPayload)
+/// - .normal          → NOT intercepted; SDK talks to api.iterable.com directly
+/// - .jwt401          → intercepted and proxied to api.iterable.com with the
+///                      Authorization header rewritten to an expired JWT, so the
+///                      real backend returns a real 401 InvalidJwtPayload
 /// - .server500       → local synthesized 500
 /// - .connectionError → local synthesized NSURLErrorNotConnectedToInternet
 ///
 /// Registered globally via URLProtocol.registerClass() and injected into
-/// URLSessionConfiguration via swizzling, so it intercepts requests from every
-/// URLSession — including the SDK's offline task queue.
+/// URLSessionConfiguration via swizzling, so it's in the chain for every
+/// URLSession — but it opts out (canInit → false) when the mode is .normal.
 final class MockAPIServerURLProtocol: URLProtocol {
 
     private static let handledKey = "MockAPIServerURLProtocol.handled"
@@ -20,6 +20,12 @@ final class MockAPIServerURLProtocol: URLProtocol {
 
     override class func canInit(with request: URLRequest) -> Bool {
         guard MockAPIServer.shared.isActive else { return false }
+
+        // Normal mode = the whole point is to let the SDK hit the real backend.
+        // Opt out of interception entirely so URLSession routes the request
+        // straight to api.iterable.com — no proxying required.
+        guard MockAPIServer.shared.apiResponseMode != .normal else { return false }
+
         guard URLProtocol.property(forKey: handledKey, in: request) == nil else { return false }
         guard let host = request.url?.host, host.contains("iterable.com") else { return false }
         guard MockAPIServer.shared.shouldIntercept(request: request) else { return false }
@@ -34,10 +40,12 @@ final class MockAPIServerURLProtocol: URLProtocol {
         switch MockAPIServer.shared.apiResponseMode {
         case .server500, .connectionError:
             serveLocal()
-        case .normal:
-            proxyToRealBackend(swapExpiredJwt: false)
         case .jwt401:
-            proxyToRealBackend(swapExpiredJwt: true)
+            proxyWithExpiredJwt()
+        case .normal:
+            // canInit returns false for .normal, so this is unreachable — but
+            // belt-and-suspenders in case the mode flips between canInit and here.
+            client?.urlProtocolDidFinishLoading(self)
         }
     }
 
@@ -73,9 +81,9 @@ final class MockAPIServerURLProtocol: URLProtocol {
         client?.urlProtocolDidFinishLoading(self)
     }
 
-    // MARK: - Proxy to real backend (mirrors Android MockServer.proxy())
+    // MARK: - Proxy with expired JWT (.jwt401 only)
 
-    private func proxyToRealBackend(swapExpiredJwt: Bool) {
+    private func proxyWithExpiredJwt() {
         guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
             client?.urlProtocol(self, didFailWithError: URLError(.unknown))
             return
@@ -84,16 +92,14 @@ final class MockAPIServerURLProtocol: URLProtocol {
         // Mark handled so our canInit skips the re-issued request (avoids recursion).
         URLProtocol.setProperty(true, forKey: MockAPIServerURLProtocol.handledKey, in: mutableRequest)
 
-        if swapExpiredJwt {
-            // Match MockAuthDelegate's email source so the forged expired JWT
-            // identifies the same user the SDK signed for — otherwise Iterable
-            // can return `jwtUserIdentifiersMismatched` instead of
-            // `InvalidJwtPayload`, exercising the wrong retry branch.
-            let email = IterableAPI.email ?? AppDelegate.currentTestEmail ?? ""
-            let secret = MockAPIServer.shared.jwtSecret ?? ""
-            let expired = JwtHelper.generateToken(email: email, secret: secret, expired: true) ?? "expired"
-            mutableRequest.setValue("Bearer \(expired)", forHTTPHeaderField: "Authorization")
-        }
+        // Match MockAuthDelegate's email source so the forged expired JWT
+        // identifies the same user the SDK signed for — otherwise Iterable
+        // can return `jwtUserIdentifiersMismatched` instead of
+        // `InvalidJwtPayload`, exercising the wrong retry branch.
+        let email = IterableAPI.email ?? AppDelegate.currentTestEmail ?? ""
+        let secret = MockAPIServer.shared.jwtSecret ?? ""
+        let expired = JwtHelper.generateToken(email: email, secret: secret, expired: true) ?? "expired"
+        mutableRequest.setValue("Bearer \(expired)", forHTTPHeaderField: "Authorization")
 
         let endpoint = request.url?.path.split(separator: "/").last.map(String.init)
             ?? request.url?.path
@@ -115,8 +121,7 @@ final class MockAPIServerURLProtocol: URLProtocol {
 
             if let httpResponse = response as? HTTPURLResponse {
                 let emoji = (200..<300).contains(httpResponse.statusCode) ? "✅" : "❌"
-                let tag = swapExpiredJwt ? " (expired JWT)" : ""
-                LogStore.shared.log("📤 \(endpoint) → \(httpResponse.statusCode) \(emoji)\(tag)")
+                LogStore.shared.log("📤 \(endpoint) → \(httpResponse.statusCode) \(emoji) (expired JWT)")
                 self.client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
             }
 

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/OfflineRetryTestViewController.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/OfflineRetryTestViewController.swift
@@ -42,6 +42,15 @@ final class OfflineRetryTestViewController: UIViewController {
     private var radioButtons: [UIButton] = []
     private var selectedResponseMode: MockAPIServer.APIResponseMode = .normal
 
+    // Hint beside the radios: "→ real backend" vs "→ local mock"
+    private let responseDestinationLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 10, weight: .regular)
+        label.textColor = .systemGray
+        label.text = "→ real backend"
+        return label
+    }()
+
     // Auth status
     private let authStatusLabel: UILabel = {
         let label = UILabel()
@@ -176,6 +185,7 @@ final class OfflineRetryTestViewController: UIViewController {
             radioButtons.append(button)
             radioRow.addArrangedSubview(button)
         }
+        radioRow.addArrangedSubview(responseDestinationLabel)
         // Select first radio
         radioButtons.first?.isSelected = true
         updateRadioAppearance()
@@ -573,7 +583,16 @@ final class OfflineRetryTestViewController: UIViewController {
         let mode = modes[sender.tag]
         selectedResponseMode = mode
         MockAPIServer.shared.apiResponseMode = mode
-        log("Response: \(mode.rawValue)")
+
+        let destination: String
+        switch mode {
+        case .normal:          destination = "→ real backend"
+        case .jwt401:          destination = "→ real backend (expired JWT)"
+        case .server500:       destination = "→ local mock"
+        case .connectionError: destination = "→ local mock"
+        }
+        responseDestinationLabel.text = destination
+        log("Response: \(mode.rawValue) \(destination)")
     }
 
     @objc private func showDatabase() {

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/OfflineRetryTestViewController.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/OfflineRetry/OfflineRetryTestViewController.swift
@@ -47,7 +47,7 @@ final class OfflineRetryTestViewController: UIViewController {
         let label = UILabel()
         label.font = .systemFont(ofSize: 10, weight: .regular)
         label.textColor = .systemGray
-        label.text = "→ real backend"
+        label.text = "→ real backend (direct)"
         return label
     }()
 
@@ -586,7 +586,7 @@ final class OfflineRetryTestViewController: UIViewController {
 
         let destination: String
         switch mode {
-        case .normal:          destination = "→ real backend"
+        case .normal:          destination = "→ real backend (direct)"
         case .jwt401:          destination = "→ real backend (expired JWT)"
         case .server500:       destination = "→ local mock"
         case .connectionError: destination = "→ local mock"


### PR DESCRIPTION
## What
The BCIT tester's JWT Auth Retry screen used to fabricate every response locally, so the SDK's new JWT retry logic was never validated against real Iterable traffic. Mirror the Android network-tester so Normal/401 proxy through to `api.iterable.com` while 500/ConnErr stay locally synthesized.

## Changes
- `MockAPIServerURLProtocol.startLoading` dispatches on response mode: Normal and 401 proxy through `URLSession.shared` (handled-marker avoids URLProtocol recursion); 500/ConnErr keep the existing local synthesis.
- For mode 401 the forwarded request's `Authorization` is rewritten to `Bearer <locally-forged expired JWT>` using the same email source (`IterableAPI.email ?? AppDelegate.currentTestEmail`) as `MockAuthDelegate`, so the backend returns real `InvalidJwtPayload` rather than a user-mismatch error.
- `stopLoading` cancels the forwarded task; completion swallows `NSURLErrorCancelled` to respect the URLProtocol contract.
- `MockAPIServer` exposes `jwtSecret`, drops unused success/jwt401 local helpers, and narrows `mockResponse(for:)` to 500/ConnErr.
- Small UI hint next to the response radios: "→ real backend" vs "→ local mock".
- README gains a JWT Auth Retry response-mode table and test-config.json notes.

## Impact
- **Breaking changes**: None — SDK and prod app code untouched; changes are scoped to the BCIT tester app.
- **Dependencies**: None.
- **Performance**: Proxied round-trips introduce real network latency (that is the point).
- **Data**: `Normal` and `401` now send real traffic to whichever Iterable project `test-config.json` points at. Current `projectId` is 28411 — keep using a dedicated test project so prod dashboards stay clean.

## Testing
**How to test:**
1. `tests/business-critical-integration/scripts/build-and-run.sh`
2. Open JWT Auth Retry → enter a test email → **Login**.
3. Mode = **Normal**, tap **Fire All** → network log should show real `200`s from `api.iterable.com` (not the old canned `{"successCount":1}`).
4. Mode = **401**, tap **Fire All** → expect real `401` with `{"code":"InvalidJwtPayload", ...}` from Iterable; confirm SDK pause + refresh + queue flush when flipped back to Normal.
5. Mode = **500** / **Conn Err** → unchanged local behavior.

**Edge cases:**
- Log out (email cleared): proxy in Normal still runs, but the SDK won't attach an auth token — you'll see real 401s from the backend; that's expected.
- Rapid mode flipping during an in-flight request: `stopLoading` should cancel the forwarded task silently (no noisy error).

**Known unverified items:** I have not yet observed a round-trip myself, so POST body forwarding through `URLRequest.httpBody` over URLProtocol is untested end-to-end (known iOS quirk when the SDK uses a body stream). Worth watching the first Normal-mode Fire All for empty-body 400s.