### PR TITLE
SDK-325 BCIT Migrate temp domain setup to final custom domain

### DIFF
--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/AppDelegate.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/AppDelegate.swift
@@ -475,13 +475,13 @@ extension AppDelegate: IterableURLDelegate {
             print("🌐 HTTPS URL received in URL delegate: \(url.absoluteString)")
             
             // Check if this is from our tracking domain (shouldn't happen if SDK unwrapped correctly)
-            if url.host == "links.tsetester.com" {
+            if url.host == "links.bcittesting.com" {
                 print("⚠️ Received wrapped tracking URL - SDK may not have unwrapped it")
             }
             
-            // Handle tsetester.com URLs with routing
-            if url.host == "tsetester.com" {
-                print("🎯 tsetester.com URL detected: \(url.path)")
+            // Handle bcittesting.com URLs with routing
+            if url.host == "bcittesting.com" {
+                print("🎯 bcittesting.com URL detected: \(url.path)")
                 
                 if url.path.hasPrefix("/update/") {
                     print("📱 Navigating to update screen for path: \(url.path)")
@@ -491,8 +491,8 @@ extension AppDelegate: IterableURLDelegate {
                     return true
                 }
                 
-                // For other tsetester.com paths, show generic alert
-                print("📱 Showing alert for tsetester.com path: \(url.path)")
+                // For other bcittesting.com paths, show generic alert
+                print("📱 Showing alert for bcittesting.com path: \(url.path)")
                 DispatchQueue.main.async {
                     self.showDeepLinkAlert(url: url)
                 }

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/Home/UpdateViewController.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/Home/UpdateViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-/// UpdateViewController - Displayed when deep link navigates to tsetester.com/update/*
+/// UpdateViewController - Displayed when deep link navigates to bcittesting.com/update/*
 class UpdateViewController: UIViewController {
     
     // MARK: - Properties
@@ -68,8 +68,8 @@ class UpdateViewController: UIViewController {
         label.text = """
         ✅ Deep Link Flow Complete
         
-        1. Wrapped link: links.tsetester.com/a/click
-        2. SDK unwrapped to: tsetester.com/update/hi
+        1. Wrapped link: links.bcittesting.com/a/click
+        2. SDK unwrapped to: bcittesting.com/update/hi
         3. SDK followed exactly ONE redirect
         4. App received unwrapped URL
         5. App navigated to this Update screen

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/SupportingFiles/iterablesdk-integration-tester.entitlements
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/SupportingFiles/iterablesdk-integration-tester.entitlements
@@ -6,7 +6,7 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:links.tsetester.com</string>
+		<string>applinks:links.bcittesting.com</string>
 	</array>
 </dict>
 </plist>

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/Tests/DeepLinkingIntegrationTests.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/Tests/DeepLinkingIntegrationTests.swift
@@ -43,7 +43,7 @@ class DeepLinkingIntegrationTests: IntegrationTestBase {
         print("🧪 Testing non-app links open in Safari (not app)")
         print("🎯 Links with /u/ pattern or non-AASA paths should open Safari")
         
-        let browserURL = "https://links.tsetester.com/u/click?url=https://iterable.com"
+        let browserURL = "https://links.bcittesting.com/u/click?url=https://iterable.com"
         
         print("🔗 Test URL: \(browserURL)")
         print("✅ Expected: Safari opens (not our app)")
@@ -77,12 +77,15 @@ class DeepLinkingIntegrationTests: IntegrationTestBase {
         try XCTSkipIf(isRunningInCI, "Universal Link tests require AASA and real Safari — skipped on CI")
         print("🧪 Testing deep link from Reminders app with Jena's test link")
         
-        // Jena's test URL - wrapped link that should unwrap to https://tsetester.com/update/hi
+        // TODO(SDK-325): regenerate this wrapped link against the new Mobile SDK Testing
+        // project (post SDK-36). The _t/_m/_e tokens below are tied to the old project and
+        // will 404 against links.bcittesting.com until the link is regenerated.
+        // Wrapped link should unwrap to https://bcittesting.com/update/hi
         // SDK should follow exactly ONE redirect and stop at the first destination
-        let testURL = "https://links.tsetester.com/a/click?_t=5cce074b113d48fa9ef346e4333ed8e8&_m=74aKPNrAjTpuZM4vZTDueu64xMdbHDz5Tn&_e=l6cj19GbssUn6h5qtXjRcC5os6azNW1cqdk9lsvmxxRl4ZTAW8mIB4IHJA97wE1i5f0eRDtm-KpgKI7-tM-Cly6umZo4P8HU8krftMYvL3T2sCpm3uFDBF2iJ5vQ-G6sqNMmae4_8jkE1DU9aKRhraZ1zzUZ3j-dFbQJrxdLt4tb0C7jnXSARVFf27FKFhBKnYSO23taBmf_4G5dTTXKmC_1CGnT9bu1nAwP-WMyYShoQhmjoGO9ppDCrVStSYPsimwub0h5XnC11g4u5yML_WZssgC7LSUOX7qCNOIDr9dLhrx2Rc2TY12k0maESyanjNgNZ4Lr8LMClCMJ3d9TMg%3D%3D"
+        let testURL = "https://links.bcittesting.com/a/click?_t=TODO_REGENERATE_TOKEN&_m=TODO&_e=TODO"
         
         print("🔗 Test URL: \(testURL)")
-        print("🎯 Expected unwrapped destination: https://tsetester.com/update/hi")
+        print("🎯 Expected unwrapped destination: https://bcittesting.com/update/hi")
         
         // Open link from Reminders app
         openLinkFromRemindersApp(url: testURL)
@@ -196,12 +199,15 @@ class DeepLinkingIntegrationTests: IntegrationTestBase {
         print("   to completionHandler, which tells URLSession to STOP following redirects")
         print("   See: swift-sdk/Internal/Network/NetworkSession.swift:136")
         
-        // Using Jena's test link which redirects to tsetester.com/update/hi
+        // TODO(SDK-325): regenerate this wrapped link against the new Mobile SDK Testing
+        // project (post SDK-36). The _t/_m/_e tokens below are tied to the old project and
+        // will 404 against links.bcittesting.com until the link is regenerated.
+        // Link should redirect to bcittesting.com/update/hi
         // If there are multiple redirects after that, SDK should NOT follow them
-        let testURL = "https://links.tsetester.com/a/click?_t=5cce074b113d48fa9ef346e4333ed8e8&_m=74aKPNrAjTpuZM4vZTDueu64xMdbHDz5Tn&_e=l6cj19GbssUn6h5qtXjRcC5os6azNW1cqdk9lsvmxxRl4ZTAW8mIB4IHJA97wE1i5f0eRDtm-KpgKI7-tM-Cly6umZo4P8HU8krftMYvL3T2sCpm3uFDBF2iJ5vQ-G6sqNMmae4_8jkE1DU9aKRhraZ1zzUZ3j-dFbQJrxdLt4tb0C7jnXSARVFf27FKFhBKnYSO23taBmf_4G5dTTXKmC_1CGnT9bu1nAwP-WMyYShoQhmjoGO9ppDCrVStSYPsimwub0h5XnC11g4u5yML_WZssgC7LSUOX7qCNOIDr9dLhrx2Rc2TY12k0maESyanjNgNZ4Lr8LMClCMJ3d9TMg%3D%3D"
+        let testURL = "https://links.bcittesting.com/a/click?_t=TODO_REGENERATE_TOKEN&_m=TODO&_e=TODO"
         
         print("🔗 Test URL: \(testURL)")
-        print("✅ Expected: SDK stops at first redirect (tsetester.com/update/hi)")
+        print("✅ Expected: SDK stops at first redirect (bcittesting.com/update/hi)")
         print("❌ Should NOT follow: Any subsequent redirects beyond the first one")
         
         // Open link from Reminders app
@@ -250,8 +256,8 @@ class DeepLinkingIntegrationTests: IntegrationTestBase {
         let networkMonitorTitle = app.navigationBars["Network Monitor"]
         XCTAssertTrue(networkMonitorTitle.waitForExistence(timeout: standardTimeout), "Network Monitor should open")
         
-        // Look for the wrapped link request (the initial request to links.tsetester.com)
-        let wrappedLinkPredicate = NSPredicate(format: "label CONTAINS[c] 'links.tsetester.com'")
+        // Look for the wrapped link request (the initial request to links.bcittesting.com)
+        let wrappedLinkPredicate = NSPredicate(format: "label CONTAINS[c] 'links.bcittesting.com'")
         let wrappedLinkCell = app.cells.containing(wrappedLinkPredicate).firstMatch
         
         if wrappedLinkCell.waitForExistence(timeout: 5.0) {
@@ -270,7 +276,7 @@ class DeepLinkingIntegrationTests: IntegrationTestBase {
         
         // CRITICAL: Verify we did NOT make a request to any "final destination" domain
         // If there was a multi-hop redirect, we would see requests to intermediate domains
-        // For this test, we're assuming tsetester.com/update/hi is the FIRST redirect
+        // For this test, we're assuming bcittesting.com/update/hi is the FIRST redirect
         // and there should be NO subsequent requests to other domains
         
         // Count how many unique domains we made requests to
@@ -279,10 +285,10 @@ class DeepLinkingIntegrationTests: IntegrationTestBase {
         
         for cell in allCells {
             let cellLabel = cell.staticTexts.firstMatch.label
-            if cellLabel.contains("tsetester.com") {
-                uniqueDomains.insert("tsetester.com")
-            } else if cellLabel.contains("links.tsetester.com") {
-                uniqueDomains.insert("links.tsetester.com")
+            if cellLabel.contains("bcittesting.com") {
+                uniqueDomains.insert("bcittesting.com")
+            } else if cellLabel.contains("links.bcittesting.com") {
+                uniqueDomains.insert("links.bcittesting.com")
             } else if cellLabel.contains("iterable.com") {
                 uniqueDomains.insert("iterable.com")
             }
@@ -292,12 +298,12 @@ class DeepLinkingIntegrationTests: IntegrationTestBase {
         print("🔍 Unique domains in network requests: \(uniqueDomains)")
         
         // We should see:
-        // 1. links.tsetester.com (the wrapped link)
-        // 2. tsetester.com (the first redirect destination)
+        // 1. links.bcittesting.com (the wrapped link)
+        // 2. bcittesting.com (the first redirect destination)
         // We should NOT see any third domain (which would indicate multi-hop)
         
         XCTAssertTrue(uniqueDomains.count <= 3, 
-                     "Should only see links.tsetester.com, tsetester.com, and iterable.com (SDK API calls). Found: \(uniqueDomains)")
+                     "Should only see links.bcittesting.com, bcittesting.com, and iterable.com (SDK API calls). Found: \(uniqueDomains)")
         
         print("✅ Network Monitor validation: Only expected domains found, no multi-hop redirect detected")
         


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [SDK-325](https://iterable.atlassian.net/browse/SDK-325)

## ✏️ Description

Migrating the BCIT integration tests off the temporary `tsetester.com` domain and onto the official engineering-owned `bcittesting.com` (procured via [IT-4410](https://iterable.atlassian.net/browse/IT-4410)).

### What changed

* `iterablesdk-integration-tester.entitlements`: associated domain `applinks:links.tsetester.com` -> `applinks:links.bcittesting.com`
* `AppDelegate.swift`: URL host checks and log strings now reference `bcittesting.com` / `links.bcittesting.com`
* `UpdateViewController.swift`: comment and on-screen flow info text updated
* `DeepLinkingIntegrationTests.swift`: all test URL constants point at the new domain. The two wrapped click URLs are stubbed with a `TODO_REGENERATE_TOKEN` placeholder and a `TODO(SDK-325)` comment, since the `_t/_m/_e` tokens are tied to the old Iterable project.

### Why the wrapped URL is a placeholder

The wrapped link tokens are project-scoped, so they will only become valid once [SDK-36](https://iterable.atlassian.net/browse/SDK-36) #1061 lands and we can regenerate the link against the new project. I left a loud `TODO_REGENERATE_TOKEN` so any test run that uses it fails fast with a 404 instead of silently passing or hitting the old project.

### Dependencies / sequencing

This PR is intentionally **not ready to merge yet**. The order is:

1. Merge SDK-36 #1061  (new Mobile SDK Testing project)
2. Merge iterable-infra [#15167](https://github.com/Iterable/iterable-infra/pull/15167) so `links.bcittesting.com` resolves and serves AASA
3. Configure the tracking + destination domain on the new Iterable project, upload AASA / assetlinks
4. Regenerate the wrapped link, replace the `TODO_REGENERATE_TOKEN` in this PR, then merge

[SDK-325]: https://iterable.atlassian.net/browse/SDK-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IT-4410]: https://iterable.atlassian.net/browse/IT-4410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-36]: https://iterable.atlassian.net/browse/SDK-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ