### PR TITLE
SDK-466 Cache DateFormatter and skip formatting for filtered log levels

### DIFF
--- a/swift-sdk/Internal/Utilities/IterableLogUtil.swift
+++ b/swift-sdk/Internal/Utilities/IterableLogUtil.swift
@@ -16,6 +16,8 @@ struct IterableLogUtil {
     static var sharedInstance: IterableLogUtil?
     
     func log(level: LogLevel, message: String?, file: String, method: String, line: Int) {
+        guard logDelegate.shouldLog?(level: level) ?? true else { return }
+
         let logMessage = IterableLogUtil.formatLogMessage(message: message, file: file, method: method, line: line, date: dateProvider.currentDate)
         logDelegate.log(level: level, message: logMessage)
     }
@@ -49,9 +51,13 @@ struct IterableLogUtil {
         }
     }
     
-    private static func formatDate(date: Date) -> String {
+    private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm:ss.SSSS"
-        return formatter.string(from: date)
+        return formatter
+    }()
+
+    private static func formatDate(date: Date) -> String {
+        dateFormatter.string(from: date)
     }
 }

--- a/swift-sdk/SDK/IterableConfig.swift
+++ b/swift-sdk/SDK/IterableConfig.swift
@@ -85,6 +85,12 @@ public struct IterableAPIMobileFrameworkInfo: Codable {
     ///     - message: The message to log. The message will include file, method and line of the call.
     @objc(log:message:)
     func log(level: LogLevel, message: String)
+
+    /// Return whether a message at the given level should be formatted and logged.
+    /// If this optional method is not implemented, all levels will be formatted and logged.
+    /// - Parameter level: The logging level
+    @objc(shouldLog:)
+    optional func shouldLog(level: LogLevel) -> Bool
 }
 
 /// The delegate for getting the authentication token

--- a/swift-sdk/SDK/IterableLogging.swift
+++ b/swift-sdk/SDK/IterableLogging.swift
@@ -13,10 +13,12 @@ import os
         self.minLogLevel = minLogLevel
     }
     
+    public func shouldLog(level: LogLevel) -> Bool {
+        level.rawValue >= minLogLevel.rawValue
+    }
+
     public func log(level: LogLevel = .info, message: String) {
-        guard level.rawValue >= minLogLevel.rawValue else {
-            return
-        }
+        guard shouldLog(level: level) else { return }
         
         let markedMessage = IterableLogUtil.markedMessage(level: level, message: message)
         os_log("%@", log: OSLog.default, type: OSLogType.error, markedMessage)
@@ -33,6 +35,10 @@ import os
 
 /// Will log nothing
 @objc public class NoneLogDelegate: NSObject, IterableLogDelegate {
+    public func shouldLog(level _: LogLevel) -> Bool {
+        false
+    }
+
     public func log(level _: LogLevel = .info, message _: String) {
         // Do nothing
     }

--- a/tests/unit-tests/LoggingTests.swift
+++ b/tests/unit-tests/LoggingTests.swift
@@ -7,6 +7,15 @@ import XCTest
 @testable import IterableSDK
 
 class LoggingTests: XCTestCase {
+    private class SpyDateProvider: DateProviderProtocol {
+        private(set) var currentDateAccessCount = 0
+
+        var currentDate: Date {
+            currentDateAccessCount += 1
+            return Date(timeIntervalSince1970: 0)
+        }
+    }
+
     func testLogging() {
         let expectation1 = expectation(description: "debug message")
         let expectation2 = expectation(description: "info message")
@@ -47,5 +56,25 @@ class LoggingTests: XCTestCase {
         ITBError(errorMessage)
         
         wait(for: [expectation1, expectation2, expectation3], timeout: 10.0)
+    }
+
+    func testDefaultLogDelegateDoesNotFormatFilteredLogLevel() {
+        let dateProvider = SpyDateProvider()
+        let logUtil = IterableLogUtil(dateProvider: dateProvider, logDelegate: DefaultLogDelegate(minLogLevel: .error))
+
+        logUtil.log(level: .info, message: "filtered", file: #file, method: #function, line: #line)
+        XCTAssertEqual(dateProvider.currentDateAccessCount, 0)
+
+        logUtil.log(level: .error, message: "logged", file: #file, method: #function, line: #line)
+        XCTAssertEqual(dateProvider.currentDateAccessCount, 1)
+    }
+
+    func testNoneLogDelegateDoesNotFormatMessages() {
+        let dateProvider = SpyDateProvider()
+        let logUtil = IterableLogUtil(dateProvider: dateProvider, logDelegate: NoneLogDelegate())
+
+        logUtil.log(level: .error, message: "filtered", file: #file, method: #function, line: #line)
+
+        XCTAssertEqual(dateProvider.currentDateAccessCount, 0)
     }
 }


### PR DESCRIPTION
## Summary
- Cache `IterableLogUtil`'s `DateFormatter` as a `private static let` so it is created once instead of on every log call (fixes the 2.4–3.2s main-thread hang reported by Wolt via Sentry during foreground transitions).
- Add an optional `shouldLog(level:) -> Bool` to `IterableLogDelegate` (default `true` when unimplemented) and short-circuit `IterableLogUtil.log()` before `formatLogMessage()` when the delegate says no — so apps with `DefaultLogDelegate(minLogLevel: .error)` no longer pay format cost for filtered `ITBInfo()`/`ITBDebug()` calls.
- `DefaultLogDelegate` routes its `minLogLevel` filter through `shouldLog`; `NoneLogDelegate` returns `false` for every level (bonus perf win).

Ticket: [SDK-466](https://iterable.atlassian.net/browse/SDK-466)

## Test plan
- [x] `./agent_build.sh` passes
- [x] `./agent_test.sh` passes (unit, notification-extension, and offline-events bundles all 0 failures)
- [x] New `LoggingTests` cover the short-circuit: `SpyDateProvider` confirms `currentDate` is never accessed when `DefaultLogDelegate` filters the level out, and never accessed at all under `NoneLogDelegate`
- [ ] Reviewer: sanity-check the new Obj-C selector name `shouldLog:` on `IterableLogDelegate` — low risk (Iterable-owned protocol, matches existing `log:message:` convention) but worth eyeballing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-466]: https://iterable.atlassian.net/browse/SDK-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ