### PR TITLE
SDK-468 Fix NetworkMonitor memory leak

### DIFF
--- a/agent_test.sh
+++ b/agent_test.sh
@@ -57,6 +57,21 @@ fi
 
 echo "Running Iterable Swift SDK unit tests..."
 
+# Resolve the simulator by name and boot it via CoreSimulator. Targeting by
+# UDID avoids xcodebuild's "no matching device" failures when multiple devices
+# share the same name across runtimes. This does NOT touch any Simulator.app
+# instance the user may already have open for another project.
+SIMULATOR_NAME="${SIMULATOR_NAME:-iPhone 17 Pro}"
+SIMULATOR_ID=$(xcrun simctl list devices available | grep -F "$SIMULATOR_NAME (" | head -1 | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
+
+if [[ -z "$SIMULATOR_ID" ]]; then
+    echo "❌ Could not find available simulator named '$SIMULATOR_NAME'"
+    exit 1
+fi
+
+xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
+xcrun simctl bootstatus "$SIMULATOR_ID" -b >/dev/null
+
 # Create a temporary file for the test output
 TEMP_OUTPUT=$(mktemp)
 
@@ -65,7 +80,7 @@ XCODEBUILD_CMD="xcodebuild test \
     -project swift-sdk.xcodeproj \
     -scheme swift-sdk \
     -sdk iphonesimulator \
-    -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+    -destination 'platform=iOS Simulator,id=$SIMULATOR_ID' \
     -enableCodeCoverage YES \
     -skipPackagePluginValidation \
     CODE_SIGNING_REQUIRED=NO"

--- a/swift-sdk.xcodeproj/project.pbxproj
+++ b/swift-sdk.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		ACDBB33B239582450036BB38 /* NotificationExtensionConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDBB33A239582450036BB38 /* NotificationExtensionConstants.swift */; };
 		ACE34AB5213776CB00691224 /* LocalStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE34AB4213776CB00691224 /* LocalStorageTests.swift */; };
 		ACED4C01213F50B30055A497 /* LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACED4C00213F50B30055A497 /* LoggingTests.swift */; };
+		8A4680022E4D000100000001 /* NetworkMonitorLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4680012E4D000100000001 /* NetworkMonitorLifecycleTests.swift */; };
 		ACEDF41F2183C436000B9BFE /* PendingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACEDF41E2183C436000B9BFE /* PendingTests.swift */; };
 		ACF406252507F90F005FD775 /* NetworkConnectivityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF406242507F90F005FD775 /* NetworkConnectivityManagerTests.swift */; };
 		ACF560D620E443BF000AAC23 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF560D520E443BF000AAC23 /* AppDelegate.swift */; };
@@ -849,6 +850,7 @@
 		ACDBB33A239582450036BB38 /* NotificationExtensionConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationExtensionConstants.swift; sourceTree = "<group>"; };
 		ACE34AB4213776CB00691224 /* LocalStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStorageTests.swift; sourceTree = "<group>"; };
 		ACED4C00213F50B30055A497 /* LoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingTests.swift; sourceTree = "<group>"; };
+		8A4680012E4D000100000001 /* NetworkMonitorLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitorLifecycleTests.swift; sourceTree = "<group>"; };
 		ACEDF41E2183C436000B9BFE /* PendingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTests.swift; sourceTree = "<group>"; };
 		ACF406242507F90F005FD775 /* NetworkConnectivityManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectivityManagerTests.swift; sourceTree = "<group>"; };
 		ACF560D320E443BF000AAC23 /* host-app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "host-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1371,6 +1373,7 @@
 				55B37FC0229620D20042F13A /* CommerceItemTests.swift */,
 				5536781E2576FF9000DB3652 /* IterableUtilTests.swift */,
 				ACED4C00213F50B30055A497 /* LoggingTests.swift */,
+				8A4680012E4D000100000001 /* NetworkMonitorLifecycleTests.swift */,
 				55B37FC5229752DD0042F13A /* OrderedDictionaryTests.swift */,
 				ACEDF41E2183C436000B9BFE /* PendingTests.swift */,
 			);
@@ -2407,6 +2410,7 @@
 				5588DFE928C046D7000697D7 /* MockInboxState.swift in Sources */,
 				181063DF2C9D51000078E0ED /* ValidateStoredEventCheckUnknownToKnownUserTest.swift in Sources */,
 				ACED4C01213F50B30055A497 /* LoggingTests.swift in Sources */,
+				8A4680022E4D000100000001 /* NetworkMonitorLifecycleTests.swift in Sources */,
 				AC52C5B8272A8B32000DCDCF /* KeychainWrapperTests.swift in Sources */,
 				ACC3FD9E2536D7A30004A2E0 /* InAppFilePersistenceTests.swift in Sources */,
 				5B5AA714284F1A6D0093FED4 /* MockNetworkSession.swift in Sources */,

--- a/swift-sdk/Internal/Network/NetworkConnectivityManager.swift
+++ b/swift-sdk/Internal/Network/NetworkConnectivityManager.swift
@@ -48,12 +48,14 @@ class NetworkConnectivityManager: NSObject {
     
     func stop() {
         ITBInfo()
+        networkMonitor.statusUpdatedCallback = nil
         networkMonitor.stop()
         stopTimer()
     }
     
     private func startTimer() {
         ITBInfo()
+        stopTimer()
         let interval = online ? onlineModePollingInterval : offlineModePollingInterval
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true, block: { [weak self] _ in
             ITBInfo("timer called")
@@ -75,8 +77,8 @@ class NetworkConnectivityManager: NSObject {
 
     private func updateStatus() {
         ITBInfo()
-        connectivityChecker.checkConnectivity().onSuccess { connected in
-            self.online = connected
+        connectivityChecker.checkConnectivity().onSuccess { [weak self] connected in
+            self?.online = connected
         }
     }
     
@@ -116,4 +118,3 @@ class NetworkConnectivityManager: NSObject {
         }
     }
 }
-

--- a/swift-sdk/Internal/Network/NetworkMonitor.swift
+++ b/swift-sdk/Internal/Network/NetworkMonitor.swift
@@ -8,6 +8,45 @@ import Foundation
 import Network
 #endif
 
+struct NetworkPathUpdate {
+    let debugDescription: String
+    let status: String
+}
+
+protocol NetworkPathMonitorProtocol: AnyObject {
+    var pathUpdateHandler: ((NetworkPathUpdate) -> Void)? { get set }
+    func start(queue: DispatchQueue)
+    func cancel()
+}
+
+#if canImport(Network)
+private final class NetworkPathMonitor: NetworkPathMonitorProtocol {
+    var pathUpdateHandler: ((NetworkPathUpdate) -> Void)? {
+        didSet {
+            guard let pathUpdateHandler = pathUpdateHandler else {
+                monitor.pathUpdateHandler = nil
+                return
+            }
+
+            monitor.pathUpdateHandler = { path in
+                pathUpdateHandler(NetworkPathUpdate(debugDescription: path.debugDescription,
+                                                    status: String(describing: path.status)))
+            }
+        }
+    }
+
+    func start(queue: DispatchQueue) {
+        monitor.start(queue: queue)
+    }
+
+    func cancel() {
+        monitor.cancel()
+    }
+
+    private let monitor = NWPathMonitor()
+}
+#endif
+
 /// Listens to network interface to detect status change.
 /// It only knows that the status has changed.
 /// It does not know if the network is online or not.
@@ -18,8 +57,9 @@ protocol NetworkMonitorProtocol {
 }
 
 class NetworkMonitor: NetworkMonitorProtocol {
-    init() {
+    init(pathMonitorFactory: @escaping () -> NetworkPathMonitorProtocol = { NetworkPathMonitor() }) {
         ITBInfo()
+        self.pathMonitorFactory = pathMonitorFactory
     }
     
     deinit {
@@ -31,10 +71,12 @@ class NetworkMonitor: NetworkMonitorProtocol {
 
     func start() {
         ITBInfo()
-        let networkMonitor = NWPathMonitor()
-        networkMonitor.pathUpdateHandler = { path in
+        stop()
+
+        let networkMonitor = pathMonitorFactory()
+        networkMonitor.pathUpdateHandler = { [weak self] path in
             ITBInfo("networkMonitor.pathUpdateHandler, path: \(path.debugDescription), status: \(path.status)")
-            self.statusUpdatedCallback?()
+            self?.statusUpdatedCallback?()
         }
 
         networkMonitor.start(queue: queue)
@@ -43,10 +85,12 @@ class NetworkMonitor: NetworkMonitorProtocol {
     
     func stop() {
         ITBInfo()
+        networkMonitor?.pathUpdateHandler = nil
         networkMonitor?.cancel()
         networkMonitor = nil
     }
     
-    private weak var networkMonitor: NWPathMonitor?
+    private var networkMonitor: NetworkPathMonitorProtocol?
+    private let pathMonitorFactory: () -> NetworkPathMonitorProtocol
     private let queue = DispatchQueue(label: "NetworkMonitor")
 }

--- a/swift-sdk/Internal/Network/NetworkMonitor.swift
+++ b/swift-sdk/Internal/Network/NetworkMonitor.swift
@@ -85,6 +85,10 @@ class NetworkMonitor: NetworkMonitorProtocol {
     
     func stop() {
         ITBInfo()
+        // `statusUpdatedCallback` intentionally persists across stop/start cycles:
+        // callers (e.g. `NetworkConnectivityManager`) set it once and expect it to
+        // survive, so they don't have to re-register after every stop. The
+        // `pathUpdateHandler` weak-self capture means this is not a leak risk.
         networkMonitor?.pathUpdateHandler = nil
         networkMonitor?.cancel()
         networkMonitor = nil

--- a/tests/offline-events-tests/TaskRunnerTests.swift
+++ b/tests/offline-events-tests/TaskRunnerTests.swift
@@ -7,6 +7,34 @@ import XCTest
 @testable import IterableSDK
 
 class TaskRunnerTests: XCTestCase {
+    private final class WeakBox<T: AnyObject> {
+        weak var value: T?
+
+        init(_ value: T?) {
+            self.value = value
+        }
+    }
+
+    private final class LifecycleNetworkMonitor: NetworkMonitorProtocol {
+        var statusUpdatedCallback: (() -> Void)?
+        private(set) var startCount = 0
+        private(set) var stopCount = 0
+
+        func start() {
+            startCount += 1
+        }
+
+        func stop() {
+            stopCount += 1
+        }
+    }
+
+    private final class ImmediatePersistenceContext: MockPersistenceContext {
+        override func perform(_ block: @escaping () -> Void) {
+            block()
+        }
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         
@@ -270,6 +298,58 @@ class TaskRunnerTests: XCTestCase {
         notificationCenter.post(name: UIApplication.willEnterForegroundNotification, object: nil, userInfo: nil)
         verifyTaskIsExecuted(notificationCenter, withinInterval: 10.0)
         taskRunner.stop()
+    }
+
+    func testForegroundBackgroundCyclingDoesNotLeakConnectivityLifecycle() throws {
+        let weakMonitor = WeakBox<LifecycleNetworkMonitor>(nil)
+        let weakManager = WeakBox<NetworkConnectivityManager>(nil)
+        let weakTaskRunner = WeakBox<IterableTaskRunner>(nil)
+
+        autoreleasepool {
+            let networkSession = MockNetworkSession()
+            let checker = NetworkConnectivityChecker(networkSession: networkSession)
+            let monitor = LifecycleNetworkMonitor()
+            weakMonitor.value = monitor
+            let notificationCenter = MockNotificationCenter()
+            let persistenceContextProvider = MockPersistenceContextProvider(context: ImmediatePersistenceContext())
+            let manager = NetworkConnectivityManager(networkMonitor: monitor,
+                                                     connectivityChecker: checker,
+                                                     notificationCenter: notificationCenter,
+                                                     offlineModePollingInterval: 600,
+                                                     onlineModePollingInterval: 600)
+            weakManager.value = manager
+
+            let healthMonitor = HealthMonitor(dataProvider: HealthMonitorDataProvider(maxTasks: 1000,
+                                                                                      persistenceContextProvider: persistenceContextProvider),
+                                              dateProvider: SystemDateProvider(),
+                                              networkSession: networkSession)
+            let taskRunner = IterableTaskRunner(networkSession: networkSession,
+                                                persistenceContextProvider: persistenceContextProvider,
+                                                healthMonitor: healthMonitor,
+                                                notificationCenter: notificationCenter,
+                                                timeInterval: 600,
+                                                connectivityManager: manager)
+            weakTaskRunner.value = taskRunner
+
+            taskRunner.start()
+            XCTAssertEqual(monitor.startCount, 1)
+
+            for cycleIndex in 1...3 {
+                notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil, userInfo: nil)
+                XCTAssertEqual(monitor.stopCount, cycleIndex)
+
+                notificationCenter.post(name: UIApplication.willEnterForegroundNotification, object: nil, userInfo: nil)
+                XCTAssertEqual(monitor.startCount, cycleIndex + 1)
+            }
+
+            taskRunner.stop()
+            XCTAssertEqual(monitor.stopCount, 4)
+            XCTAssertNil(monitor.statusUpdatedCallback)
+        }
+
+        XCTAssertNil(weakTaskRunner.value)
+        XCTAssertNil(weakManager.value)
+        XCTAssertNil(weakMonitor.value)
     }
     
     func testSentAtInHeader() throws {

--- a/tests/unit-tests/NetworkMonitorLifecycleTests.swift
+++ b/tests/unit-tests/NetworkMonitorLifecycleTests.swift
@@ -1,0 +1,98 @@
+//
+//  Copyright © 2026 Iterable. All rights reserved.
+//
+
+import XCTest
+
+@testable import IterableSDK
+
+class NetworkMonitorLifecycleTests: XCTestCase {
+    func testNetworkMonitorDeallocatesAfterStartAndStop() {
+        weak var weakMonitor: NetworkMonitor?
+        weak var weakPathMonitor: SpyPathMonitor?
+
+        autoreleasepool {
+            var monitor: NetworkMonitor? = NetworkMonitor(pathMonitorFactory: {
+                let pathMonitor = SpyPathMonitor()
+                weakPathMonitor = pathMonitor
+                return pathMonitor
+            })
+
+            weakMonitor = monitor
+            monitor?.start()
+            XCTAssertNotNil(weakPathMonitor)
+
+            monitor?.stop()
+            monitor = nil
+        }
+
+        XCTAssertNil(weakMonitor)
+        XCTAssertNil(weakPathMonitor)
+    }
+
+    func testStartTwiceReleasesFirstPathMonitor() {
+        var createdPathMonitorCount = 0
+        weak var firstPathMonitor: SpyPathMonitor?
+        weak var secondPathMonitor: SpyPathMonitor?
+
+        let monitor = NetworkMonitor(pathMonitorFactory: {
+            let pathMonitor = SpyPathMonitor()
+            createdPathMonitorCount += 1
+
+            if createdPathMonitorCount == 1 {
+                firstPathMonitor = pathMonitor
+            } else if createdPathMonitorCount == 2 {
+                secondPathMonitor = pathMonitor
+            }
+
+            return pathMonitor
+        })
+
+        monitor.start()
+        XCTAssertNotNil(firstPathMonitor)
+
+        monitor.start()
+        XCTAssertEqual(createdPathMonitorCount, 2)
+        XCTAssertNil(firstPathMonitor)
+        XCTAssertNotNil(secondPathMonitor)
+
+        monitor.stop()
+        XCTAssertNil(secondPathMonitor)
+    }
+
+    func testPathUpdateHandlerDoesNotInvokeStatusUpdatedCallbackAfterStop() {
+        let pathMonitor = SpyPathMonitor()
+        let monitor = NetworkMonitor(pathMonitorFactory: { pathMonitor })
+        var statusUpdatedCallbackCount = 0
+        monitor.statusUpdatedCallback = {
+            statusUpdatedCallbackCount += 1
+        }
+
+        monitor.start()
+        pathMonitor.sendPathUpdate()
+        XCTAssertEqual(statusUpdatedCallbackCount, 1)
+
+        monitor.stop()
+        XCTAssertNil(pathMonitor.pathUpdateHandler)
+
+        pathMonitor.sendPathUpdate()
+        XCTAssertEqual(statusUpdatedCallbackCount, 1)
+        XCTAssertEqual(pathMonitor.cancelCount, 1)
+    }
+
+    private final class SpyPathMonitor: NetworkPathMonitorProtocol {
+        var pathUpdateHandler: ((NetworkPathUpdate) -> Void)?
+        private(set) var cancelCount = 0
+
+        func start(queue _: DispatchQueue) {}
+
+        func cancel() {
+            cancelCount += 1
+        }
+
+        func sendPathUpdate() {
+            pathUpdateHandler?(NetworkPathUpdate(debugDescription: "spy path",
+                                                status: "satisfied"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes a customer-reported memory leak (Iterable 6.5.7 / 6.5.12, iOS 17.5 / 18.2, GitHub issue #867) where `IterableTaskRunner.start()` → `NetworkConnectivityManager.start()` → `NetworkMonitor.start()` retained `NWPathMonitor` + the `NetworkMonitor` wrapper for the lifetime of the app. Three compounding causes: `pathUpdateHandler` captured `self` strongly, the stored monitor reference was `weak` (so `stop()` was unreliable), and `start()` was not idempotent across foreground/background cycles.
- `NetworkMonitor.start()` is now idempotent, captures `[weak self]` in `pathUpdateHandler`, and stores `NWPathMonitor` strongly via a small `NetworkPathMonitorProtocol` wrapper injected through a `pathMonitorFactory` closure (default = real impl). `stop()` clears the handler, cancels the monitor, and nils the reference.
- `NetworkConnectivityManager` cleanups: `stop()` clears `statusUpdatedCallback`, `startTimer()` is idempotent, and `updateStatus()`'s connectivity-check success callback uses `[weak self]`.
- Includes a small `agent_test.sh` improvement: resolve the simulator by UDID and boot via `xcrun simctl` so xcodebuild doesn't fail when multiple simulators share a model name across runtimes. **Non-intrusive** — does not touch any `Simulator.app` instance the developer may have open for another project.

Ticket: [SDK-468](https://iterable.atlassian.net/browse/SDK-468) · Closes GitHub issue #867

## Test plan
- [x] `./agent_build.sh` passes
- [x] `./agent_test.sh` passes (588 unit + 12 notification-extension + 90 offline-events = 690 tests, 0 failures)
- [x] New `NetworkMonitorLifecycleTests` (3 cases): dealloc after `start()`/`stop()`, first monitor released on consecutive `start()` calls, no callback fires after `stop()` (also asserts `cancel()` was called)
- [x] New `TaskRunnerTests.testForegroundBackgroundCyclingDoesNotLeakConnectivityLifecycle`: cycles `didEnterBackground` / `willEnterForeground` 3× and asserts task runner, manager, and monitor all deallocate (weak-ref via `WeakBox`)
- [ ] Reviewer: the `NetworkPathMonitorProtocol` wrapper is a new internal type added for testability — please sanity-check that you're happy with the shape
- [ ] Reviewer (optional follow-up): run the original SwiftUI repro under Instruments → Leaks for 60s to confirm zero `NWPathMonitor` / `NetworkMonitor` leaks rooted in `NetworkMonitor.start()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-468]: https://iterable.atlassian.net/browse/SDK-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ