### PR TITLE
SDK-99 Add async/await variants for disablePush

### DIFF
--- a/swift-sdk/SDK/IterableAPI.swift
+++ b/swift-sdk/SDK/IterableAPI.swift
@@ -300,10 +300,28 @@ import UIKit
     public static func disableDeviceForCurrentUser() {
         disableDeviceForCurrentUser(withOnSuccess: nil, onFailure: nil)
     }
+
+    /// Disable this device's token in Iterable, for the current user.
+    @nonobjc
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    public static func disableDeviceForCurrentUser() async throws {
+        try await disableDeviceAsync { onSuccess, onFailure in
+            disableDeviceForCurrentUser(withOnSuccess: onSuccess, onFailure: onFailure)
+        }
+    }
     
     /// Disable this device's token in Iterable, for all users on this device.
     public static func disableDeviceForAllUsers() {
         disableDeviceForAllUsers(withOnSuccess: nil, onFailure: nil)
+    }
+
+    /// Disable this device's token in Iterable, for all users on this device.
+    @nonobjc
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    public static func disableDeviceForAllUsers() async throws {
+        try await disableDeviceAsync { onSuccess, onFailure in
+            disableDeviceForAllUsers(withOnSuccess: onSuccess, onFailure: onFailure)
+        }
     }
     
     /// Disable this device's token in Iterable, for the current user, with custom completion blocks
@@ -330,6 +348,29 @@ import UIKit
         guard let implementation, implementation.isSDKInitialized() else { return }
         
         implementation.disableDeviceForAllUsers(withOnSuccess: onSuccess, onFailure: onFailure)
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    private static func disableDeviceAsync(
+        _ disableDevice: (_ onSuccess: OnSuccessHandler?, _ onFailure: OnFailureHandler?) -> Void
+    ) async throws {
+        guard let implementation, implementation.isSDKInitialized() else {
+            throw SendRequestError(reason: sdkNotInitializedErrorReason)
+        }
+
+        try await withCheckedThrowingContinuation { continuation in
+            let resumeGuard = AsyncContinuationResumeGuard()
+
+            disableDevice({ _ in
+                resumeGuard.resume {
+                    continuation.resume(returning: ())
+                }
+            }, { reason, data in
+                resumeGuard.resume {
+                    continuation.resume(throwing: SendRequestError(reason: reason, data: data))
+                }
+            })
+        }
     }
     
     /// Updates the available user fields
@@ -865,7 +906,27 @@ import UIKit
     
     // MARK: - Private/Internal
     
+    private static let sdkNotInitializedErrorReason = "Iterable SDK is not initialized"
+
     static var implementation: InternalIterableAPI?
     
     override private init() { super.init() }
+}
+
+private final class AsyncContinuationResumeGuard {
+    private let lock = NSLock()
+    private var didResume = false
+
+    func resume(_ block: () -> Void) {
+        lock.lock()
+        let shouldResume = !didResume
+        if shouldResume {
+            didResume = true
+        }
+        lock.unlock()
+
+        if shouldResume {
+            block()
+        }
+    }
 }

--- a/tests/unit-tests/IterableAPITests.swift
+++ b/tests/unit-tests/IterableAPITests.swift
@@ -681,6 +681,102 @@ class IterableAPITests: XCTestCase {
         
         wait(for: [expectation], timeout: testExpectationTimeout)
     }
+
+    @available(iOS 13.0, *)
+    func testDisableDeviceForCurrentUserAsyncSuccess() async throws {
+        let oldImplementation = IterableAPI.implementation
+        defer { IterableAPI.implementation = oldImplementation }
+
+        let networkSession = MockNetworkSession(statusCode: 200)
+        let token = try await setUpIterableAPIForAsyncDisableDevice(networkSession: networkSession)
+
+        try await IterableAPI.disableDeviceForCurrentUser()
+
+        guard let request = networkSession.getRequest(withEndPoint: Const.Path.disableDevice) else {
+            return XCTFail("Expected disableDevice request")
+        }
+        guard let body = TestUtils.getRequestBody(request: request) else {
+            return XCTFail("Expected disableDevice request body")
+        }
+
+        TestUtils.validate(request: request,
+                           requestType: .post,
+                           apiEndPoint: Endpoint.api,
+                           path: Const.Path.disableDevice,
+                           queryParams: [])
+        TestUtils.validateElementPresent(withName: JsonKey.token, andValue: token.hexString(), inDictionary: body)
+        TestUtils.validateElementPresent(withName: JsonKey.email, andValue: "user@example.com", inDictionary: body)
+    }
+
+    @available(iOS 13.0, *)
+    func testDisableDeviceForAllUsersAsyncSuccess() async throws {
+        let oldImplementation = IterableAPI.implementation
+        defer { IterableAPI.implementation = oldImplementation }
+
+        let networkSession = MockNetworkSession(statusCode: 200)
+        let token = try await setUpIterableAPIForAsyncDisableDevice(networkSession: networkSession)
+
+        try await IterableAPI.disableDeviceForAllUsers()
+
+        guard let request = networkSession.getRequest(withEndPoint: Const.Path.disableDevice) else {
+            return XCTFail("Expected disableDevice request")
+        }
+        guard let body = TestUtils.getRequestBody(request: request) else {
+            return XCTFail("Expected disableDevice request body")
+        }
+
+        TestUtils.validate(request: request,
+                           requestType: .post,
+                           apiEndPoint: Endpoint.api,
+                           path: Const.Path.disableDevice,
+                           queryParams: [])
+        TestUtils.validateElementPresent(withName: JsonKey.token, andValue: token.hexString(), inDictionary: body)
+        TestUtils.validateElementNotPresent(withName: JsonKey.email, inDictionary: body)
+        TestUtils.validateElementNotPresent(withName: JsonKey.userId, inDictionary: body)
+    }
+
+    @available(iOS 13.0, *)
+    func testDisableDeviceForCurrentUserAsyncFailureThrowsSendRequestError() async throws {
+        let oldImplementation = IterableAPI.implementation
+        defer { IterableAPI.implementation = oldImplementation }
+
+        let failureReason = "disable failed"
+        let networkSession = MockNetworkSession(responseCallback: { url in
+            if url.absoluteString.contains(Const.Path.disableDevice) {
+                return MockNetworkSession.MockResponse(statusCode: 400,
+                                                       data: ["msg": failureReason].toJsonData())
+            }
+            return MockNetworkSession.MockResponse(statusCode: 200)
+        })
+        _ = try await setUpIterableAPIForAsyncDisableDevice(networkSession: networkSession)
+
+        do {
+            try await IterableAPI.disableDeviceForCurrentUser()
+            XCTFail("Expected disableDeviceForCurrentUser async API to throw")
+        } catch let error as SendRequestError {
+            XCTAssertEqual(error.reason, failureReason)
+            XCTAssertEqual(error.data, ["msg": failureReason].toJsonData())
+        } catch {
+            XCTFail("Expected SendRequestError, got \(error)")
+        }
+    }
+
+    @available(iOS 13.0, *)
+    func testDisableDeviceForCurrentUserAsyncNotInitializedThrowsSendRequestError() async {
+        let oldImplementation = IterableAPI.implementation
+        IterableAPI.implementation = nil
+        defer { IterableAPI.implementation = oldImplementation }
+
+        do {
+            try await IterableAPI.disableDeviceForCurrentUser()
+            XCTFail("Expected disableDeviceForCurrentUser async API to throw")
+        } catch let error as SendRequestError {
+            XCTAssertEqual(error.reason, "Iterable SDK is not initialized")
+            XCTAssertNil(error.data)
+        } catch {
+            XCTFail("Expected SendRequestError, got \(error)")
+        }
+    }
     
     func testUpdateCart() {
         let condition1 = XCTestExpectation(description: #function)
@@ -1478,4 +1574,54 @@ class IterableAPITests: XCTestCase {
         XCTAssertEqual(dateFromMilliseconds, testDate)
     }
 
+    @available(iOS 13.0, *)
+    private func setUpIterableAPIForAsyncDisableDevice(networkSession: MockNetworkSession) async throws -> Data {
+        let config = IterableConfig()
+        config.pushIntegrationName = "my-push-integration"
+
+        IterableAPI.initializeForTesting(apiKey: IterableAPITests.apiKey,
+                                         config: config,
+                                         networkSession: networkSession)
+        IterableAPI.email = "user@example.com"
+
+        let token = "zeeToken".data(using: .utf8)!
+        try await registerTokenForAsyncDisableDevice(token)
+        return token
+    }
+
+    @available(iOS 13.0, *)
+    private func registerTokenForAsyncDisableDevice(_ token: Data) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            let resumeGuard = TestAsyncContinuationResumeGuard()
+
+            IterableAPI.register(token: token, onSuccess: { _ in
+                resumeGuard.resume {
+                    continuation.resume(returning: ())
+                }
+            }, onFailure: { reason, data in
+                resumeGuard.resume {
+                    continuation.resume(throwing: SendRequestError(reason: reason, data: data))
+                }
+            })
+        }
+    }
+
+}
+
+private final class TestAsyncContinuationResumeGuard {
+    private let lock = NSLock()
+    private var didResume = false
+
+    func resume(_ block: () -> Void) {
+        lock.lock()
+        let shouldResume = !didResume
+        if shouldResume {
+            didResume = true
+        }
+        lock.unlock()
+
+        if shouldResume {
+            block()
+        }
+    }
 }


### PR DESCRIPTION
## What
Adds Swift concurrency overloads for the disablePush APIs so callers can `await` them. This was the only remaining piece of SDK-99 after offline-retry (SDK-297) and the success/fail callbacks already shipped.

## Changes
- Add `disableDeviceForCurrentUser() async throws` and `disableDeviceForAllUsers() async throws` on `IterableAPI`, wrapping the existing completion-handler APIs via `withCheckedThrowingContinuation`.
- Throw the public `SendRequestError` on failure (carries the reason/data from `OnFailureHandler`); an `NSLock`-backed guard makes resume exactly-once.
- Preflight throws `"Iterable SDK is not initialized"` instead of hanging the `await` on the existing silent not-initialized path (the completion methods call neither handler when uninitialized).
- `@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)` + `@nonobjc` so existing methods and the Obj-C surface stay untouched (base target remains iOS 10).

## Impact
- **Breaking changes**: None — purely additive overloads; existing parameterless/completion-handler methods and Obj-C selectors are unchanged.
- **Dependencies**: None.
- **Performance**: Negligible — a thin continuation wrapper over the existing call path.

## Testing
**How to test:**
1. Run `./agent_build.sh` (succeeds) and `./agent_test.sh` (unit 605 / notification-extension 12 / offline-events 90, 0 failures).
2. From an iOS 13+ target after `IterableAPI.initialize…`: `try await IterableAPI.disableDeviceForCurrentUser()` → a `disableDevice` request is sent with the token.
3. Force a server failure (e.g. 400) → the call throws `SendRequestError` carrying the response reason/data.
4. Call before initializing the SDK → throws `"Iterable SDK is not initialized"` and does **not** hang.

Jira: https://iterable.atlassian.net/browse/SDK-99