### PR TITLE
SDK-469 Fix CodeQL string length conflation in deep link check

### DIFF
--- a/swift-sdk/Internal/DeepLinkManager.swift
+++ b/swift-sdk/Internal/DeepLinkManager.swift
@@ -93,8 +93,13 @@ class DeepLinkManager: NSObject {
         guard let regex = try? NSRegularExpression(pattern: Const.deepLinkRegex, options: []) else {
             return false
         }
-        
-        return regex.firstMatch(in: urlString, options: [], range: NSMakeRange(0, urlString.count)) != nil
+
+        // NSRegularExpression operates on NSString (UTF-16) semantics, so the search
+        // range must be built from the NSString length, not String.count. Mixing the
+        // two conflates length measures and produces an incorrect range for strings
+        // containing non-BMP characters (e.g. emoji). See CWE-135 (SDK-469).
+        let nsString = urlString as NSString
+        return regex.firstMatch(in: urlString, options: [], range: NSRange(location: 0, length: nsString.length)) != nil
     }
     
     private lazy var redirectUrlSession: NetworkSessionProtocol = {

--- a/swift-sdk/Internal/DeepLinkManager.swift
+++ b/swift-sdk/Internal/DeepLinkManager.swift
@@ -94,12 +94,11 @@ class DeepLinkManager: NSObject {
             return false
         }
 
-        // NSRegularExpression operates on NSString (UTF-16) semantics, so the search
-        // range must be built from the NSString length, not String.count. Mixing the
-        // two conflates length measures and produces an incorrect range for strings
-        // containing non-BMP characters (e.g. emoji). See CWE-135 (SDK-469).
-        let nsString = urlString as NSString
-        return regex.firstMatch(in: urlString, options: [], range: NSRange(location: 0, length: nsString.length)) != nil
+        // Build the range with NSRange(_:in:) so it is in the UTF-16 coordinates
+        // NSRegularExpression expects. urlString.count conflates Swift String length
+        // with NSString length for non-BMP characters (CWE-135, SDK-469).
+        let range = NSRange(urlString.startIndex..<urlString.endIndex, in: urlString)
+        return regex.firstMatch(in: urlString, options: [], range: range) != nil
     }
     
     private lazy var redirectUrlSession: NetworkSessionProtocol = {

--- a/tests/unit-tests/DeepLinkTests.swift
+++ b/tests/unit-tests/DeepLinkTests.swift
@@ -149,7 +149,26 @@ class DeepLinkTests: XCTestCase {
     func testIsIterableDeepLinkReturnsFalseForEmptyString() {
         XCTAssertFalse(IterableAPI.isIterableDeepLink(""))
     }
-    
+
+    // SDK-469: when the URL contains non-BMP characters (e.g. emoji) BEFORE the
+    // deep-link path segment, String.count under-counts vs NSString.length (each
+    // 👍🏿 is one Character but four UTF-16 code units). A search range built from
+    // String.count stops short of the trailing "/a/..." segment and misses the
+    // match; a range built from NSString.length covers the full string.
+    //
+    // The emoji prefix is long enough that the count deficit pushes the entire
+    // "/a/..." token past the truncated range, so this test FAILS against the old
+    // String.count-based implementation and passes with the NSString.length fix.
+    func testIsIterableDeepLinkMatchesWithNonBMPCharactersBeforePath() {
+        let urlWithEmoji = "https://links.iterable.com/" + String(repeating: "👍🏿", count: 20) + "/a/60402396fbd5433eb35397b47ab2fb83"
+        XCTAssertTrue(IterableAPI.isIterableDeepLink(urlWithEmoji))
+    }
+
+    func testIsIterableDeepLinkHandlesNonBMPCharactersWithoutDeepLinkPath() {
+        let urlWithEmoji = "https://example.com/" + String(repeating: "👍🏿", count: 20) + "/some/path"
+        XCTAssertFalse(IterableAPI.isIterableDeepLink(urlWithEmoji))
+    }
+
     // MARK: - Other Tests
     
     /// this is a service that automatically redirects if that url is hit, make sure we are not actually hitting the url but our servers


### PR DESCRIPTION
## What
Fixes a CodeQL-flagged String-length conflation (CWE-135) in `DeepLinkManager.isIterableDeepLink`. The `NSRegularExpression` search range was built from `urlString.count` (a Swift `String` grapheme-cluster count) while `NSRegularExpression` operates on `NSString`/UTF-16 coordinates. For URLs with non-BMP characters (e.g. emoji), those measures diverge and the range under-covers the string, so a valid deep link can be missed. Ticket: [SDK-469](https://iterable.atlassian.net/browse/SDK-469).

## Changes
- `DeepLinkManager.swift`: build the `NSRange` from the bridged `NSString.length` instead of `String.count`, so the range matches the UTF-16 coordinates `NSRegularExpression` uses. Matches the ticket's prescribed fix and CodeQL's own recommended example.
- `DeepLinkTests.swift`: two regression tests — a URL with a long non-BMP prefix before the `/a/...` segment (this case returns `false` under the old `String.count` range and `true` with the fix), and a non-BMP URL without a deep-link path (stays `false`).

## Impact
- **Breaking changes**: None. Behavior only changes for previously-mishandled non-BMP URLs, which now match correctly.
- **Dependencies**: None.
- **Performance**: Negligible — one `String`→`NSString` bridge per call.

## Testing
**How to test:**
1. Run `./agent_test.sh DeepLinkTests` — 11/11 pass, including the two new SDK-469 cases.
2. Confirm CodeQL no longer flags the string-length conflation at `DeepLinkManager.swift`.
3. Edge case: a deep link like `https://links.iterable.com/👍🏿…/a/<id>` is now correctly recognized as an Iterable deep link.

[SDK-469]: https://iterable.atlassian.net/browse/SDK-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ