### PR TITLE
SDK-470 Add CustomDebugStringConvertible to AuthFailureReason

### DIFF
--- a/swift-sdk/Core/Utilities/AuthFailureReason.swift
+++ b/swift-sdk/Core/Utilities/AuthFailureReason.swift
@@ -20,3 +20,32 @@ import Foundation
     case authTokenGenerationError
     case authTokenMissing
 }
+
+extension AuthFailureReason: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .authTokenExpired:
+            return "authTokenExpired"
+        case .authTokenGenericError:
+            return "authTokenGenericError"
+        case .authTokenExpirationInvalid:
+            return "authTokenExpirationInvalid"
+        case .authTokenSignatureInvalid:
+            return "authTokenSignatureInvalid"
+        case .authTokenFormatInvalid:
+            return "authTokenFormatInvalid"
+        case .authTokenInvalidated:
+            return "authTokenInvalidated"
+        case .authTokenPayloadInvalid:
+            return "authTokenPayloadInvalid"
+        case .authTokenUserKeyInvalid:
+            return "authTokenUserKeyInvalid"
+        case .authTokenNull:
+            return "authTokenNull"
+        case .authTokenGenerationError:
+            return "authTokenGenerationError"
+        case .authTokenMissing:
+            return "authTokenMissing"
+        }
+    }
+}

--- a/tests/unit-tests/AuthTests.swift
+++ b/tests/unit-tests/AuthTests.swift
@@ -17,6 +17,26 @@ class AuthTests: XCTestCase {
     override func setUp() {
         super.setUp()
     }
+
+    func testAuthFailureReasonDebugDescriptions() {
+        let expectedDescriptions: [(AuthFailureReason, String)] = [
+            (.authTokenExpired, "authTokenExpired"),
+            (.authTokenGenericError, "authTokenGenericError"),
+            (.authTokenExpirationInvalid, "authTokenExpirationInvalid"),
+            (.authTokenSignatureInvalid, "authTokenSignatureInvalid"),
+            (.authTokenFormatInvalid, "authTokenFormatInvalid"),
+            (.authTokenInvalidated, "authTokenInvalidated"),
+            (.authTokenPayloadInvalid, "authTokenPayloadInvalid"),
+            (.authTokenUserKeyInvalid, "authTokenUserKeyInvalid"),
+            (.authTokenNull, "authTokenNull"),
+            (.authTokenGenerationError, "authTokenGenerationError"),
+            (.authTokenMissing, "authTokenMissing")
+        ]
+
+        expectedDescriptions.forEach { reason, description in
+            XCTAssertEqual(reason.debugDescription, description)
+        }
+    }
     
     func testEmailPersistence() {
         let internalAPI = InternalIterableAPI.initializeForTesting()

--- a/tests/unit-tests/AuthTests.swift
+++ b/tests/unit-tests/AuthTests.swift
@@ -34,7 +34,7 @@ class AuthTests: XCTestCase {
         ]
 
         expectedDescriptions.forEach { reason, description in
-            XCTAssertEqual(reason.debugDescription, description)
+            XCTAssertEqual(String(describing: reason), description)
         }
     }
     


### PR DESCRIPTION
## What
`AuthFailureReason` is an Int-backed `@objc` enum, so logging an instance prints a raw number. This makes it conform to `CustomDebugStringConvertible` so logs show the case name.

## Changes
- Add a `CustomDebugStringConvertible` extension mapping each case to its name.
- Switch is exhaustive with no `default`, so a future case fails to compile until labeled.
- Add a unit test covering all 11 cases.

## Impact
- **Breaking changes**: None. Additive only, public API and raw values unchanged.
- **Dependencies**: None.
- **Performance**: None.

## Testing
**How to test:**
1. Run `./agent_test.sh AuthTests`.
2. `testAuthFailureReasonDebugDescriptions` passes for all 11 cases.
3. `String(reflecting: AuthFailureReason.authTokenExpired)` returns `"authTokenExpired"`.

Jira: https://iterable.atlassian.net/browse/SDK-470