### PR TITLE
SDK-291 Fix in-app message position in landscape

### DIFF
--- a/swift-sdk/Internal/in-app/InAppCalculations.swift
+++ b/swift-sdk/Internal/in-app/InAppCalculations.swift
@@ -111,14 +111,15 @@ struct InAppCalculations {
         position.height = inAppHeight
         
         // now set the width
+        let availableWidth = parentPosition.width - safeAreaInsets.left - safeAreaInsets.right
         let notificationWidth = 100 - (paddingLeft + paddingRight)
-        position.width = parentPosition.width * notificationWidth / 100
+        position.width = availableWidth * notificationWidth / 100
         
         // Position webview
         position.center = parentPosition.center
         
         // set center x
-        position.center.x = parentPosition.width * (paddingLeft + notificationWidth / 2) / 100
+        position.center.x = safeAreaInsets.left + availableWidth * (paddingLeft + notificationWidth / 2) / 100
         
         // set center y
         switch location {
@@ -130,7 +131,11 @@ struct InAppCalculations {
             position.height = position.height + safeAreaInsets.bottom
             let halfWebViewHeight = position.height / 2
             position.center.y = parentPosition.height - halfWebViewHeight
-        default: break
+        case .center:
+            let availableHeight = parentPosition.height - safeAreaInsets.top - safeAreaInsets.bottom
+            position.center.y = safeAreaInsets.top + availableHeight / 2
+        case .full:
+            break
         }
         
         return position

--- a/tests/unit-tests/IterableHtmlMessageViewControllerTests.swift
+++ b/tests/unit-tests/IterableHtmlMessageViewControllerTests.swift
@@ -49,6 +49,14 @@ class IterableHtmlMessageViewControllerTests: XCTestCase {
                          messageLocation: .full,
                          expectedWebViewPosition: ViewPosition(width: 1234, height: 400, center: CGPoint(x: 617.0, y: 200.0)))
     }
+
+    func testWebViewFullPositioningWithSafeAreaInsetsReturnsParentPosition() {
+        checkPositioning(parentPosition: ViewPosition(width: 844, height: 390, center: CGPoint(x: 422, y: 195)),
+                         safeAreaInsets: UIEdgeInsets(top: 0, left: 47, bottom: 21, right: 0),
+                         inAppHeight: 200,
+                         messageLocation: .full,
+                         expectedWebViewPosition: ViewPosition(width: 844, height: 390, center: CGPoint(x: 422, y: 195)))
+    }
     
     func testWebViewTopPositioningWithSafeAreaInsets() {
         let inAppHeight: CGFloat = 200
@@ -74,6 +82,72 @@ class IterableHtmlMessageViewControllerTests: XCTestCase {
                          inAppHeight: inAppHeight,
                          messageLocation: .bottom,
                          expectedWebViewPosition: ViewPosition(width: 1234, height: calculatedHeight, center: CGPoint(x: 617.0, y: calculatedCenterY)))
+    }
+
+    func testWebViewPositioningWithPortraitSafeAreaInsets() {
+        let parentPosition = ViewPosition(width: 390, height: 844, center: CGPoint(x: 195, y: 422))
+        let safeAreaInsets = UIEdgeInsets(top: 47, left: 0, bottom: 34, right: 0)
+        let inAppHeight: CGFloat = 200
+
+        checkPositioning(parentPosition: parentPosition,
+                         safeAreaInsets: safeAreaInsets,
+                         inAppHeight: inAppHeight,
+                         messageLocation: .top,
+                         expectedWebViewPosition: ViewPosition(width: 390, height: 247, center: CGPoint(x: 195, y: 123.5)))
+        checkPositioning(parentPosition: parentPosition,
+                         safeAreaInsets: safeAreaInsets,
+                         inAppHeight: inAppHeight,
+                         messageLocation: .bottom,
+                         expectedWebViewPosition: ViewPosition(width: 390, height: 234, center: CGPoint(x: 195, y: 727)))
+        checkPositioning(parentPosition: parentPosition,
+                         safeAreaInsets: safeAreaInsets,
+                         inAppHeight: inAppHeight,
+                         messageLocation: .center,
+                         expectedWebViewPosition: ViewPosition(width: 390, height: 200, center: CGPoint(x: 195, y: 428.5)))
+    }
+
+    func testWebViewPositioningWithLandscapeRightSafeAreaInset() {
+        let parentPosition = ViewPosition(width: 844, height: 390, center: CGPoint(x: 422, y: 195))
+        let safeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: 21, right: 47)
+        let inAppHeight: CGFloat = 200
+
+        checkPositioning(parentPosition: parentPosition,
+                         safeAreaInsets: safeAreaInsets,
+                         inAppHeight: inAppHeight,
+                         messageLocation: .top,
+                         expectedWebViewPosition: ViewPosition(width: 797, height: 200, center: CGPoint(x: 398.5, y: 100)))
+        checkPositioning(parentPosition: parentPosition,
+                         safeAreaInsets: safeAreaInsets,
+                         inAppHeight: inAppHeight,
+                         messageLocation: .bottom,
+                         expectedWebViewPosition: ViewPosition(width: 797, height: 221, center: CGPoint(x: 398.5, y: 279.5)))
+        checkPositioning(parentPosition: parentPosition,
+                         safeAreaInsets: safeAreaInsets,
+                         inAppHeight: inAppHeight,
+                         messageLocation: .center,
+                         expectedWebViewPosition: ViewPosition(width: 797, height: 200, center: CGPoint(x: 398.5, y: 184.5)))
+    }
+
+    func testWebViewPositioningWithLandscapeLeftSafeAreaInset() {
+        let parentPosition = ViewPosition(width: 844, height: 390, center: CGPoint(x: 422, y: 195))
+        let safeAreaInsets = UIEdgeInsets(top: 0, left: 47, bottom: 21, right: 0)
+        let inAppHeight: CGFloat = 200
+
+        checkPositioning(parentPosition: parentPosition,
+                         safeAreaInsets: safeAreaInsets,
+                         inAppHeight: inAppHeight,
+                         messageLocation: .top,
+                         expectedWebViewPosition: ViewPosition(width: 797, height: 200, center: CGPoint(x: 445.5, y: 100)))
+        checkPositioning(parentPosition: parentPosition,
+                         safeAreaInsets: safeAreaInsets,
+                         inAppHeight: inAppHeight,
+                         messageLocation: .bottom,
+                         expectedWebViewPosition: ViewPosition(width: 797, height: 221, center: CGPoint(x: 445.5, y: 279.5)))
+        checkPositioning(parentPosition: parentPosition,
+                         safeAreaInsets: safeAreaInsets,
+                         inAppHeight: inAppHeight,
+                         messageLocation: .center,
+                         expectedWebViewPosition: ViewPosition(width: 797, height: 200, center: CGPoint(x: 445.5, y: 184.5)))
     }
     
     func testTopAnimation() {


### PR DESCRIPTION
## What
In-app HTML messages could be mispositioned after rotating to landscape on notched devices. The webview width and center were computed from the full parent width, ignoring the side safe-area inset where the Dynamic Island or notch sits.

## Changes
- Constrain webview width and `center.x` using `safeAreaInsets.left` and `.right`, so a message stays inside the safe area in any orientation.
- Center a `.center` message within the top and bottom safe-area bounds.
- Make the location switch exhaustive (explicit `.center` and `.full`) so a future case fails to compile until handled.
- Pure inset-based math, no orientation or global-state reads. Added unit tests for portrait and both landscape orientations.

## Impact
- **Breaking changes**: None. Internal layout math only, no API change.
- **Dependencies**: None.
- **Performance**: None.

## Testing
**How to test:**
1. Run `./agent_test.sh IterableHtmlMessageViewControllerTests` (34 tests, including new portrait and landscape cases).

**Visual check still needed (not covered by unit tests):** on a notched device or simulator, show a top, bottom, and center HTML in-app message, rotate to both landscape orientations, and confirm the message stays inside the safe area and clear of the Dynamic Island and home indicator. The unit tests verify the inset math but cannot confirm live rotation behavior or how customer HTML renders in the adjusted frame.

Jira: https://iterable.atlassian.net/browse/SDK-291