### PR TITLE
SDK-502 Fix CocoaPods crash from missing embedded-view nib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
+### Fixed
+- Fixed a crash showing out-of-the-box embedded messages on CocoaPods. `IterableEmbeddedView.xib` moved out of `Resources/` in 6.5.9, but the podspec only bundled `Resources/`, so the nib was missing from the CocoaPods resource bundle and `loadViewFromNib()` crashed. The podspec now bundles the UI component XIBs too. SPM was not affected.
 
 ## [6.7.2]
 ### Added

--- a/Iterable-iOS-SDK.podspec
+++ b/Iterable-iOS-SDK.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.resource_bundles = {
     'IterableSDKResources' => [
       'swift-sdk/Resources/**/*.{storyboard,xib,xcassets,xcdatamodeld}',
-      'swift-sdk/ui-components/**/*.xib'
+      'swift-sdk/ui-components/**/*.{storyboard,xib,xcassets,xcdatamodeld}'
     ]
   }
 

--- a/Iterable-iOS-SDK.podspec
+++ b/Iterable-iOS-SDK.podspec
@@ -26,7 +26,12 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.3'
 
-  s.resource_bundles = {'IterableSDKResources' => 'swift-sdk/Resources/**/*.{storyboard,xib,xcassets,xcdatamodeld}' }
+  s.resource_bundles = {
+    'IterableSDKResources' => [
+      'swift-sdk/Resources/**/*.{storyboard,xib,xcassets,xcdatamodeld}',
+      'swift-sdk/ui-components/**/*.xib'
+    ]
+  }
 
   s.header_dir = 'IterableSDK'
 end


### PR DESCRIPTION
## What
Apps integrating the SDK via CocoaPods crash when an out-of-the-box embedded message is shown. The podspec did not bundle `IterableEmbeddedView.xib`, so the nib was missing at runtime and `loadViewFromNib()` crashed. SPM is unaffected.

## Changes
- Add `swift-sdk/ui-components/**/*.xib` to the `IterableSDKResources` resource bundle in `Iterable-iOS-SDK.podspec`. This bundles `IterableEmbeddedView.xib` and `SampleInboxCell.xib`, which moved out of `Resources/` in 6.5.9.
- Keep the `IterableSDKResources` bundle name so `findCocoaPodsResourceBundle()` and the legacy fallback are unchanged.
- CHANGELOG entry under Unreleased.

## Impact
- **Breaking changes**: None. Resource packaging only, no API or source-layout change.
- **Dependencies**: None.
- **Performance**: None.

## Testing
**How to test:**
1. In a scratch app, add `pod 'Iterable-iOS-SDK', :path => '<local repo path>'`, then `pod install`.
2. Build the `Iterable-iOS-SDK-IterableSDKResources` target and inspect `IterableSDKResources.bundle`.
3. Confirm it now contains `IterableEmbeddedView.nib` and `SampleInboxCell.nib` (before this change it contained neither).
4. Display an out-of-the-box embedded message and confirm it renders instead of crashing.

Verified locally: the rebuilt bundle ships both nibs after the change, and `./agent_build.sh` passes.

Jira: https://iterable.atlassian.net/browse/SDK-502