### PR TITLE
Pin BCIT integration test runners to macos-15

### DIFF
--- a/.github/workflows/bcit-integration-test-deep-linking.yml
+++ b/.github/workflows/bcit-integration-test-deep-linking.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   deep-linking-test:
     name: BCIT Deep Linking Integration Test
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 30
     env:
       XCODE_VERSION: '16.4'

--- a/.github/workflows/bcit-integration-test-embedded-messages.yml
+++ b/.github/workflows/bcit-integration-test-embedded-messages.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   embedded-messages-test:
     name: BCIT Embedded Messages Integration Test
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 30
     env:
       XCODE_VERSION: '16.4'

--- a/.github/workflows/bcit-integration-test-in-app.yml
+++ b/.github/workflows/bcit-integration-test-in-app.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   inapp-messaging-test:
     name: BCIT InApp Messaging Integration Test
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 30
     env:
       XCODE_VERSION: '16.4'

--- a/.github/workflows/bcit-integration-test-push-notification.yml
+++ b/.github/workflows/bcit-integration-test-push-notification.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   push-notification-test:
     name: BCIT Push Notification Integration Test
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 30
     env:
       XCODE_VERSION: '16.4'


### PR DESCRIPTION
## Summary
- All four BCIT workflows declare `runs-on: macos-latest` and `xcode-version: '16.4'`. GitHub's `macos-latest` label now resolves to a macOS 26 runner that ships only with Xcode 26.x, so `maxim-lobanov/setup-xcode@v1` fails with `Could not find Xcode version that satisfied version spec: '16.4'`.
- This was hit on the latest release validation run for `release/SDK-527-prepare-for-release-6.7.3`, taking down the Deep Linking and Embedded Messages jobs. Push Notification happened to land on a different runner image with Xcode 16.4 still installed, but the bug is shared by all four workflows.
- Fix is to pin `runs-on: macos-15`, matching the pattern already used by `build-and-test.yml` and `e2e.yml` (which both target `macos-15` with Xcode 16.4 and continue to pass). No other behavior changes.

## Test plan
- [ ] Re-run the BCIT Deep Linking Integration Test on this PR and confirm the Setup Xcode step succeeds and the suite runs to completion.
- [ ] Re-run the BCIT Embedded Messages Integration Test on this PR and confirm parity.
- [ ] Trigger BCIT In-app and Push Notification workflows (label or manual dispatch) to confirm no regression on the previously-passing flows.
- [ ] Sanity check that `build-and-test.yml` and `e2e.yml` still pass on the same `macos-15` image.