### PR TITLE
SDK-498 Add unknown user criteria fetch callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
+### Added
+- Added optional `onCriteriaReceived(criteria:)` and `onCriteriaFetchFailed(reason:)` callbacks to `IterableUnknownUserHandler` for unknown user activation criteria fetch results.
+
 ### Fixed
 - In-app HTML render failures now log the message ID and error, and messages are dismissed if the WKWebView content process terminates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
-- Added optional `onCriteriaReceived(criteria:)` and `onCriteriaFetchFailed(reason:)` callbacks to `IterableUnknownUserHandler` for unknown user activation criteria fetch results.
+- Added optional `onCriteriaReceived(criteria:)` and `onCriteriaFetchFailed(reason:)` callbacks to `IterableUnknownUserHandler` for unknown user activation criteria fetch results. These callbacks are invoked on the main thread and may fire on every criteria fetch, including initialization, foreground fetches, and when visitor usage tracking is enabled.
 
 ### Fixed
 - In-app HTML render failures now log the message ID and error, and messages are dismissed if the WKWebView content process terminates.

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -1158,7 +1158,8 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
                 let jsonData = try JSONSerialization.data(withJSONObject: data, options: [])
                 completion(jsonData)
             } catch {
-                print("Error converting dictionary to data: \(error)")
+                ITBError("Error converting dictionary to data: \(error.localizedDescription)")
+                onFailure(error.localizedDescription)
             }
         }.onError { error in
             onFailure(error.reason ?? error.localizedDescription)

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -1152,7 +1152,7 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         }
     }
     
-    func getCriteriaData(completion: @escaping (Data) -> Void) {
+    func getCriteriaData(completion: @escaping (Data) -> Void, onFailure: @escaping (String) -> Void) {
         apiClient.getCriteria().onSuccess { data in
             do {
                 let jsonData = try JSONSerialization.data(withJSONObject: data, options: [])
@@ -1160,8 +1160,10 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
             } catch {
                 print("Error converting dictionary to data: \(error)")
             }
+        }.onError { error in
+            onFailure(error.reason ?? error.localizedDescription)
         }
-	}
+    }
 
     private func createDefaultMobileFrameworkInfo() -> IterableAPIMobileFrameworkInfo {
         let frameworkType = IterableAPIMobileFrameworkDetector.frameworkType()

--- a/swift-sdk/Internal/UnknownUserManager.swift
+++ b/swift-sdk/Internal/UnknownUserManager.swift
@@ -188,12 +188,21 @@ public class UnknownUserManager: UnknownUserManagerProtocol {
         
         IterableAPI.implementation?.getCriteriaData { returnedData in
             self.localStorage.criteriaData = returnedData
-        };
+            if let criteria = self.criteria(from: returnedData) {
+                self.config.unknownUserHandler?.onCriteriaReceived?(criteria: criteria)
+            }
+        } onFailure: { reason in
+            self.config.unknownUserHandler?.onCriteriaFetchFailed?(reason: reason)
+        }
     }
 
     @available(*, deprecated, renamed: "getUnknownCriteria()")
     public func getUnknownUserCriteria() {
         getUnknownCriteria()
+    }
+
+    private func criteria(from data: Data) -> [AnyHashable: Any]? {
+        try? JSONSerialization.jsonObject(with: data, options: []) as? [AnyHashable: Any]
     }
     
     /// Gets the last criteria fetch time in milliseconds

--- a/swift-sdk/Internal/UnknownUserManager.swift
+++ b/swift-sdk/Internal/UnknownUserManager.swift
@@ -189,10 +189,14 @@ public class UnknownUserManager: UnknownUserManagerProtocol {
         IterableAPI.implementation?.getCriteriaData { returnedData in
             self.localStorage.criteriaData = returnedData
             if let criteria = self.criteria(from: returnedData) {
-                self.config.unknownUserHandler?.onCriteriaReceived?(criteria: criteria)
+                DispatchQueue.main.async {
+                    self.config.unknownUserHandler?.onCriteriaReceived?(criteria: criteria)
+                }
             }
         } onFailure: { reason in
-            self.config.unknownUserHandler?.onCriteriaFetchFailed?(reason: reason)
+            DispatchQueue.main.async {
+                self.config.unknownUserHandler?.onCriteriaFetchFailed?(reason: reason)
+            }
         }
     }
 

--- a/swift-sdk/SDK/IterableConfig.swift
+++ b/swift-sdk/SDK/IterableConfig.swift
@@ -104,10 +104,10 @@ public struct IterableAPIMobileFrameworkInfo: Codable {
     @objc func onUnknownUserCreated(userId: String)
 
     /// Called when the SDK fetches unknown user activation criteria successfully.
-    /// Fires after the criteria response has been persisted to local storage, so it is safe to call track, trackPurchase, etc. from this callback and have those events evaluated against the just-arrived criteria set. Fires on every criteria fetch, implementation should take that into consideration.
+    /// Fires on the main thread after the criteria response has been persisted to local storage, so it is safe to call track, trackPurchase, etc. from this callback and have those events evaluated against the just-arrived criteria set. Fires on every criteria fetch, implementation should take that into consideration.
     @objc optional func onCriteriaReceived(criteria: [AnyHashable: Any])
 
-    /// Called when the unknown user activation criteria fetch fails.
+    /// Called on the main thread when the unknown user activation criteria fetch fails.
     @objc optional func onCriteriaFetchFailed(reason: String)
 }
 

--- a/swift-sdk/SDK/IterableConfig.swift
+++ b/swift-sdk/SDK/IterableConfig.swift
@@ -102,6 +102,13 @@ public struct IterableAPIMobileFrameworkInfo: Codable {
 /// The delegate for getting the UserId once unknown user session tracked
 @objc public protocol IterableUnknownUserHandler: AnyObject {
     @objc func onUnknownUserCreated(userId: String)
+
+    /// Called when the SDK fetches unknown user activation criteria successfully.
+    /// Fires after the criteria response has been persisted to local storage, so it is safe to call track, trackPurchase, etc. from this callback and have those events evaluated against the just-arrived criteria set. Fires on every criteria fetch, implementation should take that into consideration.
+    @objc optional func onCriteriaReceived(criteria: [AnyHashable: Any])
+
+    /// Called when the unknown user activation criteria fetch fails.
+    @objc optional func onCriteriaFetchFailed(reason: String)
 }
 
 /// Iterable Configuration Object. Use this when initializing the API.

--- a/tests/unit-tests/IterableApiCriteriaFetchTests.swift
+++ b/tests/unit-tests/IterableApiCriteriaFetchTests.swift
@@ -191,6 +191,46 @@ class IterableApiCriteriaFetchTests: XCTestCase {
 
         wait(for: [expectation1], timeout: testExpectationTimeout)
     }
+
+    func testCriteriaFetchSuccessInvokesUnknownUserHandlerOnEveryFetch() {
+        let expectation1 = expectation(description: "Criteria received twice")
+        expectation1.expectedFulfillmentCount = 2
+        let localStorage = MockLocalStorage()
+        let criteriaPayload: [AnyHashable: Any] = [
+            JsonKey.criteriaSets: [
+                [JsonKey.CriteriaItem.criteriaId: "123"]
+            ]
+        ]
+        let handler = MockUnknownUserHandler()
+        var receivedCount = 0
+        handler.onCriteriaReceivedCallback = { _ in
+            receivedCount += 1
+            XCTAssertTrue(Thread.isMainThread)
+            expectation1.fulfill()
+        }
+
+        mockNetworkSession.responseCallback = { url in
+            if url.absoluteString.contains(Const.Path.getCriteria) == true {
+                return MockNetworkSession.MockResponse(statusCode: 200, data: criteriaPayload.toJsonData())
+            }
+            return MockNetworkSession.MockResponse(statusCode: 200)
+        }
+
+        let config = IterableConfig()
+        config.unknownUserHandler = handler
+
+        IterableAPI.initializeForTesting(apiKey: IterableApiCriteriaFetchTests.apiKey,
+                                         config: config,
+                                         networkSession: mockNetworkSession,
+                                         localStorage: localStorage)
+        defer { IterableAPI.implementation = nil }
+
+        IterableAPI.implementation?.unknownUserManager.getUnknownCriteria()
+        IterableAPI.implementation?.unknownUserManager.getUnknownCriteria()
+
+        wait(for: [expectation1], timeout: testExpectationTimeout)
+        XCTAssertEqual(receivedCount, 2)
+    }
     
     func testForegroundCriteriaFetchWithCooldown() {
         let expectation1 = expectation(description: "First criteria fetch")

--- a/tests/unit-tests/IterableApiCriteriaFetchTests.swift
+++ b/tests/unit-tests/IterableApiCriteriaFetchTests.swift
@@ -112,6 +112,85 @@ class IterableApiCriteriaFetchTests: XCTestCase {
         
         wait(for: [expectation1], timeout: testExpectationTimeout)
     }
+
+    func testCriteriaFetchSuccessInvokesUnknownUserHandlerAfterPersistingCriteria() {
+        let expectation1 = expectation(description: "Criteria received")
+        let localStorage = MockLocalStorage()
+        let criteriaPayload: [AnyHashable: Any] = [
+            JsonKey.criteriaSets: [
+                [JsonKey.CriteriaItem.criteriaId: "123"]
+            ]
+        ]
+        let handler = MockUnknownUserHandler()
+        handler.onCriteriaReceivedCallback = { criteria in
+            let storedCriteria = localStorage.criteriaData?.json()
+            let storedCriteriaSets = storedCriteria?[JsonKey.criteriaSets] as? [[String: Any]]
+            let receivedCriteriaSets = criteria[JsonKey.criteriaSets] as? [[String: Any]]
+
+            XCTAssertEqual(storedCriteriaSets?.first?[JsonKey.CriteriaItem.criteriaId] as? String, "123")
+            XCTAssertEqual(receivedCriteriaSets?.first?[JsonKey.CriteriaItem.criteriaId] as? String, "123")
+            expectation1.fulfill()
+        }
+        handler.onCriteriaFetchFailedCallback = { reason in
+            XCTFail("Unexpected criteria fetch failure: \(reason)")
+        }
+
+        mockNetworkSession.responseCallback = { url in
+            if url.absoluteString.contains(Const.Path.getCriteria) == true {
+                return MockNetworkSession.MockResponse(statusCode: 200, data: criteriaPayload.toJsonData())
+            }
+            return MockNetworkSession.MockResponse(statusCode: 200)
+        }
+
+        let config = IterableConfig()
+        config.unknownUserHandler = handler
+
+        IterableAPI.initializeForTesting(apiKey: IterableApiCriteriaFetchTests.apiKey,
+                                         config: config,
+                                         networkSession: mockNetworkSession,
+                                         localStorage: localStorage)
+        defer { IterableAPI.implementation = nil }
+
+        IterableAPI.implementation?.unknownUserManager.getUnknownCriteria()
+
+        wait(for: [expectation1], timeout: testExpectationTimeout)
+    }
+
+    func testCriteriaFetchFailureInvokesUnknownUserHandler() {
+        let expectation1 = expectation(description: "Criteria fetch failed")
+        let localStorage = MockLocalStorage()
+        let failureReason = "criteria fetch failed"
+        let handler = MockUnknownUserHandler()
+        handler.onCriteriaReceivedCallback = { _ in
+            XCTFail("Unexpected criteria received callback")
+        }
+        handler.onCriteriaFetchFailedCallback = { reason in
+            XCTAssertEqual(reason, failureReason)
+            XCTAssertNil(localStorage.criteriaData)
+            expectation1.fulfill()
+        }
+
+        mockNetworkSession.responseCallback = { url in
+            if url.absoluteString.contains(Const.Path.getCriteria) == true {
+                return MockNetworkSession.MockResponse(statusCode: 500,
+                                                       data: ["msg": failureReason].toJsonData())
+            }
+            return MockNetworkSession.MockResponse(statusCode: 200)
+        }
+
+        let config = IterableConfig()
+        config.unknownUserHandler = handler
+
+        IterableAPI.initializeForTesting(apiKey: IterableApiCriteriaFetchTests.apiKey,
+                                         config: config,
+                                         networkSession: mockNetworkSession,
+                                         localStorage: localStorage)
+        defer { IterableAPI.implementation = nil }
+
+        IterableAPI.implementation?.unknownUserManager.getUnknownCriteria()
+
+        wait(for: [expectation1], timeout: testExpectationTimeout)
+    }
     
     func testForegroundCriteriaFetchWithCooldown() {
         let expectation1 = expectation(description: "First criteria fetch")
@@ -178,5 +257,20 @@ class IterableApiCriteriaFetchTests: XCTestCase {
         mockNotificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil, userInfo: nil)
         
         wait(for: [expectation1, expectation2, expectation3], timeout: testExpectationTimeout)
+    }
+}
+
+private final class MockUnknownUserHandler: NSObject, IterableUnknownUserHandler {
+    var onCriteriaReceivedCallback: (([AnyHashable: Any]) -> Void)?
+    var onCriteriaFetchFailedCallback: ((String) -> Void)?
+
+    func onUnknownUserCreated(userId: String) {}
+
+    func onCriteriaReceived(criteria: [AnyHashable: Any]) {
+        onCriteriaReceivedCallback?(criteria)
+    }
+
+    func onCriteriaFetchFailed(reason: String) {
+        onCriteriaFetchFailedCallback?(reason)
     }
 }


### PR DESCRIPTION
## What
Adds two callbacks to `IterableUnknownUserHandler` so apps can react when unknown-user activation criteria are fetched, matching the Android SDK (SDK-498). Apps often need to update user data right after init, but the criteria are fetched asynchronously and are required to create the unknown user, so these callbacks give a hook once the criteria arrive.

## Changes
- Add `@objc optional func onCriteriaReceived(criteria: [AnyHashable: Any])` and `@objc optional func onCriteriaFetchFailed(reason: String)` to `IterableUnknownUserHandler`. Optional to mirror Android's `default` methods, so existing conformers are unaffected.
- `UnknownUserManager.getUnknownCriteria()` persists the fetched criteria first, then fires `onCriteriaReceived` (only when the payload parses), matching Android's guarantee that track calls made from the callback evaluate against the just-arrived criteria. Fires on every fetch.
- `onCriteriaFetchFailed(reason:)` fires on a failed fetch; `getCriteriaData` now surfaces the failure reason.

## Impact
- **Breaking changes**: None. The new protocol methods are `@objc optional`, additive.
- **Parity**: matches the merged Android implementation. Android PR 1058 was closed; the version that shipped added these methods to the existing handler.

## Testing
**How to test:**
1. Run `./agent_test.sh IterableApiCriteriaFetchTests` (includes the two new tests).
2. A successful criteria fetch fires `onCriteriaReceived` with the parsed criteria, with storage already populated when the callback runs. A failed fetch fires `onCriteriaFetchFailed(reason:)` and does not write criteria to storage.

Jira: https://iterable.atlassian.net/browse/SDK-498