### PR TITLE
SDK-506 Add US staging toggle to BCIT tester app

### DIFF
--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester.xcodeproj/project.pbxproj
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		8A7281E22F4DDF50003F0EFC /* IterableSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 8A24D33B2E44F30600B53850 /* IterableSDK */; };
 		8A8CA9A82E5333C600BF3385 /* test-config.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A8CA9A62E5333C600BF3385 /* test-config.json */; };
 		8A8CA9A92E53432200BF3385 /* test-config.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A8CA9A62E5333C600BF3385 /* test-config.json */; };
+		8A8CA9AA2E53432200BF3385 /* test-config-staging.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A8CA9AC2E53432200BF3385 /* test-config-staging.json */; };
+		8A8CA9AB2E53432200BF3385 /* test-config-staging.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A8CA9AC2E53432200BF3385 /* test-config-staging.json */; };
 		8AB716912E311CA0004AAB74 /* IterableAppExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 8AB716902E311CA0004AAB74 /* IterableAppExtensions */; };
 		8AB716932E311CA0004AAB74 /* IterableSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 8AB716922E311CA0004AAB74 /* IterableSDK */; };
 /* End PBXBuildFile section */
@@ -31,6 +33,7 @@
 
 /* Begin PBXFileReference section */
 		8A8CA9A62E5333C600BF3385 /* test-config.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "test-config.json"; sourceTree = "<group>"; };
+		8A8CA9AC2E53432200BF3385 /* test-config-staging.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "test-config-staging.json"; sourceTree = "<group>"; };
 		8AB716122E3119A3004AAB74 /* IterableSDK-Integration-Tester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "IterableSDK-Integration-Tester.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AB716322E3119A3004AAB74 /* IterableSDK-Integration-TesterUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "IterableSDK-Integration-TesterUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -112,6 +115,7 @@
 			isa = PBXGroup;
 			children = (
 				8A8CA9A62E5333C600BF3385 /* test-config.json */,
+				8A8CA9AC2E53432200BF3385 /* test-config-staging.json */,
 			);
 			path = config;
 			sourceTree = "<group>";
@@ -237,6 +241,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A8CA9A82E5333C600BF3385 /* test-config.json in Resources */,
+				8A8CA9AA2E53432200BF3385 /* test-config-staging.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -245,6 +250,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A8CA9A92E53432200BF3385 /* test-config.json in Resources */,
+				8A8CA9AB2E53432200BF3385 /* test-config-staging.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/AppDelegate+IntegrationTest.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/AppDelegate+IntegrationTest.swift
@@ -6,92 +6,147 @@ import IterableSDK
 // MARK: - AppDelegate Integration Test Extensions
 
 extension AppDelegate {
-    
-    static func loadApiKeyFromConfig() -> String {
-        guard let path = Bundle.main.path(forResource: "test-config", ofType: "json"),
-              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let apiKey = json["mobileApiKey"] as? String,
-              !apiKey.isEmpty else {
-            fatalError("❌ Could not load API key from test-config.json")
+
+    enum IntegrationEnvironment: String, CaseIterable {
+        case prod
+        case staging
+
+        var title: String {
+            switch self {
+            case .prod:
+                return "Prod"
+            case .staging:
+                return "Staging (US)"
+            }
         }
-        print("✅ Loaded API key from test-config.json")
+
+        var configFileName: String {
+            switch self {
+            case .prod:
+                return "test-config.json"
+            case .staging:
+                return "test-config-staging.json"
+            }
+        }
+
+        var configResourceName: String {
+            (configFileName as NSString).deletingPathExtension
+        }
+    }
+
+    private static let selectedEnvironmentKey = "bcit_selected_environment"
+
+    static var selectedEnvironment: IntegrationEnvironment {
+        get {
+            let storedValue = UserDefaults.standard.string(forKey: selectedEnvironmentKey)
+            return IntegrationEnvironment(rawValue: storedValue ?? "") ?? .prod
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: selectedEnvironmentKey)
+        }
+    }
+
+    static var activeConfigFileName: String {
+        selectedEnvironment.configFileName
+    }
+
+    static func loadApiKeyFromConfig() -> String {
+        guard let apiKey = loadStringFromConfig("mobileApiKey") else {
+            fatalError("❌ Could not load API key from \(activeConfigFileName)")
+        }
         return apiKey
     }
     
     static func loadTestUserEmailFromConfig() -> String? {
-        guard let path = Bundle.main.path(forResource: "test-config", ofType: "json"),
-              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let email = json["testUserEmail"] as? String,
-              !email.isEmpty else {
-            fatalError("❌ Could not load test user email from test-config.json")
+        guard let email = loadStringFromConfig("testUserEmail") else {
+            fatalError("❌ Could not load test user email from \(activeConfigFileName)")
         }
-        print("✅ Loaded test user email from test-config.json")
         return email
     }
     
     static func loadServerKeyFromConfig() -> String {
-        guard let path = Bundle.main.path(forResource: "test-config", ofType: "json"),
-              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let serverKey = json["serverApiKey"] as? String,
-              !serverKey.isEmpty else {
-            fatalError("❌ Could not load server key from test-config.json")
+        guard let serverKey = loadStringFromConfig("serverApiKey") else {
+            fatalError("❌ Could not load server key from \(activeConfigFileName)")
         }
-        print("✅ Loaded server key from test-config.json")
         return serverKey
     }
 
     static func loadJWTApiKeyFromConfig() -> String? {
-        guard let path = Bundle.main.path(forResource: "test-config", ofType: "json"),
-              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let jwtKey = json["jwtApiKey"] as? String,
-              !jwtKey.isEmpty else {
-            print("⚠️ No JWT API key found in test-config.json — will use regular API key for JWT testing")
+        guard let jwtKey = loadStringFromConfig("jwtApiKey", allowPlaceholder: false) else {
+            print("⚠️ No JWT API key found in \(activeConfigFileName), will use regular API key for JWT testing")
             return nil
         }
-        print("✅ Loaded JWT API key from test-config.json")
         return jwtKey
     }
 
     static func loadJWTSecretFromConfig() -> String? {
-        guard let path = Bundle.main.path(forResource: "test-config", ofType: "json"),
-              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let jwtSecret = json["jwtSecret"] as? String,
-              !jwtSecret.isEmpty else {
-            print("⚠️ No JWT secret found in test-config.json")
+        guard let jwtSecret = loadStringFromConfig("jwtSecret", allowPlaceholder: false) else {
+            print("⚠️ No JWT secret found in \(activeConfigFileName)")
             return nil
         }
-        print("✅ Loaded JWT secret from test-config.json")
         return jwtSecret
     }
     
     static func loadProjectIdFromConfig() -> String {
-        guard let path = Bundle.main.path(forResource: "test-config", ofType: "json"),
-              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let projectId = json["projectId"] as? String,
-              !projectId.isEmpty else {
-            fatalError("❌ Could not load project ID from test-config.json")
+        guard let projectId = loadStringFromConfig("projectId") else {
+            fatalError("❌ Could not load project ID from \(activeConfigFileName)")
         }
-        print("✅ Loaded project ID from test-config.json: \(projectId)")
         return projectId
     }
     
     static func loadCIModeFromConfig() -> Bool {
-        guard let path = Bundle.main.path(forResource: "test-config", ofType: "json"),
-              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        guard let json = loadConfigJSON(),
               let testing = json["testing"] as? [String: Any],
               let ciMode = testing["ciMode"] as? Bool else {
-            print("⚠️ Could not load ciMode from test-config.json, defaulting to false")
+            print("⚠️ Could not load ciMode from \(activeConfigFileName), defaulting to false")
             return false
         }
-        print("✅ Loaded CI mode from test-config.json: \(ciMode)")
+        print("✅ Loaded CI mode from \(activeConfigFileName): \(ciMode)")
         return ciMode
+    }
+
+    static func loadDataRegionFromConfig(logWarnings: Bool = true) -> String {
+        guard let baseUrl = loadStringFromConfig("baseUrl",
+                                                allowPlaceholder: false,
+                                                logWarnings: logWarnings) else {
+            return IterableDataRegion.US
+        }
+        return baseUrl.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/api/"
+    }
+
+    private static func loadConfigJSON(logWarnings: Bool = true) -> [String: Any]? {
+        let environment = selectedEnvironment
+        guard let path = Bundle.main.path(forResource: environment.configResourceName, ofType: "json"),
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            if logWarnings {
+                let message = "⚠️ Could not load \(environment.configFileName)"
+                print(message)
+                LogStore.shared.log(message)
+            }
+            return nil
+        }
+        return json
+    }
+
+    private static func loadStringFromConfig(_ key: String,
+                                             allowPlaceholder: Bool = true,
+                                             logWarnings: Bool = true) -> String? {
+        guard let json = loadConfigJSON(logWarnings: logWarnings),
+              let value = json[key] as? String,
+              !value.isEmpty else {
+            return nil
+        }
+        if value.hasPrefix("REPLACE_WITH") {
+            if logWarnings {
+                let message = "⚠️ \(key) in \(activeConfigFileName) is still a placeholder"
+                print(message)
+                LogStore.shared.log(message)
+            }
+            return allowPlaceholder ? value : nil
+        }
+        print("✅ Loaded \(key) from \(activeConfigFileName)")
+        return value
     }
         
     static func initializeIterableSDK() {
@@ -117,11 +172,14 @@ extension AppDelegate {
         config.allowedProtocols = ["tester", "https", "http"]  // Allow custom tester:// and https:// deep link schemes
         config.enableEmbeddedMessaging = true
         config.logDelegate = SDKLogCapture.shared
+        config.dataRegion = loadDataRegionFromConfig()
 
         print("✅ [SDK INIT] Config created with delegates:")
         print("   - URL delegate: \(String(describing: config.urlDelegate))")
         print("   - Custom action delegate: \(String(describing: config.customActionDelegate))")
         print("   - Allowed protocols: \(config.allowedProtocols ?? [])")
+        print("   - Environment: \(selectedEnvironment.title)")
+        print("   - Endpoint: \(config.dataRegion)")
         
         let apiKey = loadApiKeyFromConfig()
         print("🔑 [SDK INIT] API key loaded: \(apiKey.prefix(8))...")
@@ -134,6 +192,7 @@ extension AppDelegate {
         print("✅ [SDK INIT] SDK initialized for testing")
         print("✅ [SDK INIT] Initialization complete")
         LogStore.shared.log("✅ SDK initialized")
+        LogStore.shared.log("🌐 Environment: \(selectedEnvironment.title), endpoint: \(config.dataRegion)")
 
         // Log remote config values after they've been fetched (async)
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
@@ -187,7 +246,7 @@ extension AppDelegate {
         }
 
         guard let jwtSecret = loadJWTSecretFromConfig(), !jwtSecret.isEmpty else {
-            print("[SDK INIT] No JWT secret in test-config.json — cannot generate tokens")
+            print("[SDK INIT] No JWT secret in \(activeConfigFileName), cannot generate tokens")
             return
         }
 
@@ -200,6 +259,7 @@ extension AppDelegate {
         config.enableEmbeddedMessaging = true
         config.expiringAuthTokenRefreshPeriod = 1.0 // refresh 1s before expiry
         config.logDelegate = SDKLogCapture.shared
+        config.dataRegion = loadDataRegionFromConfig()
 
         // Set up auth delegate that generates real JWTs locally
         let authDelegate = MockAuthDelegate(jwtSecret: jwtSecret)
@@ -226,6 +286,7 @@ extension AppDelegate {
 
         print("[SDK INIT] Reinitialized with JWT auth (secret: \(jwtSecret.prefix(4))...)")
         LogStore.shared.log("✅ SDK initialized with JWT auth")
+        LogStore.shared.log("🌐 Environment: \(selectedEnvironment.title), endpoint: \(config.dataRegion)")
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             let offlineMode = UserDefaults.standard.bool(forKey: "itbl_offline_mode")

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/Home/HomeViewController.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/Home/HomeViewController.swift
@@ -6,6 +6,13 @@ final class HomeViewController: UIViewController, UITextFieldDelegate {
     
     private let statusView = IterableSDKStatusView()
 
+    private let environmentControl: UISegmentedControl = {
+        let control = UISegmentedControl(items: AppDelegate.IntegrationEnvironment.allCases.map { $0.title })
+        control.accessibilityIdentifier = "environment-toggle"
+        control.heightAnchor.constraint(equalToConstant: 36).isActive = true
+        return control
+    }()
+
     private let initializeButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("Initialize SDK", for: .normal)
@@ -271,6 +278,8 @@ final class HomeViewController: UIViewController, UITextFieldDelegate {
         // Setup network monitoring
         NetworkMonitor.shared.startMonitoring()
 
+        environmentControl.selectedSegmentIndex = AppDelegate.IntegrationEnvironment.allCases.firstIndex(of: AppDelegate.selectedEnvironment) ?? 0
+        environmentControl.addTarget(self, action: #selector(environmentChanged), for: .valueChanged)
         initializeButton.addTarget(self, action: #selector(initializeSDK), for: .touchUpInside)
         userIdField.delegate = self
         emailField.delegate = self
@@ -286,7 +295,8 @@ final class HomeViewController: UIViewController, UITextFieldDelegate {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(scrollView)
 
-        let stack = UIStackView(arrangedSubviews: [initializeButton,
+        let stack = UIStackView(arrangedSubviews: [environmentControl,
+                                                   initializeButton,
                                                    userIdField,
                                                    registerUserIdButton,
                                                    emailField,
@@ -323,6 +333,24 @@ final class HomeViewController: UIViewController, UITextFieldDelegate {
 
     @objc private func initializeSDK() {
         AppDelegate.initializeIterableSDK()
+        updateButtonStates()
+    }
+
+    @objc private func environmentChanged() {
+        let environments = AppDelegate.IntegrationEnvironment.allCases
+        let selectedIndex = environmentControl.selectedSegmentIndex
+        guard environments.indices.contains(selectedIndex) else { return }
+
+        let environment = environments[selectedIndex]
+        guard environment != AppDelegate.selectedEnvironment else { return }
+
+        AppDelegate.selectedEnvironment = environment
+        LogStore.shared.log("🌐 Environment switched to \(environment.title)")
+        AppDelegate.logoutFromIterableSDK()
+        AppDelegate.reinitializeSDKWithCurrentMode()
+        if let configEmail = AppDelegate.loadTestUserEmailFromConfig() {
+            emailField.text = configEmail
+        }
         updateButtonStates()
     }
 

--- a/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/Home/IterableSDKStatusView.swift
+++ b/tests/business-critical-integration/integration-test-app/IterableSDK-Integration-Tester/App/Home/IterableSDKStatusView.swift
@@ -23,6 +23,8 @@ final class IterableSDKStatusView: UIView {
     }()
     
     private let initializationStatusView = StatusRowView(title: "SDK Initialized")
+    private let environmentStatusView = StatusRowView(title: "Environment")
+    private let endpointStatusView = StatusRowView(title: "Endpoint")
     private let jwtAuthStatusView = StatusRowView(title: "JWT Auth")
     private let emailStatusView = StatusRowView(title: "Email")
     private let userIdStatusView = StatusRowView(title: "User ID")
@@ -59,6 +61,8 @@ final class IterableSDKStatusView: UIView {
         
         containerStackView.addArrangedSubview(titleLabel)
         containerStackView.addArrangedSubview(initializationStatusView)
+        containerStackView.addArrangedSubview(environmentStatusView)
+        containerStackView.addArrangedSubview(endpointStatusView)
         containerStackView.addArrangedSubview(jwtAuthStatusView)
         containerStackView.addArrangedSubview(emailStatusView)
         containerStackView.addArrangedSubview(userIdStatusView)
@@ -66,6 +70,8 @@ final class IterableSDKStatusView: UIView {
         // Add accessibility identifiers for testing
         initializationStatusView.accessibilityIdentifier = "sdk-initialization-status"
         initializationStatusView.setValueAccessibilityIdentifier("sdk-ready-indicator")
+        environmentStatusView.accessibilityIdentifier = "sdk-environment-status"
+        endpointStatusView.accessibilityIdentifier = "sdk-endpoint-status"
         emailStatusView.accessibilityIdentifier = "sdk-email-status"
         emailStatusView.setValueAccessibilityIdentifier("sdk-email-value")
         userIdStatusView.accessibilityIdentifier = "sdk-user-id-status"
@@ -109,6 +115,9 @@ final class IterableSDKStatusView: UIView {
         // SDK Initialization status
         initializationStatusView.setValue(isInitialized ? "✓" : "✗",
                                         color: isInitialized ? .systemGreen : .systemRed)
+
+        environmentStatusView.setValue(AppDelegate.selectedEnvironment.title, color: .systemBlue)
+        endpointStatusView.setValue(AppDelegate.loadDataRegionFromConfig(logWarnings: false), color: .systemBlue)
 
         // JWT Auth status
         let hasJWTAuth = AppDelegate.mockAuthDelegate != nil


### PR DESCRIPTION
## What
Adds a Prod / Staging (US) environment toggle to the BCIT integration tester app so it can run against Iterable US staging, which is needed to validate the FCM v1 message wrapper payload (SDK-506). Test-app only, no changes to the shipped SDK.

## Changes
- Segmented control (Prod / Staging US) at the top of the home screen. Switching persists the choice to UserDefaults, logs out to clear the previous environment's state, re-inits the SDK against the new config, and shows the active environment and endpoint in the status card.
- Config loaders now read from a per-environment config file (`prod -> test-config.json`, `staging -> test-config-staging.json`), so API keys, project, and test user switch together. The env-to-file mapping is extensible for more environments later.
- The SDK endpoint (`config.dataRegion`) is derived from the active config's `baseUrl` (normalized to `.../api/`), set in both SDK init paths.
- Wire `test-config-staging.json` into the app and UI-test resource build phases.

## Impact
- **Breaking changes**: None. BCIT tester app only; `swift-sdk/` untouched.
- **Config provisioning**: the `config/*.json` files are gitignored and local (same as the existing `test-config.json`). Building the app now also requires a local `test-config-staging.json`, so reviewers and BCIT CI need that file provisioned alongside `test-config.json`.

## Testing
**How to test:**
1. Build and run the BCIT tester app.
2. Flip the top toggle to Staging (US). Confirm the status card shows the staging endpoint (`api.stg-itbl.co`) and the SDK re-initializes.
3. Flip back to Prod and confirm it returns to `api.iterable.com`.

Jira: https://iterable.atlassian.net/browse/SDK-506