### PR TITLE
SDK-569 Parse itbl delivered as a JSON string (iOS-via-FCM)

### DIFF
--- a/notification-extension/ITBNotificationServiceExtension.swift
+++ b/notification-extension/ITBNotificationServiceExtension.swift
@@ -52,7 +52,7 @@ public protocol ITBNotificationServiceExtensionDelegate {
     // MARK: - Private
     
     private func retrieveAttachment(from content: UNNotificationContent) {
-        guard let metadata = content.userInfo[JsonKey.Payload.metadata] as? [AnyHashable: Any],
+        guard let metadata = NotificationContentParser.getIterableMetadata(from: content),
               let attachmentUrlString = metadata[JsonKey.Payload.attachmentUrl] as? String,
               let url = URL(string: attachmentUrlString) else {
             attachmentRetrievalFinished = true

--- a/notification-extension/NotificationContentParser.swift
+++ b/notification-extension/NotificationContentParser.swift
@@ -7,7 +7,7 @@ import UserNotifications
 
 struct NotificationContentParser {
     static func getIterableMetadata(from content: UNNotificationContent) -> [AnyHashable: Any]? {
-        content.userInfo[JsonKey.Payload.metadata] as? [AnyHashable: Any]
+        getIterableMetadata(from: content.userInfo)
     }
 
     static func getIterableMessageId(from content: UNNotificationContent) -> String? {
@@ -36,6 +36,25 @@ struct NotificationContentParser {
             #endif
         }
         return jsonArray
+    }
+
+    private static func getIterableMetadata(from userInfo: [AnyHashable: Any]) -> [AnyHashable: Any]? {
+        guard let metadata = userInfo[JsonKey.Payload.metadata] else {
+            return nil
+        }
+
+        if let metadata = metadata as? [AnyHashable: Any] {
+            return metadata
+        }
+
+        guard let metadataString = metadata as? String,
+              let metadataData = metadataString.data(using: .utf8),
+              let jsonObject = try? JSONSerialization.jsonObject(with: metadataData),
+              let jsonDictionary = jsonObject as? [String: Any] else {
+            return nil
+        }
+
+        return Dictionary(uniqueKeysWithValues: jsonDictionary.map { (AnyHashable($0.key), $0.value) })
     }
 
     private static func createNotificationActionButton(from json: [AnyHashable: Any]) -> UNNotificationAction? {

--- a/swift-sdk/Internal/InternalIterableAppIntegration.swift
+++ b/swift-sdk/Internal/InternalIterableAppIntegration.swift
@@ -315,7 +315,7 @@ struct InternalIterableAppIntegration {
     // Normally itblValue would be the value stored in "itbl" key inside of userInfo.
     // But it is possible to save them at root level for debugging purpose.
     private static func itblValue(fromUserInfo userInfo: [AnyHashable: Any]) -> [AnyHashable: Any]? {
-        let itbl = userInfo[JsonKey.Payload.metadata] as? [AnyHashable: Any]
+        let itbl = NotificationHelper.itblElement(from: userInfo)
         
         #if DEBUG
             guard let value = itbl else {

--- a/swift-sdk/Internal/Utilities/NotificationHelper.swift
+++ b/swift-sdk/Internal/Utilities/NotificationHelper.swift
@@ -40,7 +40,7 @@ struct ITBLSilentPushNotificationInfo {
 
 struct NotificationHelper {
     static func inspect(notification: [AnyHashable: Any]) -> NotificationInfo {
-        guard let itblElement = notification[Keys.itbl.rawValue] as? [AnyHashable: Any], let isGhostPush = itblElement[Keys.isGhostPush.rawValue] as? Bool else {
+        guard let itblElement = itblElement(from: notification), let isGhostPush = itblElement[Keys.isGhostPush.rawValue] as? Bool else {
             return .other
         }
         
@@ -53,6 +53,25 @@ struct NotificationHelper {
         } else {
             return tryCreateIterablePushNotificationMetadata(itblElement: itblElement, isGhostPush: false)
         }
+    }
+
+    static func itblElement(from notification: [AnyHashable: Any]) -> [AnyHashable: Any]? {
+        guard let itblElement = notification[Keys.itbl.rawValue] else {
+            return nil
+        }
+
+        if let itblElement = itblElement as? [AnyHashable: Any] {
+            return itblElement
+        }
+
+        guard let itblString = itblElement as? String,
+              let itblData = itblString.data(using: .utf8),
+              let jsonObject = try? JSONSerialization.jsonObject(with: itblData),
+              let jsonDictionary = jsonObject as? [String: Any] else {
+            return nil
+        }
+
+        return Dictionary(uniqueKeysWithValues: jsonDictionary.map { (AnyHashable($0.key), $0.value) })
     }
     
     fileprivate static func tryCreateIterablePushNotificationMetadata(itblElement: [AnyHashable: Any], isGhostPush: Bool) -> NotificationInfo {

--- a/tests/notification-extension-tests/NotificationExtensionTests.swift
+++ b/tests/notification-extension-tests/NotificationExtensionTests.swift
@@ -62,6 +62,38 @@ class NotificationExtensionTests: XCTestCase {
         
         wait(for: [condition1], timeout: timeout)
     }
+
+    func testNotificationContentParserReadsActionButtonsFromStringItbl() {
+        let content = UNMutableNotificationContent()
+        let messageId = UUID().uuidString
+        content.userInfo = [
+            "itbl": jsonString(from: [
+                "messageId": messageId,
+                "actionButtons": [[
+                    "identifier": "openAppButton",
+                    "title": "Open App",
+                    "action": [:],
+                ] as [String : Any]]
+            ])
+        ]
+
+        let actions = NotificationContentParser.getNotificationActions(from: content)
+
+        XCTAssertEqual(NotificationContentParser.getIterableMessageId(from: content), messageId)
+        XCTAssertEqual(actions.count, 1)
+        XCTAssertEqual(actions.first?.identifier, "openAppButton")
+        XCTAssertEqual(actions.first?.title, "Open App")
+    }
+
+    func testNotificationContentParserIgnoresMalformedStringItbl() {
+        let content = UNMutableNotificationContent()
+        content.userInfo = [
+            "itbl": "{\"messageId\":\"12345\""
+        ]
+
+        XCTAssertNil(NotificationContentParser.getIterableMessageId(from: content))
+        XCTAssertTrue(NotificationContentParser.getNotificationActions(from: content).isEmpty)
+    }
     
     @available(iOS 14.0, *)
     func testPushImageAttachment() {
@@ -493,5 +525,10 @@ class NotificationExtensionTests: XCTestCase {
         }
         
         wait(for: [expectation1], timeout: timeout)
+    }
+
+    private func jsonString(from json: [String: Any]) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return String(data: data, encoding: .utf8)!
     }
 }

--- a/tests/notification-extension-tests/NotificationExtensionTests.swift
+++ b/tests/notification-extension-tests/NotificationExtensionTests.swift
@@ -128,7 +128,43 @@ class NotificationExtensionTests: XCTestCase {
 
         wait(for: [condition1], timeout: timeout)
     }
-    
+
+    @available(iOS 14.0, *)
+    func testPushImageAttachmentFromStringItbl() {
+        // iOS-via-FCM delivers itbl as a JSON string; confirm the extension still retrieves
+        // the attachment end-to-end, not just that the parser reads the metadata.
+        let condition1 = expectation(description: "image attachment didn't function as expected")
+
+        let content = UNMutableNotificationContent()
+        let messageId = UUID().uuidString
+
+        content.userInfo = [
+            "itbl": jsonString(from: [
+                "messageId": messageId,
+                "attachment-url": "https://github.com/Iterable/swift-sdk/raw/master/images/Iterable-Logo.png"
+            ])
+        ]
+
+        let request = UNNotificationRequest(identifier: "request", content: content, trigger: nil)
+
+        appExtension.didReceive(request) { content in
+            XCTAssertEqual(content.attachments.count, 1)
+
+            guard let firstAttachment = content.attachments.first else {
+                XCTFail("attachment doesn't exist")
+                return
+            }
+
+            XCTAssertNotNil(firstAttachment.url)
+            XCTAssertEqual(firstAttachment.url.scheme, "file")
+            XCTAssertEqual(firstAttachment.type, UTType.png.identifier)
+
+            condition1.fulfill()
+        }
+
+        wait(for: [condition1], timeout: timeout)
+    }
+
     @available(iOS 14.0, *)
     func testPushVideoAttachment() {
         let condition1 = expectation(description: "video attachment didn't function as expected")

--- a/tests/unit-tests/NotificationMetadataTests.swift
+++ b/tests/unit-tests/NotificationMetadataTests.swift
@@ -80,6 +80,39 @@ class NotificationMetadataTests: XCTestCase {
         XCTAssertFalse(metadata.isTestPush())
         XCTAssertTrue(metadata.isRealCampaignNotification())
     }
+
+    func testValidStringItblPayload() {
+        let campaignId = NSNumber(value: 1491853)
+        let templateId = NSNumber(value: 1629044)
+        let messageId = "46f1bb38f8c2467eafbfe08764732e3f"
+        let payload = [
+            "itbl": "{\"templateId\":1629044,\"campaignId\":1491853,\"messageId\":\"\(messageId)\",\"isGhostPush\":false}"
+        ]
+
+        guard case let NotificationInfo.iterable(metadata) = NotificationHelper.inspect(notification: payload) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(metadata.campaignId, campaignId)
+        XCTAssertEqual(metadata.templateId, templateId)
+        XCTAssertEqual(metadata.messageId, messageId)
+        XCTAssertFalse(metadata.isGhostPush)
+        XCTAssertTrue(metadata.isRealCampaignNotification())
+    }
+
+    func testMalformedStringItblPayload() {
+        let payload = [
+            "itbl": "{\"templateId\":1629044"
+        ]
+
+        guard case NotificationInfo.other = NotificationHelper.inspect(notification: payload) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertNil(IterablePushNotificationMetadata.metadata(fromLaunchOptions: payload))
+    }
     
     func testValidProofPayload() {
         let campaignId = NSNumber(value: 0)

--- a/tests/unit-tests/NotificationResponseTests.swift
+++ b/tests/unit-tests/NotificationResponseTests.swift
@@ -168,4 +168,58 @@ class NotificationResponseTests: XCTestCase {
         
         XCTAssertEqual(urlOpener.openedUrl?.absoluteString, "https://example.com")
     }
+
+    // iOS-via-FCM delivers itbl as a JSON string rather than a dictionary. These two tests
+    // exercise the full open-handling flow (not just parsing) to confirm tracking and actions
+    // still fire when itbl arrives as a string.
+
+    func testTrackOpenPushFromStringItbl() {
+        let messageId = UUID().uuidString
+        let userInfo: [AnyHashable: Any] = [
+            "itbl": "{\"campaignId\":1234,\"templateId\":4321,\"isGhostPush\":false,\"messageId\":\"\(messageId)\"}",
+        ]
+
+        let response = MockNotificationResponse(userInfo: userInfo, actionIdentifier: UNNotificationDefaultActionIdentifier)
+        let pushTracker = MockPushTracker()
+        let appIntegration = InternalIterableAppIntegration(tracker: pushTracker,
+                                                            urlOpener: MockUrlOpener(),
+                                                            inAppNotifiable: EmptyInAppManager(),
+                                                            embeddedNotifiable: EmptyEmbeddedManager())
+        appIntegration.userNotificationCenter(nil, didReceive: response, withCompletionHandler: nil)
+
+        XCTAssertEqual(pushTracker.campaignId, 1234)
+        XCTAssertEqual(pushTracker.templateId, 4321)
+        XCTAssertEqual(pushTracker.messageId, messageId)
+        XCTAssertEqual(pushTracker.dataFields?[JsonKey.actionIdentifier] as? String, JsonValue.ActionIdentifier.pushOpenDefault)
+    }
+
+    func testCustomActionFromStringItbl() {
+        let messageId = UUID().uuidString
+        let userInfo: [AnyHashable: Any] = [
+            "itbl": "{\"campaignId\":1234,\"templateId\":4321,\"isGhostPush\":false,\"messageId\":\"\(messageId)\",\"defaultAction\":{\"type\":\"customAction\"}}",
+        ]
+
+        let response = MockNotificationResponse(userInfo: userInfo, actionIdentifier: UNNotificationDefaultActionIdentifier)
+        let pushTracker = MockPushTracker()
+        let expection = XCTestExpectation(description: "customActionDelegate is called")
+        let customActionDelegate = MockCustomActionDelegate(returnValue: true)
+        customActionDelegate.callback = { customActionName, _ in
+            XCTAssertEqual(customActionName, "customAction")
+            expection.fulfill()
+        }
+
+        let appIntegration = InternalIterableAppIntegration(tracker: pushTracker,
+                                                            customActionDelegate: customActionDelegate,
+                                                            urlOpener: MockUrlOpener(),
+                                                            inAppNotifiable: EmptyInAppManager(),
+                                                            embeddedNotifiable: EmptyEmbeddedManager())
+        appIntegration.userNotificationCenter(nil, didReceive: response, withCompletionHandler: nil)
+
+        wait(for: [expection], timeout: testExpectationTimeout)
+
+        XCTAssertEqual(pushTracker.campaignId, 1234)
+        XCTAssertEqual(pushTracker.templateId, 4321)
+        XCTAssertEqual(pushTracker.messageId, messageId)
+        XCTAssertEqual(pushTracker.dataFields?[JsonKey.actionIdentifier] as? String, JsonValue.ActionIdentifier.pushOpenDefault)
+    }
 }


### PR DESCRIPTION
###### 🎟️ Jira Ticket: [SDK-569](https://iterable.atlassian.net/browse/SDK-569)

## What
iOS devices registered via FCM receive pushes where `userInfo["itbl"]` is a JSON string, not a dictionary, because FCM's `message.data` is a `Map<String, String>` and gets merged into the APNs payload. Every SDK parse site did `as? [AnyHashable: Any]`, which returns nil for a string, so push-open tracking, ghost/silent classification, default actions, deep links, action buttons, and notification-extension rich media all silently no-op. This adds tolerant `itbl` extraction so those flows work whether `itbl` arrives as a dictionary or a string.

Found during MOB-10018 (FCM analytics_label) staging validation, and confirmed on the legacy FCM path too, where there is no `apns.payload` object to fall back on, so this SDK change is the only possible fix on that path.

## Changes
- Tolerant `itbl` extraction: a dictionary is used as-is; a `String` is JSON-decoded via `JSONSerialization`; malformed input returns nil rather than crashing.
- Applied at all four parse sites: `NotificationHelper` and `InternalIterableAppIntegration` (IterableSDK target), `NotificationContentParser` and `ITBNotificationServiceExtension` (IterableAppExtensions target). The two targets keep separate helpers because they are independent SPM targets with no shared dependency.
- Tests at both the parse layer and the flow layer: open tracking, custom action, and attachment retrieval all driven from a string `itbl`, plus malformed-string handling.

## Impact
- **Breaking changes**: None. Dictionary payloads (direct APNs) parse exactly as before; the string path is purely additive.
- **Dependencies**: None.
- **Performance**: one extra JSON decode, and only when `itbl` arrives as a string (the FCM path). The dictionary path is unchanged.

## Testing
**How to test:**
1. Register an iOS device via FCM (platform GCM / firebaseJson) so pushes arrive with a stringified `itbl`.
2. Send a push and open it: the open tracks (campaign / template / message id), default actions and deep links fire, action buttons render, and rich-media attachments load.
3. Confirm direct-APNs (dictionary `itbl`) behavior is unchanged.

**What I tested:**
- [x] `unit-tests/NotificationMetadataTests`: valid and malformed string `itbl` parsing
- [x] `unit-tests/NotificationResponseTests`: open tracking and custom action fired from a string `itbl`
- [x] `notification-extension-tests/NotificationExtensionTests`: action buttons and image attachment from a string `itbl`, malformed string ignored

[SDK-569]: https://iterable.atlassian.net/browse/SDK-569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ